### PR TITLE
Windows 11 bug is actually Firefox 98 bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Known BROKEN Keys/Harwdare
 
 * Pixel 3a / Pixel 4 + Chrome - Does not send correct attestation certificates,
   and ignores requested algorithms.
-* Windows Hello + Windows 11 (22000.556) + Firefox running on AMD Ryzen 9 + MSI
-  X570 Chipset (BIOS version A.F3, released 2021-09-27) - When aaguid is meant
+* Windows 10 / Windows 11 + Firefox 98 - When aaguid is meant
   to be 16 bytes of 0, it emits a single 0 byte.
 
 Standards Compliance

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -3060,7 +3060,7 @@ mod tests {
 
     /// See https://github.com/kanidm/webauthn-rs/issues/105
     #[test]
-    fn test_windows_11_hello_incorrectly_truncates_aaguid() {
+    fn test_firefox_98_hello_incorrectly_truncates_aaguid() {
         let _ = tracing_subscriber::fmt::try_init();
         let wan = unsafe {
             Webauthn::new(

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -222,14 +222,16 @@ fn extensions_parser<T: Ceremony>(i: &[u8]) -> nom::IResult<&[u8], T::SignedExte
 }
 
 fn aaguid_parser(i: &[u8]) -> nom::IResult<&[u8], Aaguid> {
-    // We have observed with Windows Hello on Windows 11 aaguids of 0 being
+    // We have observed with Firefox 98 on Windows 10 and 11 aaguids of 0 being
     // serialized as 1 null-byte rather than 16 of them, as required by the spec
-    // (https://www.w3.org/TR/webauthn-3/#sctn-attested-credential-data).
+    // [1]. A fix for this bug has been released into Firefox 99 [2].
+    //
+    // [1]: https://www.w3.org/TR/webauthn-3/#sctn-attested-credential-data
+    // [2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1759098
     if let Some(0) = i.first() {
         warn!(
-            "Aaguids beginning with 0 are suspicious. This could be the Windows \
-             11 Windows Hello bug where a zero aaguid gets truncated down to 1 \
-             byte."
+            "Aaguids beginning with 0 are suspicious. This could be the Firefox \
+             98 Windows bug where a zero aaguid gets truncated down to 1 byte."
         );
     }
 


### PR DESCRIPTION
Given [this bug report][1], #105 appears to be a Firefox 98 bug, not a Windows
11 bug. To confirm, I tested that Firefox Nightly (version 100) on both Windows
10 and 11 does exhibit this bug, while Firefox 98 does exhibit this bug on
Windows 10 in addition to Windows 11.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1759098

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)