### PR TITLE
Add extra metadata to registered keys

### DIFF
--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -15,7 +15,7 @@ license = "MPL-2.0"
 [features]
 insecure_rs1 = []
 
-default = ["insecure_rs1"]
+default = []
 
 [dependencies]
 base64urlsafedata = { path = "../base64urlsafedata" }

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -3258,7 +3258,7 @@ mod tests {
             // }),
             true,
             &RequestRegistrationExtensions::default(),
-            true
+            true,
         );
         debug!("{:?}", result);
         let cred = result.unwrap();

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -217,7 +217,6 @@ pub struct RegisteredExtensions {
 }
 
 impl RegisteredExtensions {
-    #[cfg(test)]
     pub(crate) fn none() -> Self {
         RegisteredExtensions {
             cred_protect: ExtnState::NotRequested,
@@ -263,6 +262,55 @@ pub struct Credential {
     /// The attestation certificate of this credential.
     pub attestation: ParsedAttestationData,
     // pub attestation: SerialisableAttestationData,
+}
+
+impl From<CredentialV3> for Credential {
+    fn from(other: CredentialV3) -> Credential {
+        let CredentialV3 {
+            cred_id,
+            cred,
+            counter,
+            verified,
+            registration_policy,
+        } = other;
+
+        Credential {
+            cred_id: Base64UrlSafeData(cred_id),
+            cred,
+            counter,
+            user_verified: verified,
+            registration_policy,
+            extensions: RegisteredExtensions::none(),
+            attestation: ParsedAttestationData::None,
+        }
+    }
+}
+
+/// A legacy serialisation from version 3 of Webauthn RS. Only useful for migrations.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CredentialV3 {
+    /// The ID of this credential.
+    pub cred_id: Vec<u8>,
+    /// The public key of this credential
+    pub cred: COSEKey,
+    /// The counter for this credential
+    pub counter: u32,
+    /// During registration, if this credential was verified
+    /// then this is true. If not it is false. This is based on
+    /// the policy at the time of registration of the credential.
+    ///
+    /// This is a deviation from the Webauthn specification, because
+    /// it clarifies the user experience of the credentials to UV
+    /// being a per-credential attribute, rather than a per-authentication
+    /// ceremony attribute. For example it can be surprising to register
+    /// a credential as un-verified but then to use verification with it
+    /// in the future.
+    pub verified: bool,
+    /// During registration, the policy that was requested from this
+    /// credential. This is used to understand if the how the verified
+    /// component interacts with the device, IE an always verified authenticator
+    /// vs one that can dynamically request it.
+    pub registration_policy: UserVerificationPolicy,
 }
 
 /// Serialised Attestation Data which can be stored in a stable database or similar.
@@ -483,22 +531,75 @@ pub struct AuthenticationResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SerialisableAttestationCa {
     pub(crate) ca: Base64UrlSafeData,
+    pub(crate) platform_only: bool,
+    pub(crate) key_storage: KeyStorageClass,
+    pub(crate) strict: bool,
+}
+
+/// Type type of storage that this credential is *likely* backed by. This is derived from
+/// testing by the Webauthn-RS project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum KeyStorageClass {
+    /// This credential may exist between multiple devices. This is commonly called a passkey
+    /// and represents that the credential is not bound to any specific hardware and could be
+    /// recovered through some third party mechanism.
+    ///
+    /// This keystorage class has the most external risks of credential disclosure if the
+    /// related third party account is compromised.
+    MultiDevice,
+    /// This credential is bound to a single hardware cryptographic device and may not be used
+    /// without that specific hardware. However
+    ///
+    /// This keystorage class is secure in the majority of use cases. In some extremely rare
+    /// environments it may not be considered secure as an attacker who possesses the
+    /// CredentialID could perform and offline bruteforce attack, but this is highly infeasible
+    /// as these credentials generally use aes128 which would take potentialy thousands of years
+    /// to bruteforce.
+    SingleDeviceWrappedKey,
+    /// This credential is bound to a single hardware cryptographic device, and never leaves
+    /// that device. The CredentialID is just for lookup and association and has no relation to the
+    /// private key (unlike a wrapped key).
+    ///
+    /// This keystorage class is the highest level of security, asserting that a credential resides
+    /// only in a secure cryptographic processor.
+    ResidentKey,
 }
 
 /// A structure representing an Attestation CA and other options associated to this CA.
+///
+/// Generally depending on the Attestation CA in use, this can help determine properties
+/// of the authenticator that is in use.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(
     try_from = "SerialisableAttestationCa",
     into = "SerialisableAttestationCa"
 )]
 pub struct AttestationCa {
-    pub(crate) ca: x509::X509,
+    /// The x509 root CA of the attestation chain that a security key will be attested too.
+    pub ca: x509::X509,
+    /// If a credential signed by this attestation CA is provided, then this boolean determines
+    /// if it is platform only (IE part of the device, and can never leave it) or is roaming and
+    /// can be used between multiple devices through transports like USB, Bluetooth or NFC.
+    pub platform_only: bool,
+    /// If a credential signed by this attestation CA is provided, this shows the minimum level
+    /// of keystorage provided. Some devices can support multiple key storage classes (ie yubikey)
+    /// but due to limitations of the Webauthn standard there is no way to assert this during
+    /// registration leaving us to make the safe and conservative choice to pick the lowest
+    /// common method for that manufacturer.
+    pub key_storage: KeyStorageClass,
+    /// A flag determining if this credential meets the Webauthn-RS's projects high level of
+    /// quality. Considerations are not just the supply chain and cryptographic soundness, but
+    /// also the user experience, hardware quality, manufacturer response to issues, and more.
+    pub strict: bool,
 }
 
 impl Into<SerialisableAttestationCa> for AttestationCa {
     fn into(self) -> SerialisableAttestationCa {
         SerialisableAttestationCa {
             ca: Base64UrlSafeData(self.ca.to_der().expect("Invalid DER")),
+            platform_only: self.platform_only,
+            key_storage: self.key_storage,
+            strict: self.strict,
         }
     }
 }
