### PR TITLE
Reduce ability for people to accidentally allow replay attacks

### DIFF
--- a/compat_tester/webauthn-rs-demo/Cargo.toml
+++ b/compat_tester/webauthn-rs-demo/Cargo.toml
@@ -13,7 +13,7 @@ license = "MPL-2.0"
 [dependencies]
 webauthn-rs-demo-shared = { path = "../webauthn-rs-demo-shared", features = ["core"] }
 webauthn-rs-core = { path = "../../webauthn-rs-core" }
-webauthn-rs = { path = "../../webauthn-rs", features = ["resident-key-support", "preview-features"] }
+webauthn-rs = { path = "../../webauthn-rs", features = ["resident-key-support", "preview-features", "danger-allow-state-serialisation"] }
 tide = "0.16"
 tide-rustls = "0.3"
 async-std = { version = "1.6", features = ["attributes"] }

--- a/tutorial/server/axum/Cargo.toml
+++ b/tutorial/server/axum/Cargo.toml
@@ -12,7 +12,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 serde = { version = "1", features = ["derive"] }
 rand = {version="0.8", features=["min_const_gen"]}
-webauthn-rs = { path = "../../../webauthn-rs" }
+webauthn-rs = { path = "../../../webauthn-rs", features = ["danger-allow-state-serialisation"] }
 axum = {version = "0.5.11", features = ["http2"]}
 tokio = {version="1.19.2", features = ["full"]}
 uuid = {version="1.1.2", features=["v4"]}

--- a/tutorial/server/axum/src/auth.rs
+++ b/tutorial/server/axum/src/auth.rs
@@ -95,6 +95,9 @@ pub async fn start_register(
         exclude_credentials,
     ) {
         Ok((ccr, reg_state)) => {
+            // Note that due to the session store in use being a server side memory store, this is
+            // safe to store the reg_state into the session since it is not client controlled and
+            // not open to replay attacks. If this was a cookie store, this would be UNSAFE.
             session
                 .insert("reg_state", (username, user_unique_id, reg_state))
                 .expect("Failed to insert");
@@ -215,6 +218,9 @@ pub async fn start_authentication(
             // Drop the mutex to allow the mut borrows below to proceed
             drop(users_guard);
 
+            // Note that due to the session store in use being a server side memory store, this is
+            // safe to store the auth_state into the session since it is not client controlled and
+            // not open to replay attacks. If this was a cookie store, this would be UNSAFE.
             session
                 .insert("auth_state", (user_unique_id, auth_state))
                 .expect("Failed to insert");

--- a/tutorial/server/tide/Cargo.toml
+++ b/tutorial/server/tide/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webauthn-rs = { path = "../../../webauthn-rs" }
+webauthn-rs = { path = "../../../webauthn-rs", features = ["danger-allow-state-serialisation"] }
 tide = "0.16"
 async-std = { version = "1.6", features = ["attributes"] }
 tracing = "0.1"

--- a/tutorial/server/tide/src/main.rs
+++ b/tutorial/server/tide/src/main.rs
@@ -141,6 +141,9 @@ async fn start_register(mut request: tide::Request<AppState>) -> tide::Result {
         exclude_credentials,
     ) {
         Ok((ccr, reg_state)) => {
+            // Note that due to the session store in use being a server side memory store, this is
+            // safe to store the reg_state into the session since it is not client controlled and
+            // not open to replay attacks. If this was a cookie store, this would be UNSAFE.
             request
                 .session_mut()
                 .insert("reg_state", (username, user_unique_id, reg_state))
@@ -262,6 +265,9 @@ async fn start_authentication(mut request: tide::Request<AppState>) -> tide::Res
             // Drop the mutex to allow the mut borrows below to proceed
             drop(users_guard);
 
+            // Note that due to the session store in use being a server side memory store, this is
+            // safe to store the auth_state into the session since it is not client controlled and
+            // not open to replay attacks. If this was a cookie store, this would be UNSAFE.
             request
                 .session_mut()
                 .insert("auth_state", (user_unique_id, auth_state))

--- a/webauthn-rs/Cargo.toml
+++ b/webauthn-rs/Cargo.toml
@@ -14,6 +14,7 @@ license = "MPL-2.0"
 resident-key-support = []
 preview-features = []
 danger-insecure-rs1 = ["webauthn-rs-core/insecure-rs1"]
+danger-allow-state-serialisation = []
 danger-credential-internals = []
 danger-user-presence-only-security-keys = []
 

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -8,13 +8,31 @@ use webauthn_rs_core::interface::{
 use webauthn_rs_core::proto::{COSEAlgorithm, Credential, CredentialID, ParsedAttestation};
 
 /// An in progress registration session for a [Passkey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct PasskeyRegistration {
     pub(crate) rs: RegistrationState,
 }
 
 /// An in progress authentication session for a [Passkey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct PasskeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -93,14 +111,32 @@ impl PartialEq for Passkey {
 // PasswordlessKey
 
 /// An in progress registration session for a [PasswordlessKey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct PasswordlessKeyRegistration {
     pub(crate) rs: RegistrationState,
     pub(crate) ca_list: AttestationCaList,
 }
 
-/// An in progress registration session for a [PasswordlessKey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// An in progress authentication session for a [PasswordlessKey].
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct PasswordlessKeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -177,14 +213,32 @@ impl From<Credential> for PasswordlessKey {
 }
 
 /// An in progress registration session for a [SecurityKey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct SecurityKeyRegistration {
     pub(crate) rs: RegistrationState,
     pub(crate) ca_list: Option<AttestationCaList>,
 }
 
 /// An in progress authentication session for a [SecurityKey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct SecurityKeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -267,14 +321,32 @@ impl From<Credential> for SecurityKey {
 }
 
 /// An in progress registration session for a [DeviceKey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct DeviceKeyRegistration {
     pub(crate) rs: RegistrationState,
     pub(crate) ca_list: AttestationCaList,
 }
 
-/// An in progress registration session for a [DeviceKey].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// An in progress authentication session for a [DeviceKey].
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct DeviceKeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -358,7 +430,16 @@ impl From<Credential> for DeviceKey {
 
 /// An in progress authentication session for a [DiscoverableKey]. [Passkey] and [DeviceKey]
 /// can be used with these workflows.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
+///
+/// Failure to do so *may* open you to replay attacks which can significantly weaken the
+/// security of this system.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "danger-allow-state-serialisation",
+    derive(Serialize, Deserialize)
+)]
 pub struct DiscoverableAuthentication {
     pub(crate) ast: AuthenticationState,
 }

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -87,6 +87,28 @@
 //! when they are elevated to be self-contained MFA as the user believes these UV prompts to be
 //! unreliable and not verified correctly. In these cases you MUST communicate to the user that
 //! the UV *may* occur on registration and then will not occur again, and that is *by design*.
