### PR TITLE
swap to cbor 2

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1"
 url = "2"
 serde_json = "1.0"
 nom = "7.1"
-serde_cbor = "0.11"
+serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
 openssl = "0.10"
 rpassword = "5.0"
 

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }
 webauthn-rs-proto = { version = "0.4.6", path = "../webauthn-rs-proto" }
 serde = { version = "1", features = ["derive"] }
-serde_cbor = "0.11"
+serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
 serde_json = "1.0"
 nom = "7.1"
 base64 = "0.13"


### PR DESCRIPTION
Swap to our cbor 2 library - currently identical in source to serde cbor 