### PR TITLE
Rename COSE content type and ESDSA members to conform to spec

### DIFF
--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -9,7 +9,7 @@ use crate::crypto;
 use crate::crypto::compute_sha256;
 use crate::error::WebauthnError;
 use crate::proto::{
-    AttestedCredentialData, COSEContentType, COSEKey, COSEKeyType, Credential, Tpm2bName, TpmAlgId,
+    AttestedCredentialData, COSEAlgorithm, COSEKey, COSEKeyType, Credential, Tpm2bName, TpmAlgId,
     TpmSt, TpmsAttest, TpmtPublic, TpmtSignature, TpmuAttest, TpmuPublicId, TpmuPublicParms,
     UserVerificationPolicy,
 };
@@ -100,7 +100,7 @@ pub(crate) fn verify_packed_attestation(
 
     let alg = cbor_try_i128!(alg_value)
         .map_err(|_| WebauthnError::AttestationStatementAlgInvalid)
-        .and_then(COSEContentType::try_from)?;
+        .and_then(COSEAlgorithm::try_from)?;
 
     match (
         att_stmt_map.get(x5c_key),
@@ -286,7 +286,7 @@ pub(crate) fn verify_fidou2f_attestation(
     //
     // // try from asserts this condition given the alg.
     let cerificate_public_key =
-        crypto::X509PublicKey::try_from((att_cert.as_slice(), COSEContentType::ECDSA_SHA256))?;
+        crypto::X509PublicKey::try_from((att_cert.as_slice(), COSEAlgorithm::ES256))?;
 
     // Extract the claimed rpIdHash from authenticatorData, and the claimed credentialId and credentialPublicKey from authenticatorData.attestedCredentialData.
     //
@@ -388,7 +388,7 @@ pub(crate) fn verify_tpm_attestation(
 
     let alg = cbor_try_i128!(alg_value)
         .map_err(|_| WebauthnError::AttestationStatementAlgInvalid)
-        .and_then(COSEContentType::try_from)?;
+        .and_then(COSEAlgorithm::try_from)?;
 
     // eprintln!("alg = {:?}", alg);
 
@@ -627,7 +627,7 @@ pub(crate) fn verify_apple_anonymous_attestation(
         .iter()
         .zip(
             // FIXME: this is determined empirically, not sure if it's always right.
-            std::iter::once(alg).chain(std::iter::repeat(COSEContentType::ECDSA_SHA384)),
+            std::iter::once(alg).chain(std::iter::repeat(COSEAlgorithm::ES384)),
         )
         .map(|(values, alg)| {
             cbor_try_bytes!(values)

--- a/src/core.rs
+++ b/src/core.rs
@@ -919,8 +919,8 @@ pub trait WebauthnConfig {
     /// Get the list of valid credential algorthims that this service can accept. Unless you have
     /// speific requirements around this, we advise you leave this function to the default
     /// implementation.
-    fn get_credential_algorithms(&self) -> Vec<COSEContentType> {
-        vec![COSEContentType::ECDSA_SHA256, COSEContentType::RS256]
+    fn get_credential_algorithms(&self) -> Vec<COSEAlgorithm> {
+        vec![COSEAlgorithm::ES256, COSEAlgorithm::RS256]
     }
 
     /// Return a timeout on how long the authenticator has to respond to a challenge. This value
@@ -1052,7 +1052,7 @@ mod tests {
         AuthenticatorAssertionResponseRaw, AuthenticatorAttestationResponseRaw, Challenge,
         Credential, PublicKeyCredential, RegisterPublicKeyCredential, UserVerificationPolicy,
     };
-    use crate::proto::{COSEContentType, COSEEC2Key, COSEKey, COSEKeyType, ECDSACurve};
+    use crate::proto::{COSEAlgorithm, COSEEC2Key, COSEKey, COSEKeyType, ECDSACurve};
     use crate::Webauthn;
 
     // Test the crypto operations of the webauthn impl
@@ -1232,7 +1232,7 @@ mod tests {
                 238, 21, 13, 27, 145, 140, 27, 208, 101, 166, 81,
             ],
             cred: COSEKey {
-                type_: COSEContentType::ECDSA_SHA256,
+                type_: COSEAlgorithm::ES256,
                 key: COSEKeyType::EC_EC2(COSEEC2Key {
                     curve: ECDSACurve::SECP256R1,
                     x: [
@@ -1917,7 +1917,7 @@ mod tests {
                     240, 148, 132, 191, 165, 150, 166, 252, 39, 97, 137, 21, 186,
                 ],
                 cred: COSEKey {
-                    type_: COSEContentType::ECDSA_SHA256,
+                    type_: COSEAlgorithm::ES256,
                     key: COSEKeyType::EC_EC2(COSEEC2Key {
                         curve: ECDSACurve::SECP256R1,
                         x: [
@@ -1944,7 +1944,7 @@ mod tests {
                     122, 120, 204, 174, 28, 58, 171, 43, 218, 81, 195, 177,
                 ],
                 cred: COSEKey {
-                    type_: COSEContentType::ECDSA_SHA256,
+                    type_: COSEAlgorithm::ES256,
                     key: COSEKeyType::EC_EC2(COSEEC2Key {
                         curve: ECDSACurve::SECP256R1,
                         x: [

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -11,7 +11,7 @@
 
 use crate::proto::AttestationConveyancePreference;
 use crate::proto::AuthenticatorAttachment;
-use crate::proto::COSEContentType;
+use crate::proto::COSEAlgorithm;
 use crate::WebauthnConfig;
 
 /// An implementation of an Ephemeral (in-memory) webauthn configuration provider
@@ -71,18 +71,18 @@ impl WebauthnConfig for WebauthnEphemeralConfig {
     ///
     /// WARNING: This returns *all* possible algorithms, not just SUPPORTED ones. This
     /// is so that
-    fn get_credential_algorithms(&self) -> Vec<COSEContentType> {
+    fn get_credential_algorithms(&self) -> Vec<COSEAlgorithm> {
         vec![
-            COSEContentType::ECDSA_SHA256,
-            COSEContentType::ECDSA_SHA384,
-            COSEContentType::ECDSA_SHA512,
-            COSEContentType::RS256,
-            COSEContentType::RS384,
-            COSEContentType::RS512,
-            COSEContentType::PS256,
-            COSEContentType::PS384,
-            COSEContentType::PS512,
-            COSEContentType::EDDSA,
+            COSEAlgorithm::ES256,
+            COSEAlgorithm::ES384,
+            COSEAlgorithm::ES512,
+            COSEAlgorithm::RS256,
+            COSEAlgorithm::RS384,
+            COSEAlgorithm::RS512,
+            COSEAlgorithm::PS256,
+            COSEAlgorithm::PS384,
+            COSEAlgorithm::PS512,
+            COSEAlgorithm::EDDSA,
         ]
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -159,7 +159,7 @@ pub enum WebauthnError {
     COSEKeyECDSAInvalidCurve,
 
     #[error("The COSEKey contains invalid cryptographic algorithm request")]
-    COSEKeyECDSAContentType,
+    COSEKeyInvalidAlgorithm,
 
     #[error("The credential exist check failed")]
     CredentialExistCheckError,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -152,18 +152,17 @@ impl TryFrom<i128> for ECDSACurve {
     }
 }
 
-/// A COSE Key Content type, indicating the type of key and hash type
-/// that should be used with this key. You shouldn't need to alter or
-/// use this value.
+/// A COSE signature algorithm, indicating the type of key and hash type
+/// that should be used. You shouldn't need to alter or use this value.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum COSEContentType {
+pub enum COSEAlgorithm {
     /// Identifies this key as ECDSA (recommended SECP256R1) with SHA256 hashing
-    ECDSA_SHA256 = -7, // recommends curve SECP256R1
+    ES256 = -7, // recommends curve SECP256R1
     /// Identifies this key as ECDSA (recommended SECP384R1) with SHA384 hashing
-    ECDSA_SHA384 = -35, // recommends curve SECP384R1
+    ES384 = -35, // recommends curve SECP384R1
     /// Identifies this key as ECDSA (recommended SECP521R1) with SHA512 hashing
-    ECDSA_SHA512 = -36, // recommends curve SECP521R1
+    ES512 = -36, // recommends curve SECP521R1
     /// Identifies this key as RS256 aka RSASSA-PKCS1-v1_5 w/ SHA-256
     RS256 = -257,
     /// Identifies this key as RS384 aka RSASSA-PKCS1-v1_5 w/ SHA-384
@@ -183,40 +182,40 @@ pub enum COSEContentType {
     INSECURE_RS1 = -65535,
 }
 
-impl TryFrom<i128> for COSEContentType {
+impl TryFrom<i128> for COSEAlgorithm {
     type Error = WebauthnError;
     fn try_from(i: i128) -> Result<Self, Self::Error> {
         match i {
-            -7 => Ok(COSEContentType::ECDSA_SHA256),
-            -35 => Ok(COSEContentType::ECDSA_SHA384),
-            -36 => Ok(COSEContentType::ECDSA_SHA512),
-            -257 => Ok(COSEContentType::RS256),
-            -258 => Ok(COSEContentType::RS384),
-            -259 => Ok(COSEContentType::RS512),
-            -37 => Ok(COSEContentType::PS256),
-            -38 => Ok(COSEContentType::PS384),
-            -39 => Ok(COSEContentType::PS512),
-            -8 => Ok(COSEContentType::EDDSA),
-            -65535 => Ok(COSEContentType::INSECURE_RS1),
-            _ => Err(WebauthnError::COSEKeyECDSAContentType),
+            -7 => Ok(COSEAlgorithm::ES256),
+            -35 => Ok(COSEAlgorithm::ES384),
+            -36 => Ok(COSEAlgorithm::ES512),
+            -257 => Ok(COSEAlgorithm::RS256),
+            -258 => Ok(COSEAlgorithm::RS384),
+            -259 => Ok(COSEAlgorithm::RS512),
+            -37 => Ok(COSEAlgorithm::PS256),
+            -38 => Ok(COSEAlgorithm::PS384),
+            -39 => Ok(COSEAlgorithm::PS512),
+            -8 => Ok(COSEAlgorithm::EDDSA),
+            -65535 => Ok(COSEAlgorithm::INSECURE_RS1),
+            _ => Err(WebauthnError::COSEKeyInvalidAlgorithm),
         }
     }
 }
 
-impl From<&COSEContentType> for i64 {
-    fn from(c: &COSEContentType) -> Self {
+impl From<&COSEAlgorithm> for i64 {
+    fn from(c: &COSEAlgorithm) -> Self {
         match c {
-            COSEContentType::ECDSA_SHA256 => -7,
-            COSEContentType::ECDSA_SHA384 => -35,
-            COSEContentType::ECDSA_SHA512 => -6,
-            COSEContentType::RS256 => -257,
-            COSEContentType::RS384 => -258,
-            COSEContentType::RS512 => -259,
-            COSEContentType::PS256 => -37,
-            COSEContentType::PS384 => -38,
-            COSEContentType::PS512 => -39,
-            COSEContentType::EDDSA => -8,
-            COSEContentType::INSECURE_RS1 => -65535,
+            COSEAlgorithm::ES256 => -7,
+            COSEAlgorithm::ES384 => -35,
+            COSEAlgorithm::ES512 => -6,
+            COSEAlgorithm::RS256 => -257,
+            COSEAlgorithm::RS384 => -258,
+            COSEAlgorithm::RS512 => -259,
+            COSEAlgorithm::PS256 => -37,
+            COSEAlgorithm::PS384 => -38,
+            COSEAlgorithm::PS512 => -39,
+            COSEAlgorithm::EDDSA => -8,
+            COSEAlgorithm::INSECURE_RS1 => -65535,
         }
     }
 }
@@ -276,7 +275,7 @@ pub enum COSEKeyType {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct COSEKey {
     /// The type of key that this contains
-    pub type_: COSEContentType,
+    pub type_: COSEAlgorithm,
     /// The public key
     pub key: COSEKeyType,
 }


### PR DESCRIPTION
Implements #74

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)