### PR TITLE
Extend registration metadata options

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -425,9 +425,7 @@ impl TryFrom<&X509PublicKey> for COSEKey {
     type Error = WebauthnError;
     fn try_from(cert: &X509PublicKey) -> Result<COSEKey, Self::Error> {
         let key = match cert.t {
-            COSEAlgorithm::ES256
-            | COSEAlgorithm::ES384
-            | COSEAlgorithm::ES512 => {
+            COSEAlgorithm::ES256 | COSEAlgorithm::ES384 | COSEAlgorithm::ES512 => {
                 let ec_key = cert
                     .pubk
                     .public_key()


### PR DESCRIPTION
This changes what we parse to policy_verify_trust to be clearer, and moves the ParsedAttestationData out to proto since we may choose to expose this to consumers later. 

A lingering question is what we return from `register_credential`. Currently we return `Result<(Credential, AuthenticatorData<Registration>), WebauthnError>` but outside of the extensions in authenticator data, this is not very useful.

I think we should consider changing this to return ParsedAttestationData instead, and moving the Registration extensions into PAD, which is "nicer" for consumers to then consume.

I think PAD should be left as NOT ser/deser because I think it should be up to consumers to save what they want from the structure in a way that is compatible and auditable for them. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
