### PR TITLE
fix(policy_verify_trust): update documentation to match default impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,22 +904,20 @@ pub trait WebauthnConfig {
     /// If the attestation statement attStmt successfully verified but is not trustworthy per step
     /// 16 above, the Relying Party SHOULD fail the registration ceremony.
     ///
-    /// The default implementation of this method rejects None and Uncertain attestation, and
+    /// The default implementation of this method rejects ECDAA and Uncertain attestation, and
     /// will "blindly trust" self attestation and the other types as valid.
     /// If you have strict security requirements we strongly recommend you implement this function,
     /// and we may in the future provide a stronger default relying party policy.
     fn policy_verify_trust(&self, at: AttestationType) -> Result<Credential, ()> {
         log::debug!("policy_verify_trust -> {:?}", at);
         match at {
-            AttestationType::Basic(credential, _attest_cert) => Ok(credential),
-            AttestationType::Self_(credential) => Ok(credential),
-            AttestationType::AttCa(credential, _attest_cert, _ca_chain) => Ok(credential),
-            AttestationType::None(credential) => Ok(credential),
-            _ => {
-                // We don't know how to assert trust in this yet, or we just
-                // don't trust it at all (Uncertain, None).
-                Err(())
-            }
+            AttestationType::Basic(credential, _)
+            | AttestationType::Self_(credential)
+            | AttestationType::AttCa(credential, _, _)
+            | AttestationType::None(credential) => Ok(credential),
+            // We don't know how to assert trust in these yet, or we just
+            // don't trust it at all (Uncertain, None).
+            AttestationType::ECDAA | AttestationType::Uncertain(_) => Err(()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,20 +904,21 @@ pub trait WebauthnConfig {
     /// If the attestation statement attStmt successfully verified but is not trustworthy per step
     /// 16 above, the Relying Party SHOULD fail the registration ceremony.
     ///
-    /// The default implementation of this method rejects ECDAA and Uncertain attestation, and
+    /// The default implementation of this method rejects Uncertain attestation, and
     /// will "blindly trust" self attestation and the other types as valid.
     /// If you have strict security requirements we strongly recommend you implement this function,
     /// and we may in the future provide a stronger default relying party policy.
     fn policy_verify_trust(&self, at: AttestationType) -> Result<Credential, ()> {
         log::debug!("policy_verify_trust -> {:?}", at);
         match at {
-            AttestationType::Basic(credential, _)
-            | AttestationType::Self_(credential)
-            | AttestationType::AttCa(credential, _, _)
-            | AttestationType::None(credential) => Ok(credential),
-            // We don't know how to assert trust in these yet, or we just
-            // don't trust it at all (Uncertain, None).
-            AttestationType::ECDAA | AttestationType::Uncertain(_) => Err(()),
+            AttestationType::Basic(credential, _attest_cert) => Ok(credential),
+            AttestationType::Self_(credential) => Ok(credential),
+            AttestationType::AttCa(credential, _attest_cert, _ca_chain) => Ok(credential),
+            AttestationType::None(credential) => Ok(credential),
+            // TODO: trust is unimplemented here
+            AttestationType::ECDAA => Err(()),
+            // We don't trust Uncertain attestations
+            AttestationType::Uncertain(_) => Err(()),
         }
     }
 }


### PR DESCRIPTION
Implements #42.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)

Fixes #42.
