### PR TITLE
Add support for authenticator backup states

### DIFF
--- a/webauthn-rs-core/src/error.rs
+++ b/webauthn-rs-core/src/error.rs
@@ -231,6 +231,9 @@ pub enum WebauthnError {
     #[error("The provided call back failed to allow reporting the credential failure")]
     CredentialCompromiseReportFailure,
 
+    #[error("The backup (passkey) elligibility of this device has changed, meaning it must be re-enrolled for security validation")]
+    CredentialBackupElligibilityInconsistent,
+
     #[error("The trust path could not be established")]
     TrustFailure,
 

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -212,6 +212,15 @@ pub struct Credential {
     /// a credential as un-verified but then to use verification with it
     /// in the future.
     pub user_verified: bool,
+    /// During registration, this credential indicated that it *may* be possible
+    /// for it to exist between multiple hardware authenticators, or be backed up.
+    ///
+    /// This means the private key is NOT sealed within a hardware cryptograhic
+    /// processor, and may have impacts on your risk assessments and modeling.
+    pub backup_elligible: bool,
+    /// This credential has indicated that it is currently backed up OR that it
+    /// is shared between mulitple devices.
+    pub backup_state: bool,
     /// During registration, the policy that was requested from this
     /// credential. This is used to understand if the how the verified
     /// component interacts with the device, IE an always verified authenticator
@@ -235,11 +244,14 @@ impl From<CredentialV3> for Credential {
             registration_policy,
         } = other;
 
+        // prior to 20220520 no multi-device credentials existed to migrate from.
         Credential {
             cred_id: Base64UrlSafeData(cred_id),
             cred,
             counter,
             user_verified: verified,
+            backup_elligible: false,
+            backup_state: false,
             registration_policy,
             extensions: RegisteredExtensions::none(),
             attestation: ParsedAttestationData::None,
@@ -485,6 +497,9 @@ pub struct AuthenticationResult {
     pub cred_id: CredentialID,
     /// If the authentication provided user_verification.
     pub user_verified: bool,
+    /// The current backup state of the authenticator. It may have
+    /// changed since registration.
+    pub backup_state: bool,
     /// The state of the counter
     pub counter: u32,
     /// The response from associated extensions.

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -278,6 +278,7 @@ impl Webauthn {
         let require_resident_key = false;
         let authenticator_attachment = None;
         let policy = Some(UserVerificationPolicy::Preferred);
+        let reject_passkeys = false;
 
         self.core
             .generate_challenge_register_options(
@@ -290,7 +291,7 @@ impl Webauthn {
                 credential_algorithms,
                 require_resident_key,
                 authenticator_attachment,
-                false,
+                reject_passkeys,
             )
             .map(|(ccr, rs)| {
                 (
@@ -465,6 +466,7 @@ impl Webauthn {
         let credential_algorithms = self.algorithms.clone();
         let require_resident_key = false;
         let policy = Some(UserVerificationPolicy::Required);
+        let reject_passkeys = true;
 
         // https://www.w3.org/TR/webauthn-2/#sctn-uvm-extension
         // UVM
@@ -498,7 +500,7 @@ impl Webauthn {
                 credential_algorithms,
                 require_resident_key,
                 ui_hint_authenticator_attachment,
-                false,
+                reject_passkeys,
             )
             .map(|(ccr, rs)| {
                 (


### PR DESCRIPTION
This adds support for the upcoming authenticator backup state flags, as well as modifies our policies to handle these and expose them in credentials. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
