### PR TITLE
Add windows 11 hello to broken hw list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ please conduct a [compatability test](https://webauthn.firstyear.id.au/compat_te
 Known BROKEN Keys/Harwdare
 --------------------------
 
-* Pixel 3a / Pixel 4 + Chrome - Does not send correct attestation certificates, and ignores requested algorithms
-* Windows Hello + Windows 11 (22000.556) + Firefox running on AMD Ryzen 9 + MSI X570 Chipset (BIOS version A.F3, released 2021-09-27) - truncates 16-byte authenticator aaguid to 1 byte.
+* Pixel 3a / Pixel 4 + Chrome - Does not send correct attestation certificates, and ignores requested algorithms.
+* Windows Hello + Windows 11 (22000.556) + Firefox running on AMD Ryzen 9 + MSI X570 Chipset (BIOS version A.F3, released 2021-09-27) - Truncates 16-byte authenticator aaguid to 1 byte.
 
 Standards Compliance
 --------------------

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ please conduct a [compatability test](https://webauthn.firstyear.id.au/compat_te
 Known BROKEN Keys/Harwdare
 --------------------------
 
-* Pixel 3a / Pixel 4 + Chrome - Does not send correct attestation certificates, and ignores requested algorithms.
-* Windows Hello + Windows 11 (22000.556) + Firefox running on AMD Ryzen 9 + MSI X570 Chipset (BIOS version A.F3, released 2021-09-27) - Truncates 16-byte authenticator aaguid to 1 byte.
+* Pixel 3a / Pixel 4 + Chrome - Does not send correct attestation certificates,
+  and ignores requested algorithms.
+* Windows Hello + Windows 11 (22000.556) + Firefox running on AMD Ryzen 9 + MSI
+  X570 Chipset (BIOS version A.F3, released 2021-09-27) - When aaguid is meant
+  to be 16 bytes of 0, it emits a single 0 byte.
 
 Standards Compliance
 --------------------

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Known BROKEN Keys/Harwdare
 --------------------------
 
 * Pixel 3a / Pixel 4 + Chrome - Does not send correct attestation certificates, and ignores requested algorithms
+* Windows Hello + Windows 11 (22000.556) + Firefox running on AMD Ryzen 9 + MSI X570 Chipset (BIOS version A.F3, released 2021-09-27) - truncates 16-byte authenticator aaguid to 1 byte.
 
 Standards Compliance
 --------------------

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -3057,4 +3057,53 @@ mod tests {
         debug!("{:?}", result);
         assert!(result.is_err());
     }
+
+    /// See https://github.com/kanidm/webauthn-rs/issues/105
+    #[test]
+    fn test_windows_11_hello_incorrectly_truncates_aaguid() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let wan = unsafe {
+            Webauthn::new(
+                "https://webauthn.firstyear.id.au",
+                "webauthn.firstyear.id.au",
+                &Url::parse("https://webauthn.firstyear.id.au").unwrap(),
+                None,
+                None,
+            )
+        };
+
+        let chal: Base64UrlSafeData =
+            serde_json::from_str("\"FKVseWmr5DxQ_H9iTyoTgRPIClLspXO0XbOKQfMuaFc\"").unwrap();
+        let chal = Challenge::from(chal);
+
+        let rsp_d: RegisterPublicKeyCredential = serde_json::from_str(r#"{
+            "id": "6h7wVk2n4Buulhd5fiShGb0BBViIgvDoVO3xhn0A0Mg",
+            "rawId": "6h7wVk2n4Buulhd5fiShGb0BBViIgvDoVO3xhn0A0Mg",
+            "response": {
+            "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVkBWGq5u_Dfmhb5Hbszu7Ey-vnRfHgsSCbG7HDs7ljZfvUqRQAAAAAAACDqHvBWTafgG66WF3l-JKEZvQEFWIiC8OhU7fGGfQDQyKQBAwM5AQAgWQEAt86lR2w_hmnhDr6tvJD5hmIuWt0QkG1sphC8aqeOHuIWnbcBWnxNUrKQibJxEGJilM20s-_w-aUjDoV5MYu4NBgguFHju-qA-qe1sjhqY7UkMkx4Z1KGMeiZNNGgk5Gtmu0xjaq-1RohB3TKADeWTularHWzG6q6sJHgC-qKKa67Rmwr0T4a4S3VjLvjvSPILx88nLJvwqO1rDb5cLOgL5CEjtRijR6SNeN05uBhz2ePn5mMo2lN73pHsMGPo68pGWIWWsb2sC_aBF2eA02Me2jldIgSzMy3y8xsTIg6r_xF105pC8jOPsQVN2TJDxN9zVEuxpY_mUsqGOAFGR-SiyFDAQAB",
+            "clientDataJSON": "eyJjaGFsbGVuZ2UiOiJGS1ZzZVdtcjVEeFFfSDlpVHlvVGdSUElDbExzcFhPMFhiT0tRZk11YUZjIiwiY2xpZW50RXh0ZW5zaW9ucyI6e30sImhhc2hBbGdvcml0aG0iOiJTSEEtMjU2Iiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5maXJzdHllYXIuaWQuYXUiLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0"
+            },
+            "type": "public-key"
+        }"#).unwrap();
+
+        debug!("{:?}", rsp_d);
+
+        let result = wan.register_credential_internal(
+            &rsp_d,
+            UserVerificationPolicy::Discouraged_DO_NOT_USE,
+            &chal,
+            &[],
+            &[
+                COSEAlgorithm::RS256,
+                COSEAlgorithm::EDDSA,
+                COSEAlgorithm::INSECURE_RS1,
+            ],
+            None,
+            false,
+            &RequestRegistrationExtensions::default(),
+        );
+        debug!("{:?}", result);
+        assert!(matches!(result, Err(WebauthnError::ParseNOMFailure)));
+    }
+
 }

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -910,7 +910,7 @@ impl WebauthnCore {
         // Identify the user being authenticated and verify that this user is the owner of the public
         // key credential source credentialSource identified by credential.id:
 
-        //  - If the user was identified before the authentication ceremony was initiated, e.g., 
+        //  - If the user was identified before the authentication ceremony was initiated, e.g.,
         //  via a username or cookie,
         //      verify that the identified user is the owner of credentialSource. If
         //      response.userHandle is present, let userHandle be its value. Verify that
@@ -3105,5 +3105,4 @@ mod tests {
         debug!("{:?}", result);
         assert!(matches!(result, Err(WebauthnError::ParseNOMFailure)));
     }
-
 }

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -224,8 +224,8 @@ fn extensions_parser<T: Ceremony>(i: &[u8]) -> nom::IResult<&[u8], T::SignedExte
 fn aaguid_parser(i: &[u8]) -> nom::IResult<&[u8], Aaguid> {
     // We have observed with Windows Hello on Windows 11 aaguids of 0 being
     // serialized as 1 null-byte rather than 16 of them, as required by the spec
-    // (https://www.w3.org/TR/webauthn-2/#sctn-attested-credential-data).
-    if i[0] == 0 {
+    // (https://www.w3.org/TR/webauthn-3/#sctn-attested-credential-data).
+    if let Some(0) = i.first() {
         warn!(
             "Aaguids beginning with 0 are suspicious. This could be the Windows \
              11 Windows Hello bug where a zero aaguid gets truncated down to 1 \


### PR DESCRIPTION
Implements # .

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
