### PR TITLE
Conformance tests for ISO7816

### DIFF
--- a/webauthn-authenticator-rs/examples/conformance/core.rs
+++ b/webauthn-authenticator-rs/examples/conformance/core.rs
@@ -1,0 +1,222 @@
+use webauthn_authenticator_rs::nfc::*;
+
+#[derive(Debug)]
+enum TestResult {
+    Skipped(&'static str),
+    Pass,
+    Fail(&'static str),
+}
+
+type Test = fn(&NFCCard) -> TestResult;
+
+/// For cards which declare support for extended Lc/Le, check that they actually
+/// support it.
+fn test_extended_lc(card: &NFCCard) -> TestResult {
+    if card.atr.extended_lc != Some(true) {
+        return TestResult::Skipped("Card does not support extended Lc/Le");
+    }
+
+    // Test with Le = 256 in extended mode
+    let resp = card
+        .transmit(
+            &select_by_df_name(&APPLET_DF),
+            ISO7816LengthForm::ExtendedOnly,
+        )
+        .expect("Failed to select applet");
+
+    // Check error codes
+    if resp.is_ok() {
+        TestResult::Pass
+    } else {
+        TestResult::Fail("Card reports supporting extended Lc/Le, but doesn't")
+    }
+}
+
+/// Checks whether the card is checking the provided AID length when testing
+/// against its own applet, by selecting applets with extra bytes after the real
+/// AID.
+///
+/// Yubikey 5 NFC fails this test.
+fn test_incorrect_aid(card: &NFCCard) -> TestResult {
+    // Prepare a buffer with extra junk
+    let mut aid = [0xFF; 16];
+    aid[..APPLET_DF.len()].copy_from_slice(&APPLET_DF);
+
+    for l in APPLET_DF.len() + 1..aid.len() {
+        let resp = card
+            .transmit(&select_by_df_name(&aid[..l]), ISO7816LengthForm::ShortOnly)
+            .expect("Failed to select applet");
+
+        if resp.is_ok() {
+            return TestResult::Fail("Selecting applet DF with extra bytes unexpectedly succeeded");
+        }
+    }
+
+    TestResult::Pass
+}
+
+fn test_select_zero_ne(card: &NFCCard) -> TestResult {
+    let mut req = select_by_df_name(&APPLET_DF);
+    req.ne = 0;
+    let resp = card
+        .transmit(&req, ISO7816LengthForm::ShortOnly)
+        .expect("Failed to select applet");
+
+    if !resp.is_success() {
+        return TestResult::Fail("Selecting CTAP applet should always give success");
+    }
+
+    if resp.ctap_needs_get_response() {
+        return TestResult::Fail(
+            "Card responded to interindustry SELECT command with NFCCTAP_GETRESPONSE expectation",
+        );
+    }
+
+    if resp.data.len() > 0 {
+        // We got some data back.
+        // This suggests the card is reading the command buffer out of bounds.
+        return TestResult::Fail("Expected no response data for Ne=0, card is reading from the command buffer out of bounds!");
+    }
+
+    if resp.bytes_available() == 0 {
+        return TestResult::Fail("Card didn't report a corrected response length");
+    }
+
+    // Repeat with correct length
+    req.ne = resp.bytes_available();
+    let resp = card
+        .transmit(&req, ISO7816LengthForm::ShortOnly)
+        .expect("Failed to select applet");
+
+    if !resp.is_ok() {
+        // Correct Ne should have worked?
+        return TestResult::Fail("Selecting with correct Ne should succeed");
+    }
+
+    if req.ne as usize != resp.data.len() {
+        // Incorrect extra bytes
+        TestResult::Fail("Corrected response length wasn't correct")
+    } else {
+        TestResult::Pass
+    }
+}
+
+fn test_select_truncation(card: &NFCCard) -> TestResult {
+    let mut req = select_by_df_name(&APPLET_DF);
+    let mut true_len: usize = 0;
+
+    for ne in 1..256 {
+        req.ne = ne;
+        let resp = card
+            .transmit(&req, ISO7816LengthForm::ShortOnly)
+            .expect("Failed to select applet");
+
+        if !resp.is_success() {
+            // We should always get a success response...
+            return TestResult::Fail("Selecting applet with short Ne should succeed");
+        }
+
+        if resp.data.len() > ne.into() {
+            // Limit
+            return TestResult::Fail("Card responded with too many bytes for Ne");
+        }
+
+        if resp.bytes_available() > 0 {
+            if true_len == 0 {
+                true_len = ne + resp.bytes_available();
+            } else if true_len != ne + resp.bytes_available() {
+                // changed mind
+                return TestResult::Fail("Card changed Ne between commands");
+            }
+        } else {
+            // We reached the end
+            break;
+        }
+    }
+
+    TestResult::Pass
+}
+
+fn test_card(card: NFCCard) {
+    info!("Card detected ...");
+    // Check that we're not a storage card
+    if card.atr.storage_card {
+        panic!("Detected storage card - only FIDO2 tokens are supported");
+    }
+
+    // Try to select the applet in short form.
+    let resp = card
+        .transmit(&select_by_df_name(&APPLET_DF), ISO7816LengthForm::ShortOnly)
+        .expect("Failed to select applet");
+    if !resp.is_ok() {
+        panic!("Could not select FIDO2 applet, is this a FIDO2 token?");
+    }
+
+    const TESTS: [(&str, Test); 4] = [
+        ("Select applet with extended Lc/Le", test_extended_lc),
+        ("Select incorrect applet AID", test_incorrect_aid),
+        ("Select with zero Ne", test_select_zero_ne),
+        ("Select with truncated Ne", test_select_truncation),
+    ];
+
+    let mut passes: Vec<&str> = Vec::with_capacity(TESTS.len());
+    let mut skips: Vec<(&str, &str)> = Vec::with_capacity(TESTS.len());
+    let mut failures: Vec<(&str, &str)> = Vec::with_capacity(TESTS.len());
+
+    for (name, testfn) in &TESTS {
+        println!("Started test: {}", name);
+        let res = testfn(&card);
+        println!("Finished test: {}, Result: {:?}", name, res);
+
+        match res {
+            TestResult::Pass => passes.push(name),
+            TestResult::Skipped(m) => skips.push((name, m)),
+            TestResult::Fail(m) => failures.push((name, m)),
+        }
+    }
+
+    println!("# Conformance tests finished!");
+    println!("");
+    println!("{:?}", card.atr);
+    match card.atr.card_issuers_data_str() {
+        Some(s) => println!("Card issuer's data: {}", s),
+        None => match card.atr.card_issuers_data {
+            Some(d) => println!("Card issuer's data: {:02x?}", d),
+            None => (),
+        },
+    }
+    println!("");
+    println!("## {}/{} tests passed:", passes.len(), TESTS.len());
+    println!("");
+    for n in passes {
+        println!("* {}", n);
+    }
+    println!("");
+    if skips.len() > 0 {
+        println!("## {}/{} tests skipped:", skips.len(), TESTS.len());
+        println!("");
+        for (n, m) in skips {
+            println!("* {} ({})", n, m);
+        }
+        println!("");
+    }
+    if failures.len() == 0 {
+        println!("## No tests failed!");
+    } else {
+        println!("## {}/{} tests failed:", failures.len(), TESTS.len());
+        println!("");
+        for (n, m) in failures {
+            println!("* {} ({})", n, m);
+        }
+    }
+    println!("");
+    println!("Tip: run with `RUST_LOG=trace` to see raw APDUs");
+}
+
+pub(crate) fn main() {
+    let mut reader = NFCReader::default();
+    info!("Using reader: {:?}", reader);
+
+    let card = reader.wait_for_card().expect("Error getting card");
+    test_card(card);
+}

--- a/webauthn-authenticator-rs/examples/conformance/main.rs
+++ b/webauthn-authenticator-rs/examples/conformance/main.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate tracing;
+
+#[cfg(feature = "nfc")]
+mod core;
+
+#[cfg(feature = "nfc")]
+fn main() {
+    tracing_subscriber::fmt::init();
+    core::main();
+}
+
+#[cfg(not(feature = "nfc"))]
+fn main() {
+    tracing_subscriber::fmt::init();
+    error!("This example requires the feature \"nfc\" to be enabled.");
+}


### PR DESCRIPTION
Built on top of #172 

This adds an example, `conformance`, which checks for protocol conformance violations. At the moment, it is limited to ISO7816 related issues, but could be trivially extended to capture other sorts of issues.

Example run of `cargo run --example conformance --features nfc` with a Yubico Security Key NFC C:

```
# Conformance tests finished!

Atr { protocols: [0, 1], t1: [128, 115, 192, 33, 192, 87, 89, 117, 98, 105, 75, 101, 121], storage_card: false, card_issuers_data: Some([89, 117, 98, 105, 75, 101, 121]), command_chaining: Some(true), extended_lc: Some(true) }
Card issuer's data: YubiKey

## 2/4 tests passed:

* Select incorrect applet AID
* Select with truncated Ne

## 2/4 tests failed:

* Select applet with extended Lc/Le (Card reports supporting extended Lc/Le, but doesn't)
* Select with zero Ne (Expected no response data for Ne=0, card is reading from the command buffer out of bounds!)

Tip: run with `RUST_LOG=trace` to see raw APDUs
```

And with a Yubikey 5 NFC:

```
# Conformance tests finished!

Atr { protocols: [0, 1], t1: [128, 115, 192, 33, 192, 87, 89, 117, 98, 105, 75, 101, 255], storage_card: false, card_issuers_data: Some([89, 117, 98, 105, 75, 101, 255]), command_chaining: Some(true), extended_lc: Some(true) }
Card issuer's data: [59, 75, 62, 69, 4b, 65, ff]

## 1/4 tests passed:

* Select with truncated Ne

## 3/4 tests failed:

* Select applet with extended Lc/Le (Card reports supporting extended Lc/Le, but doesn't)
* Select incorrect applet AID (Selecting applet DF with extra bytes unexpectedly succeeded)
* Select with zero Ne (Expected no response data for Ne=0, card is reading from the command buffer out of bounds!)

Tip: run with `RUST_LOG=trace` to see raw APDUs
```


- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