+//!
+//! ## Allow Serialising Registration and Authentication State
+//!
+//! During a webauthn registration or authentication ceremony, a random challenge is produced and
+//! provided to the client. The full content of what is needed for the server to validate this
+//! challenge is stored in the associated registration or authentication state types. This value
+//! *MUST* be persisted on the server. If you store this in a cookie or some other form of client
+//! side stored value, the client can replay a previous authentication state and signature without
+//! possession of, or interaction with the authenticator, bypassing pretty much all of the guarantees
+//! of webauthn. Because of this risk by default these states are *not* allowed to be serialised
+//! which prevents them from accidentally being placed into a cookie.
+//!
+//! However there are some *safe* cases of serialising these values. This includes serialising to
+//! a database, or using a cookie "memory store" where the client side cookie is a key into a server-side
+//! map or similar. Both of these prevent the replay attack threat.
+//!
+//! An alternate but "less good" method to mitigate replay attacks is to associate a very short
+//! expiry window to the cookie if you need full client side state, but this may still allow some
+//! forms of real time replay attacks to occur.
+//!
+//! Enabling the feature `danger-allow-state-serialisation` allows you to re-enable serialisation
+//! of these types, provided you accept and understand the handling risks associated.
 
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
@@ -344,6 +366,11 @@ impl Webauthn {
     /// on the server the `PasskeyRegistration` which contains the state of this registration
     /// attempt and is paired to the `CreationChallengeResponse`.
     ///
+    /// WARNING ⚠️  YOU MUST STORE THE `PasskeyRegistration` VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
+    ///
     /// ```
     /// # use webauthn_rs::prelude::*;
     ///
@@ -448,6 +475,11 @@ impl Webauthn {
     /// a `RequestChallengeResponse`, which should be serialised to json and sent to the user agent (e.g. a browser).
     /// The server must persist the `PasskeyAuthentication` state as it is paired to the
     /// `RequestChallengeResponse` and required to complete the authentication.
+    ///
+    /// WARNING ⚠️  YOU MUST STORE THE `PasskeyAuthentication` VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
     pub fn start_passkey_authentication(
         &self,
         creds: &[Passkey],
@@ -532,6 +564,11 @@ impl Webauthn {
     /// send to the user agent (e.g. a browser) for it to conduct the registration. You must persist
     /// on the server the `SecurityKeyRegistration` which contains the state of this registration
     /// attempt and is paired to the `CreationChallengeResponse`.
+    ///
+    /// WARNING ⚠️  YOU MUST STORE THE `SecurityKeyRegistration` VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
     ///
     /// ```
     /// # use webauthn_rs::prelude::*;
@@ -673,6 +710,11 @@ impl Webauthn {
     /// a `RequestChallengeResponse`, which should be serialised to json and sent to the user agent (e.g. a browser).
     /// The server must persist the `SecurityKeyAuthentication` state as it is paired to the
     /// `RequestChallengeResponse` and required to complete the authentication.
+    ///
+    /// WARNING ⚠️  YOU MUST STORE THE `SecurityKeyAuthentication` VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
     pub fn start_securitykey_authentication(
         &self,
         creds: &[SecurityKey],
@@ -773,6 +815,11 @@ impl Webauthn {
     /// send to the user agent (e.g. a browser) for it to conduct the registration. You must persist
     /// on the server the `PasswordlessKeyRegistration` which contains the state of this registration
     /// attempt and is paired to the `CreationChallengeResponse`.
+    ///
+    /// WARNING ⚠️  YOU MUST STORE THE `PasswordlessKeyRegistration` VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
     ///
     /// ```
     /// # use webauthn_rs::prelude::*;
@@ -902,6 +949,11 @@ impl Webauthn {
     /// a `RequestChallengeResponse`, which should be serialised to json and sent to the user agent (e.g. a browser).
     /// The server must persist the `PasswordlessKeyAuthentication` state as it is paired to the
     /// `RequestChallengeResponse` and required to complete the authentication.
+    ///
+    /// WARNING ⚠️  YOU MUST STORE THE `PasswordlessKeyAuthentication` VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
     pub fn start_passwordlesskey_authentication(
         &self,
         creds: &[PasswordlessKey],


### PR DESCRIPTION
Fixes #170 - Help to document the risks of serialising the reg/auth states with client side held cookies. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
