### PR TITLE
Refactor functions to take more arguments by reference

### DIFF
--- a/examples/tide/actors.rs
+++ b/examples/tide/actors.rs
@@ -88,7 +88,7 @@ impl WebauthnActor {
         let r = match creds.get_mut(&username) {
             Some(ucreds) => self
                 .wan
-                .register_credential(reg, rs, |cred_id| Ok(ucreds.contains_key(cred_id)))
+                .register_credential(reg, &rs, |cred_id| Ok(ucreds.contains_key(cred_id)))
                 .map(|cred| {
                     let cred_id = cred.0.cred_id.clone();
                     ucreds.insert(cred_id, cred.0);
@@ -96,7 +96,7 @@ impl WebauthnActor {
             None => {
                 let r = self
                     .wan
-                    .register_credential(reg, rs, |_| Ok(false))
+                    .register_credential(reg, &rs, |_| Ok(false))
                     .map(|cred| {
                         let mut t = BTreeMap::new();
                         let credential_id = cred.0.cred_id.clone();
@@ -134,11 +134,11 @@ impl WebauthnActor {
         let mut creds = self.creds.lock().await;
         let r = self
             .wan
-            .authenticate_credential(lgn, st)
+            .authenticate_credential(lgn, &st)
             .map(|(cred_id, auth_data)| {
                 let _ = match creds.get_mut(&username) {
                     Some(v) => {
-                        let mut c = v.remove(&cred_id).unwrap();
+                        let mut c = v.remove(cred_id).unwrap();
                         c.counter = auth_data.counter;
                         v.insert(cred_id.clone(), c);
                         Ok(())

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -82,7 +82,7 @@ pub(crate) fn verify_packed_attestation(
     counter: u32,
     user_verified: bool,
     att_stmt: &serde_cbor::Value,
-    auth_data_bytes: Vec<u8>,
+    auth_data_bytes: &[u8],
     client_data_hash: &[u8],
 ) -> Result<AttestationType, WebauthnError> {
     // 1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the contained fields
@@ -334,7 +334,7 @@ pub(crate) fn verify_tpm_attestation(
     counter: u32,
     user_verified: bool,
     att_stmt: &serde_cbor::Value,
-    auth_data_bytes: Vec<u8>,
+    auth_data_bytes: &[u8],
     client_data_hash: &[u8],
 ) -> Result<AttestationType, WebauthnError> {
     log::debug!("begin verify_tpm_attest");
@@ -573,7 +573,7 @@ pub(crate) fn verify_apple_anonymous_attestation(
     counter: u32,
     user_verified: bool,
     att_stmt: &serde_cbor::Value,
-    auth_data_bytes: Vec<u8>,
+    auth_data_bytes: &[u8],
     client_data_hash: &[u8],
 ) -> Result<AttestationType, WebauthnError> {
     // 1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the contained fields.

--- a/src/base64_data.rs
+++ b/src/base64_data.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A container for binary that should be base64 encoded in serialisation. In reverse
-/// when deserialising, will decode from many different types of base64 possible.
+/// when deserializing, will decode from many different types of base64 possible.
 pub struct Base64UrlSafeData(pub Vec<u8>);
 
 impl fmt::Display for Base64UrlSafeData {
@@ -24,12 +24,6 @@ impl fmt::Display for Base64UrlSafeData {
 impl Into<Vec<u8>> for Base64UrlSafeData {
     fn into(self) -> Vec<u8> {
         self.0
-    }
-}
-
-impl AsRef<Vec<u8>> for Base64UrlSafeData {
-    fn as_ref(&self) -> &Vec<u8> {
-        &self.0
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -1102,12 +1102,8 @@ mod tests {
 
         println!("{:?}", rsp_d);
 
-        let result = wan.register_credential_internal(
-            &rsp_d,
-            UserVerificationPolicy::Required,
-            &chal,
-            &[],
-        );
+        let result =
+            wan.register_credential_internal(&rsp_d, UserVerificationPolicy::Required, &chal, &[]);
         println!("{:?}", result);
         assert!(result.is_ok());
     }
@@ -1303,12 +1299,8 @@ mod tests {
             type_: "public-key".to_string(),
         };
 
-        let result = wan.register_credential_internal(
-            &rsp_d,
-            UserVerificationPolicy::Required,
-            &chal,
-            &[],
-        );
+        let result =
+            wan.register_credential_internal(&rsp_d, UserVerificationPolicy::Required, &chal, &[]);
         println!("{:?}", result);
         assert!(result.is_ok());
         let cred = result.unwrap();
@@ -1364,8 +1356,12 @@ mod tests {
             type_: "public-key".to_string(),
         };
 
-        let r =
-            wan.verify_credential_internal(&rsp_d, UserVerificationPolicy::Required, &chal, &cred.0);
+        let r = wan.verify_credential_internal(
+            &rsp_d,
+            UserVerificationPolicy::Required,
+            &chal,
+            &cred.0,
+        );
         println!("RESULT: {:?}", r);
         assert!(r.is_ok());
     }
@@ -1657,12 +1653,8 @@ mod tests {
             type_: "public-key".to_string(),
         };
 
-        let result = wan.register_credential_internal(
-            &rsp_d,
-            UserVerificationPolicy::Required,
-            &chal,
-            &[],
-        );
+        let result =
+            wan.register_credential_internal(&rsp_d, UserVerificationPolicy::Required, &chal, &[]);
         println!("{:?}", result);
         assert!(result.is_ok());
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -62,7 +62,7 @@ impl AuthenticationState {
 ///
 /// Each of these is described in turn, but they will all map to routes in your application.
 /// The generate functions return Json challenges that are intended to be processed by the client
-/// browser, and the register and authenticate will recieve Json that is processed and verified.
+/// browser, and the register and authenticate will receive Json that is processed and verified.
 ///
 /// These functions return state that you must store and handle correctly for the authentication
 /// or registration to proceed correctly.
@@ -78,7 +78,7 @@ pub struct Webauthn<T> {
 
 impl<T> Webauthn<T> {
     /// Create a new Webauthn instance with the supplied configuration. The config type
-    /// will recieve and interact with various callbacks to allow the lifecycle and
+    /// will receive and interact with various callbacks to allow the lifecycle and
     /// application handling of Credentials to be customised for your application.
     ///
     /// You should see the Documentation for WebauthnConfig, which is the main part of
@@ -133,12 +133,12 @@ impl<T> Webauthn<T> {
     /// the lifecycle of a credential. This function will return the
     /// CreationChallengeResponse which is suitable for Serde JSON serialisation
     /// to be sent to the client.
-    /// The client (generally a webbrowser) will pass this JSON
+    /// The client (generally a web browser) will pass this JSON
     /// structure to the `navigator.credentials.create()` javascript function for registration.
     ///
-    /// It also returns a RegistratationState, that you *must*
+    /// It also returns a RegistrationState, that you *must*
     /// persist. It is strongly advised you associate this RegistrationState with the
-    /// UserId of the requestor.
+    /// UserId of the requester.
     pub fn generate_challenge_register_options(
         &self,
         user_id: UserId,
@@ -166,8 +166,8 @@ impl<T> Webauthn<T> {
         let c = CreationChallengeResponse {
             public_key: PublicKeyCredentialCreationOptions {
                 rp: RelyingParty {
-                    name: self.config.get_relying_party_name(),
-                    id: self.config.get_relying_party_id(),
+                    name: self.config.get_relying_party_name().to_owned(),
+                    id: self.config.get_relying_party_id().to_owned(),
                 },
                 user: User {
                     id: Base64UrlSafeData(user_id),
@@ -226,7 +226,7 @@ impl<T> Webauthn<T> {
     pub fn register_credential(
         &self,
         reg: &RegisterPublicKeyCredential,
-        state: RegistrationState,
+        state: &RegistrationState,
         does_exist_fn: impl Fn(&CredentialID) -> Result<bool, ()>,
     ) -> Result<(Credential, AuthenticatorData), WebauthnError>
     where
@@ -241,13 +241,14 @@ impl<T> Webauthn<T> {
             exclude_credentials,
             challenge,
         } = state;
+        let chal: &ChallengeRef = challenge.into();
 
         // TODO: check the req username matches? I think it's not possible, the caller needs to
         // create the linkage between the username and the state.
 
         // send to register_credential_internal
         let credential =
-            self.register_credential_internal(reg, policy, challenge.into(), exclude_credentials)?;
+            self.register_credential_internal(reg, policy.clone(), chal, &exclude_credentials)?;
 
         // Check that the credentialId is not yet registered to any other user. If registration is
         // requested for a credential that is already registered to a different user, the Relying
@@ -268,8 +269,8 @@ impl<T> Webauthn<T> {
         &self,
         reg: &RegisterPublicKeyCredential,
         policy: UserVerificationPolicy,
-        chal: Challenge,
-        exclude_credentials: Vec<CredentialID>,
+        chal: &ChallengeRef,
+        exclude_credentials: &[CredentialID],
     ) -> Result<(Credential, AuthenticatorData), WebauthnError>
     where
         T: WebauthnConfig,
@@ -419,7 +420,7 @@ impl<T> Webauthn<T> {
                 data.attestation_object.auth_data.counter,
                 data.attestation_object.auth_data.user_verified,
                 &data.attestation_object.att_stmt,
-                data.attestation_object.auth_data_bytes,
+                &data.attestation_object.auth_data_bytes,
                 &client_data_json_hash,
             ),
             AttestationFormat::TPM => verify_tpm_attestation(
@@ -427,7 +428,7 @@ impl<T> Webauthn<T> {
                 data.attestation_object.auth_data.counter,
                 data.attestation_object.auth_data.user_verified,
                 &data.attestation_object.att_stmt,
-                data.attestation_object.auth_data_bytes,
+                &data.attestation_object.auth_data_bytes,
                 &client_data_json_hash,
             ),
             AttestationFormat::AppleAnonymous => verify_apple_anonymous_attestation(
@@ -435,7 +436,7 @@ impl<T> Webauthn<T> {
                 data.attestation_object.auth_data.counter,
                 data.attestation_object.auth_data.user_verified,
                 &data.attestation_object.att_stmt,
-                data.attestation_object.auth_data_bytes,
+                &data.attestation_object.auth_data_bytes,
                 &client_data_json_hash,
             ),
             AttestationFormat::None => verify_none_attestation(
@@ -515,7 +516,7 @@ impl<T> Webauthn<T> {
         &self,
         rsp: &PublicKeyCredential,
         policy: UserVerificationPolicy,
-        chal: Challenge,
+        chal: &ChallengeRef,
         cred: &Credential,
     ) -> Result<AuthenticatorData, WebauthnError>
     where
@@ -710,7 +711,7 @@ impl<T> Webauthn<T> {
         let r = RequestChallengeResponse::new(
             chal.clone(),
             self.config.get_authenticator_timeout(),
-            self.config.get_relying_party_id(),
+            self.config.get_relying_party_id().to_owned(),
             ac,
             policy.clone(),
             extensions,
@@ -728,17 +729,17 @@ impl<T> Webauthn<T> {
     /// is the output of `navigator.credentials.get()`, which is processed by this
     /// function. If the authentication fails, appropriate errors will be returned.
     ///
-    /// This requireds the associated AuthenticationState that was created by
+    /// This requires the associated AuthenticationState that was created by
     /// generate_challenge_authenticate
     ///
-    /// On successful authentication, an Ok result is returned. The Ok may contain the credentialid
+    /// On successful authentication, an Ok result is returned. The Ok may contain the CredentialID
     /// and associated counter, which you *should* update for security purposes. If the Ok returns
     /// `None` then the credential does not have a counter.
-    pub fn authenticate_credential(
+    pub fn authenticate_credential<'a>(
         &self,
         rsp: &PublicKeyCredential,
-        state: AuthenticationState,
-    ) -> Result<(CredentialID, AuthenticatorData), WebauthnError>
+        state: &'a AuthenticationState,
+    ) -> Result<(&'a CredentialID, AuthenticatorData), WebauthnError>
     where
         T: WebauthnConfig,
     {
@@ -750,6 +751,7 @@ impl<T> Webauthn<T> {
             policy,
             challenge: chal,
         } = state;
+        let chal: &ChallengeRef = chal.into();
 
         // If the allowCredentials option was given when this authentication ceremony was initiated,
         // verify that credential.id identifies one of the public key credentials that were listed in allowCredentials.
@@ -777,7 +779,7 @@ impl<T> Webauthn<T> {
 
             // Using credential’s id attribute (or the corresponding rawId, if base64url encoding is
             // inappropriate for your use case), look up the corresponding credential public key.
-            let mut found_cred: Option<Credential> = None;
+            let mut found_cred: Option<&Credential> = None;
             for cred in creds {
                 if cred.cred_id == rsp.raw_id.0 {
                     found_cred = Some(cred);
@@ -788,7 +790,7 @@ impl<T> Webauthn<T> {
             found_cred.ok_or(WebauthnError::CredentialNotFound)?
         };
 
-        let auth_data = self.verify_credential_internal(rsp, policy, chal.into(), &cred)?;
+        let auth_data = self.verify_credential_internal(rsp, policy.clone(), chal, &cred)?;
         let counter = auth_data.counter;
 
         // If the signature counter value authData.signCount is nonzero or the value stored in
@@ -810,7 +812,7 @@ impl<T> Webauthn<T> {
             }
         }
 
-        Ok((cred.cred_id, auth_data))
+        Ok((&cred.cred_id, auth_data))
     }
 }
 
@@ -823,7 +825,7 @@ pub trait WebauthnConfig {
     /// confuse authenticators and will cause their credentials to be lost.
     ///
     /// Examples of names could be "My Awesome Site", "https://my-awesome-site.com.au"
-    fn get_relying_party_name(&self) -> String;
+    fn get_relying_party_name(&self) -> &str;
 
     /// Returns a reference to your sites origin. The origin is the URL to your site with
     /// protocol and port. This should rarely, if ever change. In production usage this
@@ -842,7 +844,7 @@ pub trait WebauthnConfig {
     /// If changed, all associated credentials will be lost in all authenticators.
     ///
     /// Examples of this value for the site "https://my-site.com.au/auth" is "my-site.com.au"
-    fn get_relying_party_id(&self) -> String;
+    fn get_relying_party_id(&self) -> &str;
 
     /// Get the list of valid credential algorthims that this service can accept. Unless you have
     /// speific requirements around this, we advise you leave this function to the default
@@ -994,8 +996,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Preferred_DO_NOT_USE,
-            zero_chal,
-            vec![],
+            &zero_chal,
+            &[],
         );
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -1030,8 +1032,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Preferred_DO_NOT_USE,
-            chal,
-            vec![],
+            chal.as_ref(),
+            &[],
         );
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -1066,8 +1068,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Preferred_DO_NOT_USE,
-            chal,
-            vec![],
+            &chal,
+            &[],
         );
         assert!(result.is_ok());
     }
@@ -1103,8 +1105,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Required,
-            chal,
-            vec![],
+            &chal,
+            &[],
         );
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -1176,7 +1178,7 @@ mod tests {
         let r = wan.verify_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Discouraged,
-            zero_chal,
+            &zero_chal,
             &cred,
         );
         println!("RESULT: {:?}", r);
@@ -1215,8 +1217,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Preferred_DO_NOT_USE,
-            chal,
-            vec![],
+            &chal,
+            &[],
         );
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -1233,7 +1235,7 @@ mod tests {
         let wan = Webauthn::new(wan_c);
 
         let result =
-            wan.register_credential_internal(rsp_d, UserVerificationPolicy::Required, chal, vec![]);
+            wan.register_credential_internal(rsp_d, UserVerificationPolicy::Required, &chal, &[]);
         println!("{:?}", result);
         assert!(result.is_ok());
     }
@@ -1304,8 +1306,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Required,
-            chal,
-            vec![],
+            &chal,
+            &[],
         );
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -1363,7 +1365,7 @@ mod tests {
         };
 
         let r =
-            wan.verify_credential_internal(&rsp_d, UserVerificationPolicy::Required, chal, &cred.0);
+            wan.verify_credential_internal(&rsp_d, UserVerificationPolicy::Required, &chal, &cred.0);
         println!("RESULT: {:?}", r);
         assert!(r.is_ok());
     }
@@ -1658,8 +1660,8 @@ mod tests {
         let result = wan.register_credential_internal(
             &rsp_d,
             UserVerificationPolicy::Required,
-            chal,
-            vec![],
+            &chal,
+            &[],
         );
         println!("{:?}", result);
         assert!(result.is_ok());

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -43,13 +43,13 @@ impl std::fmt::Debug for WebauthnEphemeralConfig {
 
 impl WebauthnConfig for WebauthnEphemeralConfig {
     /// Returns the relying party name. See the trait documentation for more.
-    fn get_relying_party_name(&self) -> String {
-        self.rp_name.clone()
+    fn get_relying_party_name(&self) -> &str {
+        &self.rp_name
     }
 
     /// Returns the relying party id. See the trait documentation for more.
-    fn get_relying_party_id(&self) -> String {
-        self.rp_id.clone()
+    fn get_relying_party_id(&self) -> &str {
+        &self.rp_id
     }
 
     /// Retrieve the relying party origin. See the trait documentation for more.

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -10,6 +10,8 @@ use std::convert::TryFrom;
 use js_sys::{Array, Object, Uint8Array};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
+use std::borrow::Borrow;
+use std::ops::Deref;
 
 /// Representation of a UserId
 pub type UserId = Vec<u8>;
@@ -22,7 +24,7 @@ pub type Counter = u32;
 pub type Aaguid = Vec<u8>;
 
 /// A challenge issued by the server. This contains a set of random bytes
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Challenge(pub Vec<u8>);
 
 impl Into<Base64UrlSafeData> for Challenge {
@@ -34,6 +36,58 @@ impl Into<Base64UrlSafeData> for Challenge {
 impl From<Base64UrlSafeData> for Challenge {
     fn from(d: Base64UrlSafeData) -> Self {
         Challenge(d.0)
+    }
+}
+
+/// A reference to the challenge issued by the server.
+/// This contains a set of random bytes.
+///
+/// ChallengeRef is the ?Sized Type that corresponds to Challenge
+/// in the same way that &[u8] corresponds to Vec<u8>.
+/// Vec<T> : &[T] :: Challenge : &ChallengeRef
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct ChallengeRef(pub [u8]);
+
+impl ChallengeRef {
+    /// Creates a new ChallengeRef from an array
+    pub fn new(challenge: &[u8]) -> &ChallengeRef {
+        // SAFETY
+        // Because of #[repr(transparent)], [u8] is guaranteed to have the same representation as ChallengeRef.
+        // This allows safe casting between *const pointers of these types.
+        unsafe { &*(challenge as *const [u8] as *const ChallengeRef)}
+    }
+}
+
+
+impl <'a> From< &'a Base64UrlSafeData> for &'a ChallengeRef {
+    fn from(d: &'a Base64UrlSafeData) -> Self {
+        ChallengeRef::new(d.0.as_slice())
+    }
+}
+
+impl ToOwned for ChallengeRef {
+    type Owned = Challenge;
+
+    fn to_owned(&self) -> Self::Owned {
+        Challenge(self.0.to_vec())
+    }
+}
+impl Borrow<ChallengeRef> for Challenge {
+    fn borrow(&self) -> &ChallengeRef {
+        ChallengeRef::new(&self.0)
+    }
+}
+impl AsRef<ChallengeRef> for Challenge {
+    fn as_ref(&self) -> &ChallengeRef {
+        ChallengeRef::new(&self.0)
+    }
+}
+impl Deref for Challenge {
+    type Target = ChallengeRef;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
     }
 }
 
@@ -796,11 +850,11 @@ pub struct TokenBinding {
     pub id: Option<String>,
 }
 
-impl TryFrom<&Vec<u8>> for CollectedClientData {
+impl TryFrom<&[u8]> for CollectedClientData {
     type Error = WebauthnError;
-    fn try_from(data: &Vec<u8>) -> Result<CollectedClientData, WebauthnError> {
+    fn try_from(data: &[u8]) -> Result<CollectedClientData, WebauthnError> {
         let ccd: CollectedClientData =
-            serde_json::from_slice(&data).map_err(WebauthnError::ParseJSONFailure)?;
+            serde_json::from_slice(data).map_err(WebauthnError::ParseJSONFailure)?;
         Ok(ccd)
     }
 }
@@ -896,10 +950,10 @@ named!( authenticator_data_parser<&[u8], AuthenticatorData>,
     )
 );
 
-impl TryFrom<&Vec<u8>> for AuthenticatorData {
+impl TryFrom<&[u8]> for AuthenticatorData {
     type Error = WebauthnError;
-    fn try_from(auth_data_bytes: &Vec<u8>) -> Result<Self, Self::Error> {
-        authenticator_data_parser(auth_data_bytes.as_slice())
+    fn try_from(auth_data_bytes: &[u8]) -> Result<Self, Self::Error> {
+        authenticator_data_parser(auth_data_bytes)
             .map_err(|e| {
                 log::debug!("nom -> {:?}", e);
                 WebauthnError::ParseNOMFailure
@@ -912,7 +966,7 @@ impl TryFrom<&Vec<u8>> for AuthenticatorData {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AttestationObjectInner<'a> {
     pub(crate) auth_data: &'a [u8],
-    pub(crate) fmt: String,
+    pub(crate) fmt: &'a str,
     pub(crate) att_stmt: serde_cbor::Value,
 }
 
@@ -935,15 +989,14 @@ impl TryFrom<&[u8]> for AttestationObject {
     fn try_from(data: &[u8]) -> Result<AttestationObject, WebauthnError> {
         let aoi: AttestationObjectInner =
             serde_cbor::from_slice(&data).map_err(WebauthnError::ParseCBORFailure)?;
-        let auth_data_bytes: Vec<u8> = aoi.auth_data.iter().copied().collect();
-
-        let auth_data = AuthenticatorData::try_from(&auth_data_bytes)?;
+        let auth_data_bytes: &[u8] = aoi.auth_data;
+        let auth_data = AuthenticatorData::try_from(auth_data_bytes)?;
 
         // Yay! Now we can assemble a reasonably sane structure.
         Ok(AttestationObject {
-            fmt: aoi.fmt.clone(),
+            fmt: aoi.fmt.to_owned(),
             auth_data,
-            auth_data_bytes,
+            auth_data_bytes: auth_data_bytes.to_owned(),
             att_stmt: aoi.att_stmt,
         })
     }
@@ -1067,6 +1120,20 @@ impl TryFrom<&AuthenticatorAssertionResponseRaw> for AuthenticatorAssertionRespo
             client_data_bytes: aarr.client_data_json.clone().into(),
             signature: aarr.signature.clone().into(),
             user_handle: aarr.user_handle.clone().map(|uh| uh.into()),
+        })
+    }
+}
+
+impl TryFrom<AuthenticatorAssertionResponseRaw> for AuthenticatorAssertionResponse {
+    type Error = WebauthnError;
+    fn try_from(aarr: AuthenticatorAssertionResponseRaw) -> Result<Self, Self::Error> {
+        Ok(AuthenticatorAssertionResponse {
+            authenticator_data: AuthenticatorData::try_from(aarr.authenticator_data.as_ref())?,
+            authenticator_data_bytes: aarr.authenticator_data.into(),
+            client_data: CollectedClientData::try_from(aarr.client_data_json.as_ref())?,
+            client_data_bytes: aarr.client_data_json.into(),
+            signature: aarr.signature.into(),
+            user_handle: aarr.user_handle.map(|uh| uh.into()),
         })
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -25,7 +25,13 @@ pub type Aaguid = Vec<u8>;
 
 /// A challenge issued by the server. This contains a set of random bytes
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Challenge(pub Vec<u8>);
+pub struct Challenge(pub(crate) Vec<u8>);
+impl Challenge {
+    /// Creates a new Challenge from a `Vec<u8>`
+    pub fn new(challenge: Vec<u8>) -> Self {
+        Challenge(challenge)
+    }
+}
 
 impl Into<Base64UrlSafeData> for Challenge {
     fn into(self) -> Base64UrlSafeData {
@@ -47,10 +53,10 @@ impl From<Base64UrlSafeData> for Challenge {
 /// Vec<T> : &[T] :: Challenge : &ChallengeRef
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
-pub struct ChallengeRef(pub [u8]);
+pub struct ChallengeRef(pub(crate) [u8]);
 
 impl ChallengeRef {
-    /// Creates a new ChallengeRef from an array
+    /// Creates a new ChallengeRef from a slice
     pub fn new(challenge: &[u8]) -> &ChallengeRef {
         // SAFETY
         // Because of #[repr(transparent)], [u8] is guaranteed to have the same representation as ChallengeRef.
@@ -1123,19 +1129,6 @@ impl TryFrom<&AuthenticatorAssertionResponseRaw> for AuthenticatorAssertionRespo
     }
 }
 
-impl TryFrom<AuthenticatorAssertionResponseRaw> for AuthenticatorAssertionResponse {
-    type Error = WebauthnError;
-    fn try_from(aarr: AuthenticatorAssertionResponseRaw) -> Result<Self, Self::Error> {
-        Ok(AuthenticatorAssertionResponse {
-            authenticator_data: AuthenticatorData::try_from(aarr.authenticator_data.as_ref())?,
-            authenticator_data_bytes: aarr.authenticator_data.into(),
-            client_data: CollectedClientData::try_from(aarr.client_data_json.as_ref())?,
-            client_data_bytes: aarr.client_data_json.into(),
-            signature: aarr.signature.into(),
-            user_handle: aarr.user_handle.map(|uh| uh.into()),
-        })
-    }
-}
 
 /// https://w3c.github.io/webauthn/#authenticatorassertionresponse
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -8,10 +8,10 @@ use std::convert::TryFrom;
 
 #[cfg(feature = "wasm")]
 use js_sys::{Array, Object, Uint8Array};
-#[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::*;
 use std::borrow::Borrow;
 use std::ops::Deref;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
 
 /// Representation of a UserId
 pub type UserId = Vec<u8>;
@@ -55,12 +55,11 @@ impl ChallengeRef {
         // SAFETY
         // Because of #[repr(transparent)], [u8] is guaranteed to have the same representation as ChallengeRef.
         // This allows safe casting between *const pointers of these types.
-        unsafe { &*(challenge as *const [u8] as *const ChallengeRef)}
+        unsafe { &*(challenge as *const [u8] as *const ChallengeRef) }
     }
 }
 
-
-impl <'a> From< &'a Base64UrlSafeData> for &'a ChallengeRef {
+impl<'a> From<&'a Base64UrlSafeData> for &'a ChallengeRef {
     fn from(d: &'a Base64UrlSafeData) -> Self {
         ChallengeRef::new(d.0.as_slice())
     }


### PR DESCRIPTION
Implements #61.

* Adds `ChallengeRef`, to allow working with `Challenge`s in the same way that `&[T]` and `Vec<T>` are used.
  * This adds a small amount of unsafe code, but it is very mundane as far as unsafe code goes.
* `Webauthn::register_credential_internal()` takes `chal` and `exclude_credentials` by reference.
* `Webauthn::register_credential()` takes `state` by reference.
* `Webauthn::authenticate_credential()` takes `state` by reference and returns a reference to a `CredentialID`.
* `WebauthnConfig`'s methods:  `get_relying_party_name` and `get_relying_party_id` now return `&str` instead of `String`.
  * I'm not sure if this is ideal. I understand that webauthn_rs code currently needs to clone these `&str`s anyways, but the trait was asking that the implementer perform `&self -> String` which will always require a reallocation (or questionable use of interior mutability) to get ownership of a `String` to return.
  * Making the functions return a &str limits the ability of the implementer of the trait to `format!()` them if needed. If you believe that ad-hoc formatting in these functions is a common, then defining the function to return `Cow<'_, str>` should be done instead to allow either pass an unformatted str or a formatted String.

Some enums in this crate that could be `Copy` are not, I'm also wondering if this is done with the understanding that they may become not `Copy` in the future, or if they could be made to derive that marker trait.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
