### PR TITLE
Do not serialize transports when not present

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -819,6 +819,7 @@ pub struct PublicKeyCredentialDescriptor {
     id: Base64UrlSafeData,
     /// The allowed transports for this credential. Note this is a hint, and is not
     /// enforced.
+    #[serde(skip_serializing_if = "Option::is_none")]
     transports: Option<Vec<AuthenticatorTransport>>,
 }
 


### PR DESCRIPTION
Currently transports is serialized as null, which seems to be breaking some clients for me that either expect an array or the value to simply be not present.

I've changed it to be skipped when the value is None, matching other optional fields in similar structs.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
