### PR TITLE
Authentication Verification Refactor

### DIFF
--- a/examples/tide/actors.rs
+++ b/examples/tide/actors.rs
@@ -1,7 +1,7 @@
 use webauthn_rs::error::WebauthnError;
 use webauthn_rs::proto::{
     CreationChallengeResponse, Credential, CredentialID, PublicKeyCredential,
-    RegisterPublicKeyCredential, RequestChallengeResponse, UserId, UserVerificationPolicy,
+    RegisterPublicKeyCredential, RequestChallengeResponse, UserId,
 };
 use webauthn_rs::{
     ephemeral::WebauthnEphemeralConfig,
@@ -52,7 +52,8 @@ impl WebauthnActor {
             Some(UserVerificationPolicy::Discouraged),
             Some(exts),
         )?;
-        // .generate_challenge_register(&username, Some(UserVerificationPolicy::Discouraged))?;
+
+        // let (ccr, rs) = self.wan.generate_challenge_register(&username, false)?;
         self.reg_chals.lock().await.put(username.into_bytes(), rs);
         tide::log::debug!("complete ChallengeRegister -> {:?}", ccr);
         Ok(ccr)

--- a/examples/tide/actors.rs
+++ b/examples/tide/actors.rs
@@ -49,7 +49,7 @@ impl WebauthnActor {
             username.to_string(),
             username.to_string(),
             None,
-            Some(UserVerificationPolicy::Discouraged),
+            Some(webauthn_rs::proto::UserVerificationPolicy::Discouraged),
             Some(exts),
         )?;
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -600,7 +600,7 @@ impl<T> Webauthn<T> {
             }
             (UserVerificationPolicy::Discouraged, UserVerificationPolicy::Discouraged) => {
                 // If this token always verifies, even under discouraged, we can enforce that.
-                if cred.verified && self.get_require_uv_consistency() {
+                if cred.verified && self.config.get_require_uv_consistency() {
                     // This token always sends UV, so we enforce that.
                     if !data.authenticator_data.user_verified {
                         log::debug!("Token registered UV=true with DC, enforcing UV policy.");

--- a/src/core.rs
+++ b/src/core.rs
@@ -726,10 +726,9 @@ impl<T> Webauthn<T> {
     where
         T: WebauthnConfig,
     {
-        let (verified, unverified): (Vec<Credential>, Vec<Credential>) =
-            creds.into_iter().partition(|cred| {
-                cred.registration_policy == UserVerificationPolicy::Required
-            });
+        let (verified, unverified): (Vec<Credential>, Vec<Credential>) = creds
+            .into_iter()
+            .partition(|cred| cred.registration_policy == UserVerificationPolicy::Required);
 
         match (verified.len(), unverified.len()) {
             (_, 0) => self.generate_challenge_authenticate_inner(
@@ -1943,7 +1942,8 @@ mod tests {
         // Ensure we get a bad result.
 
         assert!(
-            wan.generate_challenge_authenticate(creds.clone()).unwrap_err()
+            wan.generate_challenge_authenticate(creds.clone())
+                .unwrap_err()
                 == WebauthnError::InconsistentUserVerificationPolicy
         );
 
@@ -1951,52 +1951,52 @@ mod tests {
         // cred 0 verified + uv::req
         // cred 1 verified + uv::req
         {
-        creds.get_mut(0)
-            .map(|cred| {
-                cred.verified = true;
-                cred.registration_policy = UserVerificationPolicy::Required;
-                ()
-            })
-            .unwrap();
-        creds.get_mut(1)
-            .map(|cred| {
-                cred.verified = true;
-                cred.registration_policy = UserVerificationPolicy::Required;
-                ()
-            })
-            .unwrap();
+            creds
+                .get_mut(0)
+                .map(|cred| {
+                    cred.verified = true;
+                    cred.registration_policy = UserVerificationPolicy::Required;
+                    ()
+                })
+                .unwrap();
+            creds
+                .get_mut(1)
+                .map(|cred| {
+                    cred.verified = true;
+                    cred.registration_policy = UserVerificationPolicy::Required;
+                    ()
+                })
+                .unwrap();
         }
 
         let r = wan.generate_challenge_authenticate(creds.clone());
         eprintln!("{:?}", r);
-        assert!(
-            r.is_ok()
-        );
+        assert!(r.is_ok());
 
         // now mutate to different states to check.
         // cred 0 verified + uv::dc
         // cred 1 verified + uv::dc
         {
-        creds.get_mut(0)
-            .map(|cred| {
-                cred.verified = true;
-                cred.registration_policy = UserVerificationPolicy::Discouraged;
-                ()
-            })
-            .unwrap();
-        creds.get_mut(1)
-            .map(|cred| {
-                cred.verified = false;
-                cred.registration_policy = UserVerificationPolicy::Discouraged;
-                ()
-            })
-            .unwrap();
+            creds
+                .get_mut(0)
+                .map(|cred| {
+                    cred.verified = true;
+                    cred.registration_policy = UserVerificationPolicy::Discouraged;
+                    ()
+                })
+                .unwrap();
+            creds
+                .get_mut(1)
+                .map(|cred| {
+                    cred.verified = false;
+                    cred.registration_policy = UserVerificationPolicy::Discouraged;
+                    ()
+                })
+                .unwrap();
         }
 
         let r = wan.generate_challenge_authenticate(creds.clone());
         eprintln!("{:?}", r);
-        assert!(
-            r.is_ok()
-        );
+        assert!(r.is_ok());
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -278,7 +278,7 @@ impl<T> Webauthn<T> {
         policy: UserVerificationPolicy,
         chal: &ChallengeRef,
         exclude_credentials: &[CredentialID],
-    ) -> Result<(Credential, AuthenticatorData), WebauthnError>
+    ) -> Result<(Credential, AuthenticatorData<Registration>), WebauthnError>
     where
         T: WebauthnConfig,
     {
@@ -598,8 +598,9 @@ impl<T> Webauthn<T> {
                     return Err(WebauthnError::UserNotVerified);
                 }
             }
-            (UserVerificationPolicy::Discouraged, UserVerificationPolicy::Discouraged) => {
-                // If this token always verifies, even under discouraged, we can enforce that.
+            (_, UserVerificationPolicy::Discouraged) => {
+                // If this token always verifies, even under discouraged, we can enforce that behaviour
+                // from registration.
                 if cred.verified && self.config.get_require_uv_consistency() {
                     // This token always sends UV, so we enforce that.
                     if !data.authenticator_data.user_verified {
@@ -608,8 +609,9 @@ impl<T> Webauthn<T> {
                     }
                 }
             }
-            // Pass - we can not know if historical verification was requested. We must allow
-            // unverified tokens now.
+            // Pass - we can not know if verification was requested to the client in the past correctly.
+            // This means we can't know what it's behaviour is at the moment.
+            // We must allow unverified tokens now.
             _ => {}
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -209,3 +209,9 @@ pub enum WebauthnError {
     #[error("The attested credential public key and subject public key do not match")]
     AttestationCredentialSubjectKeyMismatch,
 }
+
+impl PartialEq for WebauthnError {
+    fn eq(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -548,7 +548,7 @@ pub struct GetCredBlobResponse(Base64UrlSafeData);
 #[serde(rename_all = "camelCase")]
 pub struct RequestAuthenticationExtensions {
     /// The `credBlob` extension options
-    #[serde(rename = "getCredBlob", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "credBlob", skip_serializing_if = "Option::is_none")]
     pub get_cred_blob: Option<CredBlobGet>,
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -307,6 +307,11 @@ pub struct Credential {
     /// a credential as un-verified but then to use verification with it
     /// in the future.
     pub verified: bool,
+    /// During registration, the policy that was requested from this
+    /// credential. This is used to understand if the how the verified
+    /// component interacts with the device, IE an always verified authenticator
+    /// vs one that can dynamically request it.
+    pub registration_policy: UserVerificationPolicy,
 }
 
 impl Credential {
@@ -316,12 +321,14 @@ impl Credential {
         ck: COSEKey,
         counter: u32,
         verified: bool,
+        registration_policy: UserVerificationPolicy,
     ) -> Self {
         Credential {
             cred_id: acd.credential_id.clone(),
             cred: ck,
             counter,
             verified,
+            registration_policy,
         }
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -548,7 +548,7 @@ pub struct GetCredBlobResponse(Base64UrlSafeData);
 #[serde(rename_all = "camelCase")]
 pub struct RequestAuthenticationExtensions {
     /// The `credBlob` extension options
-    #[serde(rename = "credBlob", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "getCredBlob", skip_serializing_if = "Option::is_none")]
     pub get_cred_blob: Option<CredBlobGet>,
 }
 


### PR DESCRIPTION
Supercedes #49 - this implements the start of the design as discussed in https://github.com/kanidm/webauthn-rs/blob/master/designs/authentication-use-cases.md

This allows:

* Multiple credentials, with a derive UV policy and checked for consistency.
* A single credential, which can have a policy over-ride applied.

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] documentation has been updated with relevant examples (if relevant)
