### PR TITLE
Update CCD to spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 static/bundle.js
 examples/tide/tide_yew/pkg
+examples/tide/tide_yew/target

--- a/src/error.rs
+++ b/src/error.rs
@@ -208,4 +208,9 @@ pub enum WebauthnError {
 
     #[error("The attested credential public key and subject public key do not match")]
     AttestationCredentialSubjectKeyMismatch,
+
+    #[error(
+        "The credential was created in a cross-origin context (while cross-origin was disallowed)"
+    )]
+    CredentialCrossOrigin,
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -963,8 +963,8 @@ pub struct CollectedClientData {
     pub origin: String,
     // /// The inverse of the sameOriginWithAncestors argument value that was
     // /// passed into the internal method.
-    // #[serde(rename = "crossOrigin", skip_serializing_if = "Option::is_none")]
-    // pub cross_origin: Option<bool>,
+    #[serde(rename = "crossOrigin", skip_serializing_if = "Option::is_none")]
+    pub cross_origin: Option<bool>,
     /// tokenBinding.
     #[serde(rename = "tokenBinding")]
     pub token_binding: Option<TokenBinding>,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -961,8 +961,8 @@ pub struct CollectedClientData {
     pub challenge: Base64UrlSafeData,
     /// The rp origin as the browser understood it.
     pub origin: String,
-    // /// The inverse of the sameOriginWithAncestors argument value that was
-    // /// passed into the internal method.
+    /// The inverse of the sameOriginWithAncestors argument value that was
+    /// passed into the internal method.
     #[serde(rename = "crossOrigin", skip_serializing_if = "Option::is_none")]
     pub cross_origin: Option<bool>,
     /// tokenBinding.


### PR DESCRIPTION
Add `crossOrigin` field to `CollectedClientData` and capture unknown keys in an extra field.

Additionally updates some formatting left over from credBlob.

Implements #52.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)