### PR TITLE
Adding Eq and PartialEq so I can use biscuit claims for the json

### DIFF
--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -27,7 +27,7 @@ pub type Counter = u32;
 /// The in progress state of a credential registration attempt. You must persist this in a server
 /// side location associated to the active session requesting the registration. This contains the
 /// user unique id which you can use to reference the user requesting the registration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RegistrationState {
     pub(crate) policy: UserVerificationPolicy,
     pub(crate) exclude_credentials: Vec<CredentialID>,
@@ -41,7 +41,7 @@ pub struct RegistrationState {
 
 /// The in progress state of an authentication attempt. You must persist this associated to the UserID
 /// requesting the registration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AuthenticationState {
     pub(crate) credentials: Vec<Credential>,
     pub(crate) policy: UserVerificationPolicy,

--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -65,7 +65,7 @@ impl From<Vec<u8>> for CredBlobSet {
 /// Extension option inputs for PublicKeyCredentialCreationOptions.
 ///
 /// Implements \[AuthenticatorExtensionsClientInputs\] from the spec.
-#[derive(Debug, Serialize, Clone, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestRegistrationExtensions {
     /// The `credProtect` extension options

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -33,7 +33,7 @@ pub type CredentialID = Base64UrlSafeData;
 /// that is is NOT possible assert verification has been bypassed or not from the server
 /// viewpoint, and to the user it may create confusion about when verification is or is
 /// not required.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Serialize, Deserialize, PartialEq)]
 #[allow(non_camel_case_types)]
 #[serde(rename_all = "lowercase")]
 pub enum UserVerificationPolicy {
@@ -141,7 +141,7 @@ pub struct PublicKeyCredentialDescriptor {
 /// to help a user select a relevant authenticator type.
 ///
 /// <https://www.w3.org/TR/webauthn/#attachment>
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, Serialize, Deserialize, PartialEq)]
 pub enum AuthenticatorAttachment {
     /// Request a device that is part of the machine aka inseperable.
     /// <https://www.w3.org/TR/webauthn/#attachment>

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -8,13 +8,13 @@ use webauthn_rs_core::interface::{
 use webauthn_rs_core::proto::{COSEAlgorithm, Credential, CredentialID, ParsedAttestation};
 
 /// An in progress registration session for a [Passkey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PasskeyRegistration {
     pub(crate) rs: RegistrationState,
 }
 
 /// An in progress authentication session for a [Passkey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PasskeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }


### PR DESCRIPTION
Added Eq and PartialEq to types to allow use of PasskeyAuthentication and PasskeyRegistration in biscuit JWE claims. 

For reference: https://docs.rs/biscuit/latest/biscuit/struct.ClaimsSet.html

- [X] cargo fmt has been run
- [X] cargo test has been run and passes
- [N/A] documentation has been updated with relevant examples (if relevant)
