### PR TITLE
114 108 detect rs1 passkeys

### DIFF
--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -12,6 +12,11 @@ keywords = ["webauthn", "authentication"]
 categories = ["authentication", "web-programming"]
 license = "MPL-2.0"
 
+[features]
+insecure_rs1 = []
+
+default = ["insecure_rs1"]
+
 [dependencies]
 base64urlsafedata = { path = "../base64urlsafedata" }
 webauthn-rs-proto = { path = "../webauthn-rs-proto" }

--- a/webauthn-rs-core/src/error.rs
+++ b/webauthn-rs-core/src/error.rs
@@ -195,6 +195,12 @@ pub enum WebauthnError {
     #[error("The COSEKey contains invalid cryptographic algorithm request")]
     COSEKeyInvalidAlgorithm,
 
+    #[error("The credential may be a passkey and not truly bound to hardware.")]
+    CredentialMayNotBeHardwareBound,
+
+    #[error("The credential uses insecure cryptographic routines and is not trusted")]
+    CredentialInsecureCryptography,
+
     #[error("The credential exist check failed")]
     CredentialExistCheckError,
 

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -30,6 +30,7 @@ pub struct RegistrationState {
     pub(crate) require_resident_key: bool,
     pub(crate) authenticator_attachment: Option<AuthenticatorAttachment>,
     pub(crate) extensions: RequestRegistrationExtensions,
+    pub(crate) experimental_allow_passkeys: bool,
 }
 
 /// The in progress state of an authentication attempt. You must persist this associated to the UserID

--- a/webauthn-rs-demo-shared/src/lib.rs
+++ b/webauthn-rs-demo-shared/src/lib.rs
@@ -461,6 +461,8 @@ pub enum ResponseError {
     COSEKeyECDSAInvalidCurve,
     COSEKeyEDDSAInvalidCurve,
     COSEKeyInvalidAlgorithm,
+    CredentialMayNotBeHardwareBound,
+    CredentialInsecureCryptography,
     CredentialExistCheckError,
     CredentialAlreadyExists,
     CredentialPersistenceError,
@@ -558,6 +560,9 @@ impl From<WebauthnError> for ResponseError {
             WebauthnError::COSEKeyRSANEInvalid => Self::COSEKeyRSANEInvalid,
             WebauthnError::COSEKeyECDSAInvalidCurve => Self::COSEKeyECDSAInvalidCurve,
             WebauthnError::COSEKeyInvalidAlgorithm => Self::COSEKeyInvalidAlgorithm,
+
+            WebauthnError::CredentialMayNotBeHardwareBound => Self::CredentialMayNotBeHardwareBound,
+            WebauthnError::CredentialInsecureCryptography => Self::CredentialInsecureCryptography,
             WebauthnError::CredentialExistCheckError => Self::CredentialExistCheckError,
             WebauthnError::CredentialAlreadyExists => Self::CredentialAlreadyExists,
             WebauthnError::CredentialPersistenceError => Self::CredentialPersistenceError,

--- a/webauthn-rs-demo/src/actors.rs
+++ b/webauthn-rs-demo/src/actors.rs
@@ -218,6 +218,7 @@ impl WebauthnActor {
             algorithm.unwrap_or_else(|| vec![COSEAlgorithm::ES256, COSEAlgorithm::RS256]),
             false,
             attachment,
+            false,
         )?;
 
         debug!("complete ChallengeRegister -> {:?}", ccr);

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -261,6 +261,7 @@ impl Webauthn {
                 credential_algorithms,
                 require_resident_key,
                 authenticator_attachment,
+                true,
             )
             .map(|(ccr, rs)| {
                 (
@@ -465,6 +466,7 @@ impl Webauthn {
                 credential_algorithms,
                 require_resident_key,
                 authenticator_attachment,
+                true,
             )
             .map(|(ccr, rs)| {
                 (


### PR DESCRIPTION
Fixes #114  Fixes #108 - this adds a cfg feature allowing rs1 to be disabled. Additionally, an experimental internal only flag is added to reject credentials with a counter of 0 which likely indicates a passkey and a credential that is synced between multiple devices. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
