### PR TITLE
fix handling of strange origins

### DIFF
--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -1094,6 +1094,9 @@ impl WebauthnCore {
         ccd_url: &url::Url,
         cnf_url: &url::Url,
     ) -> bool {
+        if ccd_url == cnf_url {
+            return true;
+        }
         if allow_subdomains_origin {
             match (ccd_url.origin(), cnf_url.origin()) {
                 (
@@ -3757,5 +3760,22 @@ mod tests {
                 Err(WebauthnError::CredentialInsecureCryptography)
             ))
         }
+    }
+
+    #[test]
+    fn test_ios_origin_matches() {
+        assert!(Webauthn::origins_match(
+            false,
+            false,
+            &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+            &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+        ));
+
+        assert!(!Webauthn::origins_match(
+            false,
+            false,
+            &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+            &Url::parse("ios:bundle-id:com.foo.baz").unwrap(),
+        ));
     }
 }


### PR DESCRIPTION
These (see the test cases) parse as `scheme: "ios"` and `path: "bundle-id:com.foo.bar"` with no `host`, so they don't compare normally. However, if the input urls are exactly matching, i think we can just consider that a match?

Fixes #

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
