### PR TITLE
20220613 ca management

### DIFF
--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -2,7 +2,6 @@
 #![warn(unused_extern_crates)]
 // #![warn(missing_docs)]
 
-
 #[macro_use]
 extern crate tracing;
 

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -19,6 +19,7 @@ use openssl::stack;
 use openssl::x509;
 use openssl::x509::store;
 use openssl::x509::verify;
+use openssl::hash::MessageDigest;
 use x509_parser::oid_registry::Oid;
 
 /// x509 certificate extensions are validated in the webauthn spec by checking
@@ -1232,11 +1233,11 @@ pub(crate) fn verify_android_safetynet_attestation(
 }
 
 /// Verify the attestation chain
-pub fn verify_attestation_ca_chain(
-    att_data: &ParsedAttestationData,
-    ca_list: &AttestationCaList,
+pub fn verify_attestation_ca_chain<'a>(
+    att_data: &'_ ParsedAttestationData,
+    ca_list: &'a AttestationCaList,
     danger_disable_certificate_time_checks: bool,
-) -> Result<(), WebauthnError> {
+) -> Result<Option<&'a AttestationCa>, WebauthnError> {
     // If the ca_list is empty, Immediately fail since no valid attestation can be created.
     if ca_list.cas.is_empty() {
         return Err(WebauthnError::AttestationCertificateTrustStoreEmpty);
@@ -1249,7 +1250,7 @@ pub fn verify_attestation_ca_chain(
         ParsedAttestationData::AnonCa(chain) => chain,
         ParsedAttestationData::Self_ | ParsedAttestationData::None => {
             // nothing to check
-            return Ok(());
+            return Ok(None);
         }
         ParsedAttestationData::ECDAA | ParsedAttestationData::Uncertain => {
             return Err(WebauthnError::AttestationNotVerifiable);
@@ -1295,29 +1296,61 @@ pub fn verify_attestation_ca_chain(
     let mut ca_ctx = x509::X509StoreContext::new().map_err(WebauthnError::OpenSSLError)?;
 
     // Providing the cert and chain, validate we have a ref to our store.
-    let res = ca_ctx
+    // Note this is a result<result ... because the inner .init must return an errorstack
+    // for openssl.
+    let res: Result<_, _> = ca_ctx
         .init(&ca_store, &leaf, &chain_stack, |ca_ctx_ref| {
             ca_ctx_ref.verify_cert().map(|_| {
                 // The value as passed in is a boolean that we ignore in favour of the richer error type.
-                debug!("{:?}", ca_ctx_ref.error());
-                debug!(
-                    "ca_ctx_ref verify cert - error depth={}, sn={:?}",
-                    ca_ctx_ref.error_depth(),
-                    ca_ctx_ref.current_cert().map(|crt| crt.subject_name())
-                );
-                ca_ctx_ref.error()
+                let res = ca_ctx_ref.error();
+                debug!("{:?}", res);
+                if res == x509::X509VerifyResult::OK {
+                    ca_ctx_ref.chain().and_then(|chain| {
+                        // If there is a chain here, we get the root.
+                        let idx = chain.len() - 1;
+                        chain.get(idx)
+                    })
+                    .and_then(|ca_cert| {
+                        // If we got it from the stack, we can now digest it.
+                        ca_cert.digest(MessageDigest::sha256()).ok()
+                        // We let the digest bubble out now, we've done too much here
+                        // already!
+                    })
+                    .ok_or(WebauthnError::AttestationTrustFailure)
+                } else {
+                    debug!(
+                        "ca_ctx_ref verify cert - error depth={}, sn={:?}",
+                        ca_ctx_ref.error_depth(),
+                        ca_ctx_ref.current_cert().map(|crt| crt.subject_name())
+                    );
+                    Err(WebauthnError::AttestationChainNotTrusted(res.to_string()))
+                }
             })
         })
         .map_err(|e| {
+            // If an openssl error occured, dump it here.
             error!(?e);
             e
         })?;
 
-    if res != x509::X509VerifyResult::OK {
-        return Err(WebauthnError::AttestationChainNotTrusted(res.to_string()));
-    }
-
-    debug!("Attestation Success");
-
-    Ok(())
+    // Now we have a result<DigestOfCaUsed, Error> and we want to attach our related
+    // attestation CA.
+    res.and_then(|dgst| {
+        ca_list.cas.iter()
+            .filter_map(|ca_crt| {
+                ca_crt.ca.digest(MessageDigest::sha256())
+                    .ok()
+                    .and_then(|ca_crt_dgst| {
+                        if ca_crt_dgst.as_ref() == dgst.as_ref() {
+                            Some(ca_crt)
+                        } else {
+                            None
+                        }
+                    })
+            })
+            .take(1)
+            .next()
+            .map(|ca_crt| Some(ca_crt))
+            .ok_or_else(|| WebauthnError::AttestationChainNotTrusted("Invalid CA digest maps".to_string()))
+    })
 }

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -1,7 +1,7 @@
 //! Extended Structs and representations for Webauthn Operations. These types are designed
 //! to allow persistance and should not change.
 
-use crate::attestation::{AttestationFormat, verify_attestation_ca_chain};
+use crate::attestation::{verify_attestation_ca_chain, AttestationFormat};
 use crate::constants::*;
 use crate::error::*;
 use std::fmt;
@@ -259,7 +259,7 @@ impl Credential {
         verify_attestation_ca_chain(
             &self.attestation.data,
             &ca_list,
-            danger_disable_certificate_time_checks
+            danger_disable_certificate_time_checks,
         )
     }
 }

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -1,7 +1,7 @@
 //! Extended Structs and representations for Webauthn Operations. These types are designed
 //! to allow persistance and should not change.
 
-use crate::attestation::AttestationFormat;
+use crate::attestation::{AttestationFormat, verify_attestation_ca_chain};
 use crate::constants::*;
 use crate::error::*;
 use std::fmt;
@@ -234,6 +234,34 @@ pub struct Credential {
     pub attestation: ParsedAttestation,
     /// the format of the attestation
     pub attestation_format: AttestationFormat,
+}
+
+impl Credential {
+    /// Re-verify this Credential's attestation chain. This re-applies the same process
+    /// for certificate authority verification that occured at registration. This can
+    /// be useful if you want to re-assert your credentials match an updated or changed
+    /// ca_list from the time that registration occured. This can also be useful to
+    /// re-determine certain properties of your device that may exist.
+    ///
+    /// # Safety
+    /// Due to the design of CA infrastructure by certain providers, it is NOT possible
+    /// to verify the CA expiry time. Certain vendors use CA intermediates that have
+    /// expiries that are only valid for approximately 10 minutes, meaning that if we
+    /// enforced time validity, these would false negative for their validity.
+    pub fn verify_attestation<'a>(
+        &'_ self,
+        ca_list: &'a AttestationCaList,
+    ) -> Result<Option<&'a AttestationCa>, WebauthnError> {
+        // Why do we disable this? Because of Apple. They issue dynamic short lived
+        // attestation certs, that last for about 5 minutes. This means that
+        // post-registration validation will always fail if we validate time.
+        let danger_disable_certificate_time_checks = true;
+        verify_attestation_ca_chain(
+            &self.attestation.data,
+            &ca_list,
+            danger_disable_certificate_time_checks
+        )
+    }
 }
 
 impl From<CredentialV3> for Credential {


### PR DESCRIPTION
This improves some backup state management flag handling. It also allows re-attestation of the credential post-registration. It also adds the ability to return which CA provided the attestation of the credential.

The question I have is *how* we should return that CA that did the attestation. Should we put the attestation CA into the Credential? Should we just return it as a tuple from `register_credential()`? Or should we do something else? 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
