### PR TITLE
Allow passkey upgrades

### DIFF
--- a/webauthn-authenticator-rs/src/u2fhid.rs
+++ b/webauthn-authenticator-rs/src/u2fhid.rs
@@ -386,7 +386,9 @@ mod tests {
 
         trace!(?cred);
 
-        let (chal, auth_state) = wan.generate_challenge_authenticate(vec![cred], None).unwrap();
+        let (chal, auth_state) = wan
+            .generate_challenge_authenticate(vec![cred], None)
+            .unwrap();
 
         let r = u
             .perform_auth(

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -47,6 +47,7 @@ pub struct AuthenticationState {
     pub(crate) policy: UserVerificationPolicy,
     pub(crate) challenge: Base64UrlSafeData,
     pub(crate) appid: Option<String>,
+    pub(crate) allow_backup_eligible_upgrade: bool,
 }
 
 impl AuthenticationState {
@@ -613,6 +614,11 @@ pub struct AuthenticationResult {
     /// The current backup state of the authenticator. It may have
     /// changed since registration.
     pub(crate) backup_state: bool,
+    /// The current backup eligibility of the authenticator. It may have
+    /// changed since registration in rare cases. This transition may ONLY
+    /// be false to true, never the reverse. This is common on passkeys
+    /// during some upgrades.
+    pub(crate) backup_eligible: bool,
     /// The state of the counter
     pub(crate) counter: Counter,
     /// The response from associated extensions.
@@ -640,6 +646,14 @@ impl AuthenticationResult {
     /// changed since registration.
     pub fn backup_state(&self) -> bool {
         self.backup_state
+    }
+
+    /// The current backup eligibility of the authenticator. It may have
+    /// changed since registration in rare cases. This transition may ONLY
+    /// be false to true, never the reverse. This is common on passkeys
+    /// during some upgrades.
+    pub fn backup_eligible(&self) -> bool {
+        self.backup_eligible
     }
 
     /// The state of the counter
@@ -715,7 +729,7 @@ impl AttestationCa {
 
     /// The microsoft root CA for TPM attestation.
     ///
-    /// Not ellible for strict - many TPM's use SHA1 in signatures, which means they are
+    /// Not eligible for strict - many TPM's use SHA1 in signatures, which means they are
     /// potentially weak.
     ///
     /// In the future we may reject RS1 signatures, allowing this to be moved into the
@@ -729,7 +743,7 @@ impl AttestationCa {
 
     /// Nitrokey root CA for their FIDO2 device range.
     ///
-    /// Not elligble for strict - hardware is difficult to interact with, low quality,
+    /// Not eligible for strict - hardware is difficult to interact with, low quality,
     /// and easy to break or destroy.
     pub fn nitrokey_fido2_root_ca() -> Self {
         AttestationCa {
@@ -739,7 +753,7 @@ impl AttestationCa {
 
     /// Nitrokey root CA for their U2F device range.
     ///
-    /// Not elligble for strict - hardware is difficult to interact with, low quality,
+    /// Not eligible for strict - hardware is difficult to interact with, low quality,
     /// and easy to break or destroy.
     pub fn nitrokey_u2f_root_ca() -> Self {
         AttestationCa {

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -177,7 +177,7 @@ impl Credential {
         trace!(?extensions);
         let counter = auth_data.counter;
         let user_verified = auth_data.user_verified;
-        let backup_elligible = auth_data.backup_elligible;
+        let backup_eligible = auth_data.backup_eligible;
         let backup_state = auth_data.backup_state;
 
         // due to bugs in chrome, we have to disable transports because lol.
@@ -189,7 +189,7 @@ impl Credential {
             counter,
             transports,
             user_verified,
-            backup_eligible: backup_elligible,
+            backup_eligible,
             backup_state,
             registration_policy,
             extensions,
@@ -348,7 +348,7 @@ fn authenticator_data_parser<T: Ceremony>(i: &[u8]) -> nom::IResult<&[u8], Authe
             counter,
             user_verified: data_flags.2,
             user_present: data_flags.3,
-            backup_elligible: data_flags.4,
+            backup_eligible: data_flags.4,
             backup_state: data_flags.5,
             acd,
             extensions,
@@ -369,7 +369,7 @@ pub struct AuthenticatorData<T: Ceremony> {
     pub user_verified: bool,
     /// Flag defining if the authenticator *could* be backed up OR transferred
     /// between multiple devices.
-    pub backup_elligible: bool,
+    pub backup_eligible: bool,
     /// Flag defining if the authenticator *knows* it is currently backed up or
     /// present on multiple devices.
     pub backup_state: bool,

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -86,6 +86,14 @@ impl Passkey {
                 changed = true;
             }
 
+            if res.backup_eligible() != self.cred.backup_eligible {
+                // MUST be false -> true
+                assert!(!self.cred.backup_eligible);
+                assert!(res.backup_eligible());
+                self.cred.backup_eligible = res.backup_eligible();
+                changed = true;
+            }
+
             Some(changed)
         } else {
             None

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -488,9 +488,15 @@ impl Webauthn {
         let extensions = None;
         let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
         let policy = UserVerificationPolicy::Preferred;
+        let allow_backup_eligible_upgrade = true;
 
         self.core
-            .generate_challenge_authenticate_policy(creds, policy, extensions)
+            .generate_challenge_authenticate_policy(
+                creds,
+                policy,
+                extensions,
+                allow_backup_eligible_upgrade,
+            )
             .map(|(rcr, ast)| (rcr, PasskeyAuthentication { ast }))
     }
 
@@ -722,6 +728,7 @@ impl Webauthn {
     ) -> WebauthnResult<(RequestChallengeResponse, SecurityKeyAuthentication)> {
         let extensions = None;
         let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
+        let allow_backup_eligible_upgrade = false;
 
         let policy = if cfg!(feature = "danger-user-presence-only-security-keys") {
             UserVerificationPolicy::Discouraged_DO_NOT_USE
@@ -730,7 +737,12 @@ impl Webauthn {
         };
 
         self.core
-            .generate_challenge_authenticate_policy(creds, policy, extensions)
+            .generate_challenge_authenticate_policy(
+                creds,
+                policy,
+                extensions,
+                allow_backup_eligible_upgrade,
+            )
             .map(|(rcr, ast)| (rcr, SecurityKeyAuthentication { ast }))
     }
 
@@ -968,9 +980,15 @@ impl Webauthn {
         });
 
         let policy = UserVerificationPolicy::Required;
+        let allow_backup_eligible_upgrade = false;
 
         self.core
-            .generate_challenge_authenticate_policy(creds, policy, extensions)
+            .generate_challenge_authenticate_policy(
+                creds,
+                policy,
+                extensions,
+                allow_backup_eligible_upgrade,
+            )
             .map(|(rcr, ast)| (rcr, PasswordlessKeyAuthentication { ast }))
     }
 
@@ -1147,9 +1165,15 @@ impl Webauthn {
         });
 
         let policy = UserVerificationPolicy::Required;
+        let allow_backup_eligible_upgrade = false;
 
         self.core
-            .generate_challenge_authenticate_policy(creds, policy, extensions)
+            .generate_challenge_authenticate_policy(
+                creds,
+                policy,
+                extensions,
+                allow_backup_eligible_upgrade,
+            )
             .map(|(rcr, ast)| (rcr, DeviceKeyAuthentication { ast }))
     }
 


### PR DESCRIPTION
Fixes #185 - this allows BE to change false -> true on a passkey, and gives RP's the choice to allow that upgrade. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
