### PR TITLE
Did some housecleaning for Clippy v2

### DIFF
--- a/compat_tester/webauthn-rs-demo/src/main.rs
+++ b/compat_tester/webauthn-rs-demo/src/main.rs
@@ -15,8 +15,8 @@ use webauthn_rs::prelude::Uuid;
 use webauthn_rs::prelude::{
     DeviceKey,
     DeviceKeyRegistration,
-    // PassKey,
-    // PassKeyRegistration,
+    // Passkey,
+    // PasskeyRegistration,
 };
 use webauthn_rs_core::proto::{Credential, PublicKeyCredential, RegisterPublicKeyCredential};
 use webauthn_rs_demo_shared::*;

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -155,6 +155,7 @@ impl WebauthnCore {
     /// It also returns a RegistrationState, that you *must*
     /// persist. It is strongly advised you associate this RegistrationState with the
     /// UserId of the requester.
+     #[allow(clippy::too_many_arguments)]
     pub fn generate_challenge_register_options(
         &self,
         user_unique_id: &[u8],
@@ -326,6 +327,7 @@ impl WebauthnCore {
         Ok(credential)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn register_credential_internal(
         &self,
         reg: &RegisterPublicKeyCredential,

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -212,7 +212,7 @@ impl WebauthnCore {
                     id: self.rp_id.clone(),
                 },
                 user: User {
-                    id: Base64UrlSafeData(user_id.clone()),
+                    id: Base64UrlSafeData(user_id),
                     name: user_name.to_string(),
                     display_name: user_display_name.to_string(),
                 },
@@ -254,7 +254,7 @@ impl WebauthnCore {
             // We can potentially enforce these!
             require_resident_key,
             authenticator_attachment,
-            extensions: extensions.unwrap_or_else(|| RequestRegistrationExtensions::default()),
+            extensions: extensions.unwrap_or_default(),
             experimental_allow_passkeys: !experimental_reject_passkeys,
         };
 
@@ -302,10 +302,10 @@ impl WebauthnCore {
             *policy,
             chal,
             exclude_credentials,
-            &credential_algorithms,
+            credential_algorithms,
             attestation_cas,
             false,
-            &extensions,
+            extensions,
             *experimental_allow_passkeys,
         )?;
 
@@ -567,7 +567,7 @@ impl WebauthnCore {
             // If given a set of ca's assert that our attestation actually matched one.
             let ca_crt = verify_attestation_ca_chain(
                 &credential.attestation.data,
-                &ca_list,
+                ca_list,
                 danger_disable_certificate_time_checks,
             )?;
 
@@ -2825,7 +2825,6 @@ mod tests {
                 .map(|cred| {
                     cred.user_verified = true;
                     cred.registration_policy = UserVerificationPolicy::Required;
-                    ()
                 })
                 .unwrap();
             creds
@@ -2833,7 +2832,6 @@ mod tests {
                 .map(|cred| {
                     cred.user_verified = true;
                     cred.registration_policy = UserVerificationPolicy::Required;
-                    ()
                 })
                 .unwrap();
         }
@@ -2851,7 +2849,6 @@ mod tests {
                 .map(|cred| {
                     cred.user_verified = true;
                     cred.registration_policy = UserVerificationPolicy::Discouraged_DO_NOT_USE;
-                    ()
                 })
                 .unwrap();
             creds
@@ -2859,7 +2856,6 @@ mod tests {
                 .map(|cred| {
                     cred.user_verified = false;
                     cred.registration_policy = UserVerificationPolicy::Discouraged_DO_NOT_USE;
-                    ()
                 })
                 .unwrap();
         }
@@ -2997,8 +2993,8 @@ mod tests {
         ]);
 
         let rsp_d = PublicKeyCredential {
-            id: id.clone(),
-            raw_id: raw_id.clone(),
+            id,
+            raw_id,
             response: AuthenticatorAssertionResponseRaw {
                 authenticator_data: Base64UrlSafeData(vec![
                     239, 115, 241, 111, 91, 226, 27, 23, 185, 145, 15, 75, 208, 190, 109, 73, 186,

--- a/webauthn-rs-core/src/crypto.rs
+++ b/webauthn-rs-core/src/crypto.rs
@@ -127,7 +127,7 @@ where
 {
     match extension {
         Ok(Some(extension)) => {
-            if f(&extension) {
+            if f(extension) {
                 Ok(())
             } else {
                 Err(WebauthnError::AttestationCertificateRequirementsNotMet)

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -456,7 +456,7 @@ pub enum ParsedAttestationData {
     /// be trustworthy in all cases. If in doubt, reject this type.
     Uncertain,
 }
-
+#[allow(clippy::from_over_into)]
 impl Into<SerialisableAttestationData> for ParsedAttestationData {
     fn into(self) -> SerialisableAttestationData {
         match self {
@@ -626,7 +626,7 @@ pub struct AttestationCa {
     /// The x509 root CA of the attestation chain that a security key will be attested to.
     pub ca: x509::X509,
 }
-
+#[allow(clippy::from_over_into)]
 impl Into<SerialisableAttestationCa> for AttestationCa {
     fn into(self) -> SerialisableAttestationCa {
         SerialisableAttestationCa {

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -271,7 +271,7 @@ impl Credential {
         let danger_disable_certificate_time_checks = true;
         verify_attestation_ca_chain(
             &self.attestation.data,
-            &ca_list,
+            ca_list,
             danger_disable_certificate_time_checks,
         )
     }

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -113,7 +113,7 @@ impl PartialEq<Credential> for Credential {
         self.cred_id == c.cred_id
     }
 }
-
+#[allow(clippy::too_many_arguments)]
 impl Credential {
     pub(crate) fn new(
         acd: &AttestedCredentialData,
@@ -306,7 +306,7 @@ fn acd_parser(i: &[u8]) -> nom::IResult<&[u8], AttestedCredentialData> {
         },
     ))
 }
-
+#[allow(clippy::type_complexity)]
 fn authenticator_data_flags(i: &[u8]) -> nom::IResult<&[u8], (bool, bool, bool, bool, bool, bool)> {
     // Using nom for bit fields is shit, do it by hand.
     let (i, ctrl) = nom::number::complete::u8(i)?;
@@ -1049,17 +1049,18 @@ fn tpmtsignature_parser(input: &[u8]) -> nom::IResult<&[u8], TpmtSignature> {
 /// From the [TPM Vendor ID Registry][1]
 /// [1]: https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-VendorIDRegistry-v1p06-r0p91-pub.pdf,
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum TpmVendor {
-    Amd,
+    AMD,
     Atmel,
     Broadcom,
     Cisco,
     FlySliceTechnologies,
     FuzhouRockchip,
     Google,
-    Hpe,
+    HPE,
     Huawei,
-    Ibm,
+    IBM,
     Infineon,
     Intel,
     Lenovo,
@@ -1070,7 +1071,7 @@ pub enum TpmVendor {
     Qualcomm,
     Samsung,
     Sinosun,
-    Smsc,
+    SMSC,
     StMicroelectronics,
     TexasInstruments,
     Winbond,
@@ -1085,16 +1086,16 @@ impl TryFrom<&[u8; 8]> for TpmVendor {
 
     fn try_from(v: &[u8; 8]) -> Result<Self, Self::Error> {
         match v {
-            b"414d4400" => Ok(Self::Amd),
+            b"414d4400" => Ok(Self::AMD),
             b"41544D4C" => Ok(Self::Atmel),
             b"4252434D" => Ok(Self::Broadcom),
             b"4353434F" => Ok(Self::Cisco),
             b"464C5953" => Ok(Self::FlySliceTechnologies),
             b"524F4343" => Ok(Self::FuzhouRockchip),
             b"474F4F47" => Ok(Self::Google),
-            b"48504500" => Ok(Self::Hpe),
+            b"48504500" => Ok(Self::HPE),
             b"48495349" => Ok(Self::Huawei),
-            b"49424D00" => Ok(Self::Ibm),
+            b"49424D00" => Ok(Self::IBM),
             b"49465800" => Ok(Self::Infineon),
             b"494E5443" => Ok(Self::Intel),
             b"4C454E00" => Ok(Self::Lenovo),
@@ -1105,7 +1106,7 @@ impl TryFrom<&[u8; 8]> for TpmVendor {
             b"51434F4D" => Ok(Self::Qualcomm),
             b"534D534E" => Ok(Self::Samsung),
             b"534E5300" => Ok(Self::Sinosun),
-            b"534D5343" => Ok(Self::Smsc),
+            b"534D5343" => Ok(Self::SMSC),
             b"53544D20" => Ok(Self::StMicroelectronics),
             b"54584E00" => Ok(Self::TexasInstruments),
             b"57454300" => Ok(Self::Winbond),

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -28,9 +28,9 @@ impl Challenge {
     }
 }
 
-impl Into<Base64UrlSafeData> for Challenge {
-    fn into(self) -> Base64UrlSafeData {
-        Base64UrlSafeData(self.0)
+impl From<Challenge> for Base64UrlSafeData {
+    fn from(chal: Challenge) -> Self {
+        Base64UrlSafeData(chal.0)
     }
 }
 
@@ -190,7 +190,7 @@ impl Credential {
             backup_state,
             registration_policy,
             extensions,
-            attestation: attestation.into(),
+            attestation,
             attestation_format,
         }
     }
@@ -336,7 +336,7 @@ fn authenticator_data_parser<T: Ceremony>(i: &[u8]) -> nom::IResult<&[u8], Authe
     let (i, acd) = cond(data_flags.1, acd_parser)(i)?;
     let (i, extensions) = cond(data_flags.0, extensions_parser::<T>)(i)?;
     trace!(?extensions);
-    let extensions = extensions.unwrap_or_else(|| T::SignedExtensions::default());
+    let extensions = extensions.unwrap_or_default();
 
     Ok((
         i,
@@ -438,7 +438,7 @@ impl TryFrom<u8> for CredProtectResponse {
 
 impl From<CredProtectResponse> for u8 {
     fn from(policy: CredProtectResponse) -> Self {
-        u8::from(policy.0 as u8)
+        policy.0 as u8
     }
 }
 
@@ -1050,16 +1050,16 @@ fn tpmtsignature_parser(input: &[u8]) -> nom::IResult<&[u8], TpmtSignature> {
 /// [1]: https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-VendorIDRegistry-v1p06-r0p91-pub.pdf,
 #[derive(Debug)]
 pub enum TpmVendor {
-    AMD,
+    Amd,
     Atmel,
     Broadcom,
     Cisco,
     FlySliceTechnologies,
     FuzhouRockchip,
     Google,
-    HPE,
+    Hpe,
     Huawei,
-    IBM,
+    Ibm,
     Infineon,
     Intel,
     Lenovo,
@@ -1070,7 +1070,7 @@ pub enum TpmVendor {
     Qualcomm,
     Samsung,
     Sinosun,
-    SMSC,
+    Smsc,
     StMicroelectronics,
     TexasInstruments,
     Winbond,
@@ -1085,16 +1085,16 @@ impl TryFrom<&[u8; 8]> for TpmVendor {
 
     fn try_from(v: &[u8; 8]) -> Result<Self, Self::Error> {
         match v {
-            b"414d4400" => Ok(Self::AMD),
+            b"414d4400" => Ok(Self::Amd),
             b"41544D4C" => Ok(Self::Atmel),
             b"4252434D" => Ok(Self::Broadcom),
             b"4353434F" => Ok(Self::Cisco),
             b"464C5953" => Ok(Self::FlySliceTechnologies),
             b"524F4343" => Ok(Self::FuzhouRockchip),
             b"474F4F47" => Ok(Self::Google),
-            b"48504500" => Ok(Self::HPE),
+            b"48504500" => Ok(Self::Hpe),
             b"48495349" => Ok(Self::Huawei),
-            b"49424D00" => Ok(Self::IBM),
+            b"49424D00" => Ok(Self::Ibm),
             b"49465800" => Ok(Self::Infineon),
             b"494E5443" => Ok(Self::Intel),
             b"4C454E00" => Ok(Self::Lenovo),
@@ -1105,7 +1105,7 @@ impl TryFrom<&[u8; 8]> for TpmVendor {
             b"51434F4D" => Ok(Self::Qualcomm),
             b"534D534E" => Ok(Self::Samsung),
             b"534E5300" => Ok(Self::Sinosun),
-            b"534D5343" => Ok(Self::SMSC),
+            b"534D5343" => Ok(Self::Smsc),
             b"53544D20" => Ok(Self::StMicroelectronics),
             b"54584E00" => Ok(Self::TexasInstruments),
             b"57454300" => Ok(Self::Winbond),
@@ -1143,7 +1143,6 @@ mod tests {
         TpmtPublic, TpmtSignature, TPM_GENERATED_VALUE,
     };
     use crate::interface::*;
-    use serde_json;
     use std::convert::TryFrom;
 
     #[test]
@@ -1303,7 +1302,7 @@ mod tests {
     fn migrate_credentialv3() {
         let legacy_cred = r#"{"cred_id":[185,151,21,12,21,82,235,193,63,50,208,32,121,10,68,148,156,101,116,95,250,113,143,108,74,246,214,171,31,234,70,31,48,138,238,54,151,36,65,70,104,121,200,87,131,254,191,100,215,125,29,49,177,71,4,114,61,69,49,96,116,148,8,205],"cred":{"type_":"ES256","key":{"EC_EC2":{"curve":"SECP256R1","x":[194,126,127,109,252,23,131,21,252,6,223,99,44,254,140,27,230,17,94,5,133,28,104,41,144,69,171,149,161,26,200,243],"y":[143,123,183,156,24,178,21,248,117,159,162,69,171,52,188,252,26,59,6,47,103,92,19,58,117,103,249,0,219,8,95,196]}}},"counter":2,"verified":false,"registration_policy":"preferred"}"#;
 
-        let cred: CredentialV3 = serde_json::from_str(&legacy_cred).unwrap();
+        let cred: CredentialV3 = serde_json::from_str(legacy_cred).unwrap();
 
         println!("{:?}", cred);
 

--- a/webauthn-rs-proto/src/attest.rs
+++ b/webauthn-rs-proto/src/attest.rs
@@ -52,15 +52,15 @@ pub struct CreationChallengeResponse {
 }
 
 #[cfg(feature = "wasm")]
-impl Into<web_sys::CredentialCreationOptions> for CreationChallengeResponse {
-    fn into(self) -> web_sys::CredentialCreationOptions {
+impl From<CreationChallengeResponse> for web_sys::CredentialCreationOptions {
+    fn from(ccr: CreationChallengeResponse) -> Self {
         use js_sys::Uint8Array;
         use wasm_bindgen::JsValue;
 
-        let chal = Uint8Array::from(self.public_key.challenge.0.as_slice());
-        let userid = Uint8Array::from(self.public_key.user.id.0.as_slice());
+        let chal = Uint8Array::from(ccr.public_key.challenge.0.as_slice());
+        let userid = Uint8Array::from(ccr.public_key.user.id.0.as_slice());
 
-        let jsv = JsValue::from_serde(&self).unwrap();
+        let jsv = JsValue::from_serde(&ccr).unwrap();
 
         let pkcco = js_sys::Reflect::get(&jsv, &"publicKey".into()).unwrap();
         js_sys::Reflect::set(&pkcco, &"challenge".into(), &chal).unwrap();
@@ -68,7 +68,7 @@ impl Into<web_sys::CredentialCreationOptions> for CreationChallengeResponse {
         let user = js_sys::Reflect::get(&pkcco, &"user".into()).unwrap();
         js_sys::Reflect::set(&user, &"id".into(), &userid).unwrap();
 
-        if let Some(extensions) = self.public_key.extensions {
+        if let Some(extensions) = ccr.public_key.extensions {
             if let Some(cred_blob) = extensions.cred_blob {
                 let exts = js_sys::Reflect::get(&pkcco, &"extensions".into()).unwrap();
                 let cred_blob = Uint8Array::from(cred_blob.0.as_ref());

--- a/webauthn-rs-proto/src/auth.rs
+++ b/webauthn-rs-proto/src/auth.rs
@@ -73,13 +73,13 @@ pub struct RequestChallengeResponse {
 }
 
 #[cfg(feature = "wasm")]
-impl Into<web_sys::CredentialRequestOptions> for RequestChallengeResponse {
-    fn into(self) -> web_sys::CredentialRequestOptions {
+impl From<RequestChallengeResponse> for web_sys::CredentialRequestOptions {
+    fn from(rcr: RequestChallengeResponse) -> Self {
         use js_sys::{Array, Object, Uint8Array};
         use wasm_bindgen::JsValue;
 
-        let chal = Uint8Array::from(self.public_key.challenge.0.as_slice());
-        let allow_creds: Array = self
+        let chal = Uint8Array::from(rcr.public_key.challenge.0.as_slice());
+        let allow_creds: Array = rcr
             .public_key
             .allow_credentials
             .iter()
@@ -104,7 +104,7 @@ impl Into<web_sys::CredentialRequestOptions> for RequestChallengeResponse {
             })
             .collect();
 
-        let jsv = JsValue::from_serde(&self).unwrap();
+        let jsv = JsValue::from_serde(&rcr).unwrap();
 
         let pkcco = js_sys::Reflect::get(&jsv, &"publicKey".into()).unwrap();
         js_sys::Reflect::set(&pkcco, &"challenge".into(), &chal).unwrap();
@@ -212,7 +212,7 @@ impl From<web_sys::PublicKeyCredential> for PublicKeyCredential {
             Base64UrlSafeData(data_response_authenticator_data);
         let data_response_signature_b64 = Base64UrlSafeData(data_response_signature);
 
-        let data_response_user_handle_b64 = data_response_user_handle.map(|d| Base64UrlSafeData(d));
+        let data_response_user_handle_b64 = data_response_user_handle.map(Base64UrlSafeData);
 
         PublicKeyCredential {
             id: format!("{}", data_raw_id_b64),

--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -133,7 +133,8 @@ pub struct RequestAuthenticationExtensions {
 }
 
 /// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientoutputs>
-#[derive(Debug, Deserialize, Serialize, Clone)]
+/// The default option here for Options are None, so it can be derived
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct AuthenticationExtensionsClientOutputs {
     /// Indicates whether the client used the provided appid extension
     #[serde(default)]
@@ -141,15 +142,6 @@ pub struct AuthenticationExtensionsClientOutputs {
 
     /// Indicates if the client used the provided cred_blob extensions.
     pub cred_blob: Option<bool>,
-}
-
-impl Default for AuthenticationExtensionsClientOutputs {
-    fn default() -> Self {
-        AuthenticationExtensionsClientOutputs {
-            appid: None,
-            cred_blob: None,
-        }
-    }
 }
 
 #[cfg(feature = "wasm")]
@@ -178,7 +170,8 @@ pub struct CredProps {
 }
 
 /// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientoutputs>
-#[derive(Debug, Deserialize, Serialize, Clone)]
+/// The default option here for Options are None, so it can be derived
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct RegistrationExtensionsClientOutputs {
     /// Indicates whether the client used the provided appid extension
     #[serde(default)]
@@ -192,16 +185,6 @@ pub struct RegistrationExtensionsClientOutputs {
     /// property is managed by the webbrowser, and is NOT SIGNED and CAN NOT be trusted!
     #[serde(default)]
     pub cred_props: Option<CredProps>,
-}
-
-impl Default for RegistrationExtensionsClientOutputs {
-    fn default() -> Self {
-        RegistrationExtensionsClientOutputs {
-            appid: None,
-            cred_blob: None,
-            cred_props: None,
-        }
-    }
 }
 
 #[cfg(feature = "wasm")]

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -147,12 +147,6 @@ impl SecurityKey {
     }
 }
 
-impl PartialEq for SecurityKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.cred.cred_id == other.cred.cred_id
-    }
-}
-
 impl From<Credential> for SecurityKey {
     /// Convert a generic webauthn credential into a security key
     fn from(cred: Credential) -> Self {

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -147,6 +147,12 @@ impl SecurityKey {
     }
 }
 
+impl PartialEq for SecurityKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cred.cred_id == other.cred.cred_id
+    }
+}
+
 impl From<Credential> for SecurityKey {
     /// Convert a generic webauthn credential into a security key
     fn from(cred: Credential) -> Self {


### PR DESCRIPTION
Dug around in the code a bit and eliminated most of the clippy errors I could find. Mostly that consisted of removing redundant .clone()s, references that are destructured, and converting some of the intos into From. There are still some left, but 3 of them require rewriting some functions with tons of inputs, 1 of them is an ugly bit based nom function, and 2 of them refer to Intos that I didn't convert because serde is deriving stuff from them.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
