### PR TITLE
Cleanup naming in extensions, return auth data in registration.

### DIFF
--- a/examples/tide/actors.rs
+++ b/examples/tide/actors.rs
@@ -90,8 +90,8 @@ impl WebauthnActor {
                 .wan
                 .register_credential(reg, rs, |cred_id| Ok(ucreds.contains_key(cred_id)))
                 .map(|cred| {
-                    let cred_id = cred.cred_id.clone();
-                    ucreds.insert(cred_id, cred);
+                    let cred_id = cred.0.cred_id.clone();
+                    ucreds.insert(cred_id, cred.0);
                 }),
             None => {
                 let r = self
@@ -99,8 +99,8 @@ impl WebauthnActor {
                     .register_credential(reg, rs, |_| Ok(false))
                     .map(|cred| {
                         let mut t = BTreeMap::new();
-                        let credential_id = cred.cred_id.clone();
-                        t.insert(credential_id, cred);
+                        let credential_id = cred.0.cred_id.clone();
+                        t.insert(credential_id, cred.0);
                         creds.insert(username, t);
                     });
                 tide::log::debug!("{:?}", self.creds);

--- a/src/core.rs
+++ b/src/core.rs
@@ -675,7 +675,7 @@ impl<T> Webauthn<T> {
     pub fn generate_challenge_authenticate_options(
         &self,
         creds: Vec<Credential>,
-        extensions: Option<RequestAuthenticationExtesions>,
+        extensions: Option<RequestAuthenticationExtensions>,
     ) -> Result<(RequestChallengeResponse, AuthenticationState), WebauthnError>
     where
         T: WebauthnConfig,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -426,29 +426,29 @@ impl RequestCredProtectExtension {
 ///
 /// Implements \[AuthenticatorExtensionsClientInputs\] from the spec.
 #[derive(Debug, Serialize, Clone, Deserialize)]
-pub struct RequestAuthenticationExtesions {
+pub struct RequestAuthenticationExtensions {
     // #[serde(flatten)]
 // none yet.
 }
 
-impl RequestAuthenticationExtesions {
+impl RequestAuthenticationExtensions {
     /// Get a builder for the [RequestRegistrationExtensions] struct
     #[must_use]
-    pub fn builder() -> RequestAuthenticationExtesionsBuilder {
-        RequestAuthenticationExtesionsBuilder::new()
+    pub fn builder() -> RequestAuthenticationExtensionsBuilder {
+        RequestAuthenticationExtensionsBuilder::new()
     }
 }
 
-/// Builder for [RequestAuthenticationExtesions] objects.
-pub struct RequestAuthenticationExtesionsBuilder(RequestAuthenticationExtesions);
+/// Builder for [RequestAuthenticationExtensions] objects.
+pub struct RequestAuthenticationExtensionsBuilder(RequestAuthenticationExtensions);
 
-impl RequestAuthenticationExtesionsBuilder {
+impl RequestAuthenticationExtensionsBuilder {
     pub(crate) fn new() -> Self {
-        Self(RequestAuthenticationExtesions {})
+        Self(RequestAuthenticationExtensions {})
     }
 
     /// Returns the inner extensions struct
-    pub fn build(self) -> RequestAuthenticationExtesions {
+    pub fn build(self) -> RequestAuthenticationExtensions {
         self.0
     }
 }
@@ -687,7 +687,7 @@ pub struct PublicKeyCredentialRequestOptions {
     /// The verification policy the browser will request.
     pub user_verification: UserVerificationPolicy,
     /// extensions.
-    pub extensions: Option<RequestAuthenticationExtesions>,
+    pub extensions: Option<RequestAuthenticationExtensions>,
 }
 
 /// A JSON serialisable challenge which is issued to the user's webbrowser
@@ -757,7 +757,7 @@ impl RequestChallengeResponse {
         relaying_party: String,
         allow_credentials: Vec<AllowCredentials>,
         user_verification_policy: UserVerificationPolicy,
-        extensions: Option<RequestAuthenticationExtesions>,
+        extensions: Option<RequestAuthenticationExtensions>,
     ) -> Self {
         RequestChallengeResponse {
             public_key: PublicKeyCredentialRequestOptions {


### PR DESCRIPTION
This cleans up some of the extension struct naming, and returns the auth_data from registration so that consumers can use this data for their auth processes. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
