### PR TITLE
20220816 updates for tpm fido

### DIFF
--- a/compat_tester/webauthn-rs-demo/Cargo.toml
+++ b/compat_tester/webauthn-rs-demo/Cargo.toml
@@ -13,7 +13,7 @@ license = "MPL-2.0"
 [dependencies]
 webauthn-rs-demo-shared = { path = "../webauthn-rs-demo-shared", features = ["core"] }
 webauthn-rs-core = { path = "../../webauthn-rs-core" }
-webauthn-rs = { path = "../../webauthn-rs", features = ["resident-key-support"] }
+webauthn-rs = { path = "../../webauthn-rs", features = ["resident-key-support", "preview-features"] }
 tide = "0.16"
 tide-rustls = "0.3"
 async-std = { version = "1.6", features = ["attributes"] }

--- a/fido-mds-tool/src/main.rs
+++ b/fido-mds-tool/src/main.rs
@@ -177,7 +177,7 @@ fn main() {
                             }
 
                             if let Some(authenticator_info) = &fd.authenticator_get_info {
-                                println!("  {:?}", authenticator_info);
+                                println!("authenticator_get_info: {:?}", authenticator_info);
                             } else {
                                 println!("authenticator_get_info: not present")
                             }

--- a/fido-mds/src/lib.rs
+++ b/fido-mds/src/lib.rs
@@ -996,6 +996,13 @@ impl TryFrom<RawFidoDevice> for FidoDevice {
             }
         });
 
+        if !supported_extensions.is_empty() && authenticator_get_info.is_some() {
+            warn!(
+                "Inconsistent supported extension descriptors in - {:?}, {:?}, {:?}",
+                aaid, aaguid, attestation_certificate_key_identifiers
+            );
+        }
+
         if invalid_metadata {
             return Err(());
         }

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -250,7 +250,7 @@ pub enum AssertionScheme {
 }
 
 /// The family of protocols this device belongs to.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub enum ProtocolFamily {
     /// No protocol family was provided

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -875,6 +875,7 @@ pub(crate) fn verify_tpm_attestation(
         ParsedAttestationData::AttCa(arr_x509),
         AttestationMetadata::Tpm {
             aaguid: Uuid::from_bytes(acd.aaguid),
+            firmware_version: certinfo.firmware_version,
         },
     ))
 }

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -3688,11 +3688,12 @@ mod tests {
             &RequestRegistrationExtensions::default(),
             true,
         );
-        dbg!(&result);
+
         if cfg!(feature = "insecure-rs1") {
             assert!(result.is_ok());
             match result.unwrap().attestation.metadata {
-                AttestationMetadata::Tpm { aaguid } => {
+                AttestationMetadata::Tpm { aaguid, firmware_version } => {
+                    assert!(firmware_version == 1390997124431944132);
                     assert!(
                         aaguid
                             == uuid::Uuid::parse_str("08987058cadc4b81b6e130de50dcbe96").unwrap()

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -3692,7 +3692,10 @@ mod tests {
         if cfg!(feature = "insecure-rs1") {
             assert!(result.is_ok());
             match result.unwrap().attestation.metadata {
-                AttestationMetadata::Tpm { aaguid, firmware_version } => {
+                AttestationMetadata::Tpm {
+                    aaguid,
+                    firmware_version,
+                } => {
                     assert!(firmware_version == 1390997124431944132);
                     assert!(
                         aaguid

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -410,6 +410,10 @@ pub enum AttestationMetadata {
         /// This is the unique id of the class/type of device. Often this id can imply the
         /// properties of the device.
         aaguid: Uuid,
+        /// The firmware version of the device at registration. It can NOT be determined
+        /// if this updates later, which may require you to re-register the device if
+        /// you need to enforce a version update.
+        firmware_version: u64,
     },
     /// various attestation flags set by the device (attested by OS)
     AndroidKey {

--- a/webauthn-rs/Cargo.toml
+++ b/webauthn-rs/Cargo.toml
@@ -12,6 +12,7 @@ license = "MPL-2.0"
 
 [features]
 resident-key-support = []
+preview-features = []
 danger-insecure-rs1 = ["webauthn-rs-core/insecure-rs1"]
 danger-credential-internals = []
 danger-user-presence-only-security-keys = []


### PR DESCRIPTION
Add support to store the TPM version in it's attestation metadata. this can be used in conjuction with the MDS to determine if the device is on an FW version that is trustworthy

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