@@ -509,6 +610,9 @@ impl TryFrom<SerialisableAttestationCa> for AttestationCa {
     fn try_from(data: SerialisableAttestationCa) -> Result<Self, Self::Error> {
         Ok(AttestationCa {
             ca: x509::X509::from_der(&data.ca.0).map_err(WebauthnError::OpenSSLError)?,
+            platform_only: data.platform_only,
+            key_storage: data.key_storage,
+            strict: data.strict,
         })
     }
 }
@@ -519,6 +623,9 @@ impl AttestationCa {
         // COSEAlgorithm::ES384,
         AttestationCa {
             ca: x509::X509::from_pem(APPLE_WEBAUTHN_ROOT_CA_PEM).unwrap(),
+            platform_only: true,
+            key_storage: KeyStorageClass::ResidentKey,
+            strict: true,
         }
     }
 
@@ -526,6 +633,9 @@ impl AttestationCa {
     pub fn yubico_u2f_root_ca_serial_457200631() -> Self {
         AttestationCa {
             ca: x509::X509::from_pem(YUBICO_U2F_ROOT_CA_SERIAL_457200631_PEM).unwrap(),
+            platform_only: false,
+            key_storage: KeyStorageClass::SingleDeviceWrappedKey,
+            strict: true,
         }
     }
 
@@ -539,6 +649,9 @@ impl AttestationCa {
     pub fn microsoft_tpm_root_certificate_authority_2014() -> Self {
         AttestationCa {
             ca: x509::X509::from_pem(MICROSOFT_TPM_ROOT_CERTIFICATE_AUTHORITY_2014_PEM).unwrap(),
+            platform_only: true,
+            key_storage: KeyStorageClass::SingleDeviceWrappedKey,
+            strict: false,
         }
     }
 
@@ -549,6 +662,9 @@ impl AttestationCa {
     pub fn nitrokey_fido2_root_ca() -> Self {
         AttestationCa {
             ca: x509::X509::from_pem(NITROKEY_FIDO2_ROOT_CA_PEM).unwrap(),
+            platform_only: false,
+            key_storage: KeyStorageClass::SingleDeviceWrappedKey,
+            strict: false,
         }
     }
 
@@ -559,6 +675,9 @@ impl AttestationCa {
     pub fn nitrokey_u2f_root_ca() -> Self {
         AttestationCa {
             ca: x509::X509::from_pem(NITROKEY_U2F_ROOT_CA_PEM).unwrap(),
+            platform_only: false,
+            key_storage: KeyStorageClass::SingleDeviceWrappedKey,
+            strict: false,
         }
     }
 }

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -548,7 +548,7 @@ pub enum KeyStorageClass {
     /// related third party account is compromised.
     MultiDevice,
     /// This credential is bound to a single hardware cryptographic device and may not be used
-    /// without that specific hardware. However
+    /// without that specific hardware.
     ///
     /// This keystorage class is secure in the majority of use cases. In some extremely rare
     /// environments it may not be considered secure as an attacker who possesses the
@@ -575,10 +575,10 @@ pub enum KeyStorageClass {
     into = "SerialisableAttestationCa"
 )]
 pub struct AttestationCa {
-    /// The x509 root CA of the attestation chain that a security key will be attested too.
+    /// The x509 root CA of the attestation chain that a security key will be attested to.
     pub ca: x509::X509,
     /// If a credential signed by this attestation CA is provided, then this boolean determines
-    /// if it is platform only (IE part of the device, and can never leave it) or is roaming and
+    /// if it is platform only (i.e. part of the device and can never leave it) or is roaming and
     /// can be used between multiple devices through transports like USB, Bluetooth or NFC.
     pub platform_only: bool,
     /// If a credential signed by this attestation CA is provided, this shows the minimum level
@@ -587,7 +587,7 @@ pub struct AttestationCa {
     /// registration leaving us to make the safe and conservative choice to pick the lowest
     /// common method for that manufacturer.
     pub key_storage: KeyStorageClass,
-    /// A flag determining if this credential meets the Webauthn-RS's projects high level of
+    /// A flag determining if this credential meets the Webauthn-RS project's high level of
     /// quality. Considerations are not just the supply chain and cryptographic soundness, but
     /// also the user experience, hardware quality, manufacturer response to issues, and more.
     pub strict: bool,

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -1082,6 +1082,7 @@ mod tests {
         RegisterPublicKeyCredential, Registration, RegistrationSignedExtensions, TpmsAttest,
         TpmtPublic, TpmtSignature, TPM_GENERATED_VALUE,
     };
+    use crate::interface::*;
     use serde_json;
     use std::convert::TryFrom;
 
@@ -1236,5 +1237,18 @@ mod tests {
         ];
 
         assert!(AuthenticatorData::<Authentication>::try_from(raw.as_slice()).is_ok());
+    }
+
+    #[test]
+    fn migrate_credentialv3() {
+        let legacy_cred = r#"{"cred_id":[185,151,21,12,21,82,235,193,63,50,208,32,121,10,68,148,156,101,116,95,250,113,143,108,74,246,214,171,31,234,70,31,48,138,238,54,151,36,65,70,104,121,200,87,131,254,191,100,215,125,29,49,177,71,4,114,61,69,49,96,116,148,8,205],"cred":{"type_":"ES256","key":{"EC_EC2":{"curve":"SECP256R1","x":[194,126,127,109,252,23,131,21,252,6,223,99,44,254,140,27,230,17,94,5,133,28,104,41,144,69,171,149,161,26,200,243],"y":[143,123,183,156,24,178,21,248,117,159,162,69,171,52,188,252,26,59,6,47,103,92,19,58,117,103,249,0,219,8,95,196]}}},"counter":2,"verified":false,"registration_policy":"preferred"}"#;
+
+        let cred: CredentialV3 = serde_json::from_str(&legacy_cred).unwrap();
+
+        println!("{:?}", cred);
+
+        let cred_migrated: Credential = cred.into();
+
+        println!("{:?}", cred_migrated);
     }
 }

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use webauthn_rs_core::interface::{AttestationCaList, AuthenticationState, RegistrationState};
-use webauthn_rs_core::proto::{Credential, CredentialID};
+use webauthn_rs_core::proto::{COSEAlgorithm, Credential, CredentialID, ParsedAttestationData};
 
 /// An in progress registration session for a [SecurityKey].
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,9 +30,30 @@ impl SecurityKey {
         &self.cred.cred_id
     }
 
+    /// Retrieve the type of cryptographic algorithm used by this key
+    pub fn cred_algorithm(&self) -> &COSEAlgorithm {
+        &self.cred.cred.type_
+    }
+
+    /// Retrieve a referenge to the attestation used during this Credentials
+    /// registration. This can tell you information about the manufacterer and
+    /// what type of credential it is.
+    pub fn attestation(&self) -> &ParsedAttestationData {
+        &self.cred.attestation
+    }
+
     /// Post authentication, update this credentials counter.
     pub fn update_credential_counter(&mut self, counter: u32) {
-        self.cred.counter = counter
+        if counter > self.cred.counter {
+            self.cred.counter = counter
+        }
+    }
+}
+
+impl From<Credential> for SecurityKey {
+    /// Convert a generic webauthn credential into a security key
+    fn from(cred: Credential) -> Self {
+        SecurityKey { cred }
     }
 }
 
@@ -63,8 +84,22 @@ impl PasswordlessKey {
         &self.cred.cred_id
     }
 
+    /// Retrieve the type of cryptographic algorithm used by this key
+    pub fn cred_algorithm(&self) -> &COSEAlgorithm {
+        &self.cred.cred.type_
+    }
+
+    /// Retrieve a referenge to the attestation used during this Credentials
+    /// registration. This can tell you information about the manufacterer and
+    /// what type of credential it is.
+    pub fn attestation(&self) -> &ParsedAttestationData {
+        &self.cred.attestation
+    }
+
     /// Post authentication, update this credentials counter.
     pub fn update_credential_counter(&mut self, counter: u32) {
-        self.cred.counter = counter
+        if counter > self.cred.counter {
+            self.cred.counter = counter
+        }
     }
 }

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -35,7 +35,7 @@ impl SecurityKey {
         &self.cred.cred.type_
     }
 
-    /// Retrieve a referenge to the attestation used during this Credentials
+    /// Retrieve a reference to the attestation used during this [`Credential`]'s
     /// registration. This can tell you information about the manufacterer and
     /// what type of credential it is.
     pub fn attestation(&self) -> &ParsedAttestationData {
@@ -89,7 +89,7 @@ impl PasswordlessKey {
         &self.cred.cred.type_
     }
 
-    /// Retrieve a referenge to the attestation used during this Credentials
+    /// Retrieve a reference to the attestation used during this [`Credential`]'s
     /// registration. This can tell you information about the manufacterer and
     /// what type of credential it is.
     pub fn attestation(&self) -> &ParsedAttestationData {

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -62,7 +62,7 @@ pub mod prelude {
     pub use url::Url;
     pub use webauthn_rs_core::error::{WebauthnError, WebauthnResult};
     pub use webauthn_rs_core::proto::{AttestationCa, AttestationCaList, AuthenticatorAttachment};
-    pub use webauthn_rs_core::proto::{RegisterPublicKeyCredential, PublicKeyCredential};
+    pub use webauthn_rs_core::proto::{PublicKeyCredential, RegisterPublicKeyCredential};
 }
 
 /// A constructor for a new [Webauthn] instance. This accepts and configures a number of site-wide
@@ -458,7 +458,7 @@ impl Webauthn {
         user_display_name: Option<&str>,
         exclude_credentials: Option<Vec<CredentialID>>,
         attestation_ca_list: Option<AttestationCaList>,
-        authenticator_attachment: Option<AuthenticatorAttachment>,
+        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>,
         // extensions
     ) -> WebauthnResult<(CreationChallengeResponse, PasswordlessKeyRegistration)> {
         let attestation = AttestationConveyancePreference::Direct;
@@ -471,6 +471,8 @@ impl Webauthn {
         // If rk - credProps
 
         // credProtect
+        let extensions = None;
+        /*
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: Some(CredProtect {
                 credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
@@ -481,6 +483,7 @@ impl Webauthn {
             uvm: Some(true),
             cred_props: Some(true),
         });
+        */
 
         // min pin
 
@@ -494,7 +497,7 @@ impl Webauthn {
                 extensions,
                 credential_algorithms,
                 require_resident_key,
-                authenticator_attachment,
+                ui_hint_authenticator_attachment,
                 false,
             )
             .map(|(ccr, rs)| {
@@ -580,14 +583,6 @@ impl Webauthn {
     }
 
     /*
-    // Register a password-less credential, needs attestation
-    /// * Must be verified
-    /// * Must be attested
-    /// * May request a pin length
-    /// * Must return what TYPE of UV (?)
-    /// * Any attachment type
-    /// * Optional - RK
-
     // Register a trusted device credential
     /// * Must be verified
     /// * Must be attested
@@ -597,8 +592,7 @@ impl Webauthn {
     /// * Must be platform attached
     /// * Need to use credProps
     /// * Optional - RK
-
-    */
+     */
 
     // Authenticate ^
 }


### PR DESCRIPTION
Add extra metadata to keys and improve key loading and conversion from older versions.

- [ ] cargo fmt has been run
- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
