### PR TITLE
Add support for Windows 10 WebAuthn API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,18 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-    name: WebAuthn Rust Frameworks (Build and Test)
+        include:
+          - os: windows-latest
+            features: --features win10
+            rust_version: stable
+          - os: windows-latest
+            features: --features nfc,usb,win10
+            rust_version: stable
+        exclude:
+          - os: windows-latest
+            rust_version: 1.45.0
+
+    name: Build and Test
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/designs/authenticator-library.md
+++ b/designs/authenticator-library.md
@@ -1,9 +1,12 @@
 # Authenticator library
 
+* **Published:** 2022-09-24
+* **Last updated:** 2022-10-07
+
 This describes the state of the `webauthn-authenticator-rs` library, and some
 potential longer term improvements.
 
-## Current state
+## Current state (Sep 2022)
 
 At present, there are two disjoint traits provided by the `webauthn-authenticator-rs` library:
 
@@ -93,6 +96,9 @@ This would let us validate and improve upon the `Transport` level API to a point
 This would provide access to NFC and USB-HID tokens through our own library, and allow us to potentially replace Mozilla's library.
 
 ### Implement an `AuthenticatorBackend` for platform-specific WebAuthn APIs
+
+- [ ] macOS Passkey API
+- [x] Windows 10 WebAuthn API (added Oct 2022)
 
 This will require `webauthn-authenticator-rs` to carry some platform-specific code.
 

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kanidm/webauthn-rs"
 u2fhid = ["authenticator"]
 nfc = ["pcsc"]
 usb = ["hidapi"]
+win10 = ["windows"]
 
 default = []
 
@@ -35,6 +36,7 @@ authenticator = { version = "0.3.2-dev.1", optional = true, default-features = f
 
 pcsc = { version = "2", optional = true }
 hidapi = { version = "1.4.2", optional = true }
+windows = { version = "0.41.0", optional = true, features = ["Win32_Graphics_Gdi", "Win32_Networking_WindowsWebServices", "Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm" ] }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/webauthn-authenticator-rs/examples/authenticate/main.rs
+++ b/webauthn-authenticator-rs/examples/authenticate/main.rs
@@ -1,0 +1,124 @@
+#[macro_use]
+extern crate tracing;
+
+use std::io::{stdin, stdout, Write};
+
+use webauthn_authenticator_rs::prelude::Url;
+use webauthn_authenticator_rs::softtoken::SoftToken;
+use webauthn_authenticator_rs::AuthenticatorBackend;
+use webauthn_rs_core::proto::RequestAuthenticationExtensions;
+use webauthn_rs_core::WebauthnCore as Webauthn;
+
+fn select_provider() -> Box<dyn AuthenticatorBackend> {
+    let mut providers: Vec<(&str, fn() -> Box<dyn AuthenticatorBackend>)> = Vec::new();
+
+    providers.push(("SoftToken", || Box::new(SoftToken::new().unwrap().0)));
+
+    #[cfg(feature = "u2fhid")]
+    providers.push(("Mozilla", || {
+        Box::new(webauthn_authenticator_rs::u2fhid::U2FHid::default())
+    }));
+
+    #[cfg(feature = "win10")]
+    providers.push(("Windows 10", || {
+        Box::new(webauthn_authenticator_rs::win10::Win10::default())
+    }));
+
+    if providers.is_empty() {
+        panic!("oops, no providers available in this build!");
+    }
+
+    loop {
+        println!("Select a provider:");
+        for (i, (name, _)) in providers.iter().enumerate() {
+            println!("({}): {}", i + 1, name);
+        }
+
+        let mut buf = String::new();
+        print!("? ");
+        stdout().flush().ok();
+        stdin().read_line(&mut buf).expect("Cannot read stdin");
+        let selected: Result<u64, _> = buf.trim().parse();
+        match selected {
+            Ok(v) => {
+                if v < 1 || (v as usize) > providers.len() {
+                    println!("Input out of range: {}", v);
+                } else {
+                    let p = providers.remove((v as usize) - 1);
+                    println!("Using {}...", p.0);
+                    return p.1();
+                }
+            }
+            Err(_) => println!("Input was not a number"),
+        }
+        println!();
+    }
+}
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    let mut u = select_provider();
+
+    // WARNING: don't use this as an example of how to use the library!
+    let wan = Webauthn::new_unsafe_experts_only(
+        "https://localhost:8080/auth",
+        "localhost",
+        vec![url::Url::parse("https://localhost:8080").unwrap()],
+        Some(1),
+        None,
+        None,
+    );
+
+    let unique_id = [
+        158, 170, 228, 89, 68, 28, 73, 194, 134, 19, 227, 153, 107, 220, 150, 238,
+    ];
+    let name = "william";
+
+    let (chal, reg_state) = wan
+        .generate_challenge_register(&unique_id, name, name, false)
+        .unwrap();
+
+    info!("🍿 challenge -> {:x?}", chal);
+
+    let r = u
+        .perform_register(
+            Url::parse("https://localhost:8080").unwrap(),
+            chal.public_key,
+            60_000,
+        )
+        .unwrap();
+
+    let cred = wan.register_credential(&r, &reg_state, None).unwrap();
+
+    trace!(?cred);
+
+    let (chal, auth_state) = wan
+        .generate_challenge_authenticate(
+            vec![cred],
+            Some(RequestAuthenticationExtensions {
+                appid: Some("example.app.id".to_string()),
+                uvm: None,
+            }),
+        )
+        .unwrap();
+
+    let r = u
+        .perform_auth(
+            Url::parse("https://localhost:8080").unwrap(),
+            chal.public_key,
+            60_000,
+        )
+        .map_err(|e| {
+            error!("Error -> {:x?}", e);
+            e
+        })
+        .expect("Failed to auth");
+    trace!(?r);
+
+    let auth_res = wan
+        .authenticate_credential(&r, &auth_state)
+        .expect("webauth authentication denied");
+
+    info!("auth_res -> {:x?}", auth_res);
+}

--- a/webauthn-authenticator-rs/examples/nfc_token_info/main.rs
+++ b/webauthn-authenticator-rs/examples/nfc_token_info/main.rs
@@ -5,6 +5,5 @@ mod core;
 
 fn main() {
     tracing_subscriber::fmt::init();
-
     core::event_loop();
 }

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -47,6 +47,9 @@ pub mod usb;
 #[cfg(feature = "u2fhid")]
 pub mod u2fhid;
 
+#[cfg(feature = "win10")]
+pub mod win10;
+
 pub struct WebauthnAuthenticator<T>
 where
     T: AuthenticatorBackend,

--- a/webauthn-authenticator-rs/src/win10/clientdata.rs
+++ b/webauthn-authenticator-rs/src/win10/clientdata.rs
@@ -1,0 +1,88 @@
+//! Wrappers for [CollectedClientData].
+use base64urlsafedata::Base64UrlSafeData;
+use std::collections::BTreeMap;
+use std::pin::Pin;
+use webauthn_rs_proto::CollectedClientData;
+
+use super::WinWrapper;
+use crate::{error::WebauthnCError, Url};
+
+use windows::{
+    core::HSTRING,
+    w,
+    Win32::Networking::WindowsWebServices::{
+        WEBAUTHN_CLIENT_DATA, WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
+    },
+};
+// Most constants are `&str`, but APIs expect `HSTRING`... there's no good work-around.
+// https://github.com/microsoft/windows-rs/issues/2049
+/// [windows::Win32::Networking::WindowsWebServices::WEBAUTHN_HASH_ALGORITHM_SHA_256]
+const SHA_256: &HSTRING = w!("SHA-256");
+
+/// Wrapper for [WEBAUTHN_CLIENT_DATA] to ensure pointer lifetime.
+pub struct WinClientData {
+    native: WEBAUTHN_CLIENT_DATA,
+    client_data_json: String,
+}
+
+impl WinClientData {
+    pub fn client_data_json(&self) -> &String {
+        &self.client_data_json
+    }
+}
+
+impl WinWrapper<CollectedClientData> for WinClientData {
+    type NativeType = WEBAUTHN_CLIENT_DATA;
+    fn new(clientdata: &CollectedClientData) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        // Construct an incomplete type first, so that all the pointers are fixed.
+        let res = Self {
+            native: WEBAUTHN_CLIENT_DATA::default(),
+            client_data_json: serde_json::to_string(clientdata)
+                .map_err(|_| WebauthnCError::Json)?,
+        };
+
+        let mut boxed = Box::pin(res);
+
+        // Create the real native type, which contains bare pointers.
+        let native = WEBAUTHN_CLIENT_DATA {
+            dwVersion: WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
+            cbClientDataJSON: boxed.client_data_json.len() as u32,
+            pbClientDataJSON: boxed.client_data_json.as_ptr() as *mut _,
+            pwszHashAlgId: SHA_256.into(),
+        };
+
+        // Update the boxed type with the proper native object.
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        Ok(boxed)
+    }
+
+    fn native_ptr(&self) -> &WEBAUTHN_CLIENT_DATA {
+        &self.native
+    }
+}
+
+pub fn creation_to_clientdata(origin: Url, challenge: Base64UrlSafeData) -> CollectedClientData {
+    CollectedClientData {
+        type_: "webauthn.create".to_string(),
+        challenge,
+        origin,
+        token_binding: None,
+        cross_origin: None,
+        unknown_keys: BTreeMap::new(),
+    }
+}
+
+pub fn get_to_clientdata(origin: Url, challenge: Base64UrlSafeData) -> CollectedClientData {
+    CollectedClientData {
+        type_: "webauthn.get".to_string(),
+        challenge,
+        origin,
+        token_binding: None,
+        cross_origin: None,
+        unknown_keys: BTreeMap::new(),
+    }
+}

--- a/webauthn-authenticator-rs/src/win10/cose.rs
+++ b/webauthn-authenticator-rs/src/win10/cose.rs
@@ -1,0 +1,108 @@
+//! Wrappers for [PubKeyCredParams].
+use crate::prelude::WebauthnCError;
+use std::pin::Pin;
+use webauthn_rs_proto::PubKeyCredParams;
+
+use super::WinWrapper;
+
+use windows::{
+    core::HSTRING,
+    Win32::Networking::WindowsWebServices::{
+        WEBAUTHN_COSE_CREDENTIAL_PARAMETER, WEBAUTHN_COSE_CREDENTIAL_PARAMETERS,
+        WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
+    },
+};
+
+/// Wrapper for [WEBAUTHN_COSE_CREDENTIAL_PARAMETER] to ensure pointer lifetime.
+struct WinCoseCredentialParameter {
+    native: WEBAUTHN_COSE_CREDENTIAL_PARAMETER,
+    _typ: HSTRING,
+}
+
+impl WinCoseCredentialParameter {
+    fn from(p: &PubKeyCredParams) -> Pin<Box<Self>> {
+        let res = Self {
+            native: Default::default(),
+            _typ: p.type_.clone().into(),
+        };
+
+        let mut boxed = Box::pin(res);
+
+        let native = WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
+            dwVersion: WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
+            pwszCredentialType: (&boxed._typ).into(),
+            lAlg: p.alg as i32,
+        };
+
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        boxed
+    }
+}
+
+pub struct WinCoseCredentialParameters {
+    native: WEBAUTHN_COSE_CREDENTIAL_PARAMETERS,
+    _params: Vec<Pin<Box<WinCoseCredentialParameter>>>,
+    _l: Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER>,
+}
+
+impl WinWrapper<Vec<PubKeyCredParams>> for WinCoseCredentialParameters {
+    type NativeType = WEBAUTHN_COSE_CREDENTIAL_PARAMETERS;
+
+    fn new(params: &Vec<PubKeyCredParams>) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        let params: Vec<Pin<Box<WinCoseCredentialParameter>>> = params
+            .iter()
+            .map(WinCoseCredentialParameter::from)
+            .collect();
+        Ok(WinCoseCredentialParameters::from_wrapped(params))
+    }
+
+    fn native_ptr(&self) -> &WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
+        &self.native
+    }
+}
+
+impl WinCoseCredentialParameters {
+    fn from_wrapped(params: Vec<Pin<Box<WinCoseCredentialParameter>>>) -> Pin<Box<Self>> {
+        let len = params.len();
+        let res = Self {
+            native: Default::default(),
+            _l: Vec::with_capacity(len),
+            _params: params,
+        };
+
+        // Box and pin the struct so it's on the heap and doesn't move.
+        let mut boxed = Box::pin(res);
+
+        // Put in all the "native" values
+        let p_ptr = boxed._params.as_ptr();
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            let l = &mut Pin::get_unchecked_mut(mut_ref)._l;
+            let l_ptr = l.as_mut_ptr();
+            for i in 0..len {
+                *l_ptr.add(i) = (*p_ptr.add(i)).native;
+            }
+
+            l.set_len(len);
+        }
+
+        // let mut l: Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER> =
+        //     params.iter().map(|p| p.native).collect();
+
+        let native = WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
+            cCredentialParameters: boxed._l.len() as u32,
+            pCredentialParameters: boxed._l.as_mut_ptr() as *mut _,
+        };
+
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        boxed
+    }
+}

--- a/webauthn-authenticator-rs/src/win10/credential.rs
+++ b/webauthn-authenticator-rs/src/win10/credential.rs
@@ -1,0 +1,179 @@
+//! Wrappers for [AllowCredentials] and [PublicKeyCredentialDescriptor].
+use crate::prelude::WebauthnCError;
+use base64urlsafedata::Base64UrlSafeData;
+use std::pin::Pin;
+use webauthn_rs_proto::{AllowCredentials, AuthenticatorTransport, PublicKeyCredentialDescriptor};
+
+use super::WinWrapper;
+
+use windows::{
+    core::HSTRING,
+    w,
+    Win32::Networking::WindowsWebServices::{
+        WEBAUTHN_CREDENTIAL_EX, WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION, WEBAUTHN_CREDENTIAL_LIST,
+        WEBAUTHN_CTAP_TRANSPORT_BLE, WEBAUTHN_CTAP_TRANSPORT_INTERNAL, WEBAUTHN_CTAP_TRANSPORT_NFC,
+        WEBAUTHN_CTAP_TRANSPORT_TEST, WEBAUTHN_CTAP_TRANSPORT_USB,
+    },
+};
+
+// Most constants are `&str`, but APIs expect `HSTRING`... there's no good work-around.
+// https://github.com/microsoft/windows-rs/issues/2049
+/// [windows::Win32::Networking::WindowsWebServices::WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY]
+const CREDENTIAL_TYPE_PUBLIC_KEY: &HSTRING = w!("public-key");
+
+/// Converts an [AuthenticatorTransport] into a value for
+/// [WEBAUTHN_CREDENTIAL_EX::dwTransports]
+fn transport_to_native(transport: &AuthenticatorTransport) -> u32 {
+    match transport {
+        AuthenticatorTransport::Ble => WEBAUTHN_CTAP_TRANSPORT_BLE,
+        AuthenticatorTransport::Internal => WEBAUTHN_CTAP_TRANSPORT_INTERNAL,
+        AuthenticatorTransport::Nfc => WEBAUTHN_CTAP_TRANSPORT_NFC,
+        AuthenticatorTransport::Test => WEBAUTHN_CTAP_TRANSPORT_TEST,
+        AuthenticatorTransport::Usb => WEBAUTHN_CTAP_TRANSPORT_USB,
+    }
+}
+
+/// Converts a bitmask of native transports into [AuthenticatorTransport].
+pub fn native_to_transports(t: u32) -> Vec<AuthenticatorTransport> {
+    let mut o: Vec<AuthenticatorTransport> = Vec::new();
+    if t & WEBAUTHN_CTAP_TRANSPORT_BLE != 0 {
+        o.push(AuthenticatorTransport::Ble);
+    }
+    if t & WEBAUTHN_CTAP_TRANSPORT_INTERNAL != 0 {
+        o.push(AuthenticatorTransport::Internal);
+    }
+    if t & WEBAUTHN_CTAP_TRANSPORT_NFC != 0 {
+        o.push(AuthenticatorTransport::Nfc);
+    }
+    if t & WEBAUTHN_CTAP_TRANSPORT_TEST != 0 {
+        o.push(AuthenticatorTransport::Test);
+    }
+    if t & WEBAUTHN_CTAP_TRANSPORT_USB != 0 {
+        o.push(AuthenticatorTransport::Usb);
+    }
+    o
+}
+
+/// Converts a [Vec<AuthenticatorTransport>] into a value for
+/// [WEBAUTHN_CREDENTIAL_EX::dwTransports]
+fn transports_to_bitmask(transports: &Option<Vec<AuthenticatorTransport>>) -> u32 {
+    match transports {
+        None => 0,
+        Some(transports) => transports.iter().map(transport_to_native).sum(),
+    }
+}
+
+/// Wrapper for [WEBAUTHN_CREDENTIAL_LIST] to ensure pointer lifetime, analogous to
+/// [PublicKeyCredentialDescriptor] and [AllowCredentials].
+pub struct WinCredentialList {
+    /// Native structure, which points to everything else here.
+    pub(crate) native: WEBAUTHN_CREDENTIAL_LIST,
+    /// Pointer to _l, because [WEBAUTHN_CREDENTIAL_LIST::ppCredentials] is a double-pointer.
+    _p: *const WEBAUTHN_CREDENTIAL_EX,
+    /// List of credentials
+    _l: Vec<WEBAUTHN_CREDENTIAL_EX>,
+    /// List of credential IDs, referenced by [WEBAUTHN_CREDENTIAL_EX::pbId]
+    _ids: Vec<Base64UrlSafeData>,
+}
+
+/// Trait to make [PublicKeyCredentialDescriptor] and [AllowCredentials] look the same.
+trait CredentialType: std::fmt::Debug {
+    fn type_(&self) -> String;
+    fn id(&self) -> Base64UrlSafeData;
+    fn transports(&self) -> u32;
+}
+
+impl CredentialType for PublicKeyCredentialDescriptor {
+    fn type_(&self) -> String {
+        self.type_.clone()
+    }
+    fn id(&self) -> Base64UrlSafeData {
+        self.id.clone()
+    }
+    fn transports(&self) -> u32 {
+        transports_to_bitmask(&self.transports)
+    }
+}
+
+impl CredentialType for AllowCredentials {
+    fn type_(&self) -> String {
+        self.type_.clone()
+    }
+    fn id(&self) -> Base64UrlSafeData {
+        self.id.clone()
+    }
+    fn transports(&self) -> u32 {
+        transports_to_bitmask(&self.transports)
+    }
+}
+
+impl<T: CredentialType> WinWrapper<Vec<T>> for WinCredentialList {
+    type NativeType = WEBAUTHN_CREDENTIAL_LIST;
+    fn new(credentials: &Vec<T>) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        // Check that all the credential types are supported.
+        for c in credentials.iter() {
+            let typ = c.type_();
+            if typ != *"public-key" {
+                error!("Unsupported credential type: {:?}", c);
+                return Err(WebauthnCError::Internal);
+            }
+        }
+
+        let len = credentials.len();
+        let res = Self {
+            native: Default::default(),
+            _p: std::ptr::null(),
+            _l: Vec::with_capacity(len),
+            _ids: credentials.iter().map(|c| c.id()).collect(),
+        };
+
+        // Box the struct so it doesn't move.
+        let mut boxed = Box::pin(res);
+
+        // Put in all the "native" values
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            let mut_ptr = Pin::get_unchecked_mut(mut_ref);
+            let l = &mut mut_ptr._l;
+            let l_ptr = l.as_mut_ptr();
+            for (i, credential) in credentials.iter().enumerate() {
+                let id = &mut mut_ptr._ids[i];
+                *l_ptr.add(i) = WEBAUTHN_CREDENTIAL_EX {
+                    dwVersion: WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION,
+                    cbId: id.0.len() as u32,
+                    pbId: id.0.as_mut_ptr() as *mut _,
+                    pwszCredentialType: CREDENTIAL_TYPE_PUBLIC_KEY.into(),
+                    dwTransports: credential.transports(),
+                };
+            }
+
+            l.set_len(len);
+        }
+
+        // Add a pointer to the pointer...
+        let p = boxed._l.as_ptr();
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref)._p = p;
+        }
+
+        let native = WEBAUTHN_CREDENTIAL_LIST {
+            cCredentials: len as u32,
+            ppCredentials: std::ptr::addr_of_mut!(boxed._p) as *mut *mut _,
+        };
+
+        // Drop in the native struct
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        // trace!(?boxed.native);
+
+        Ok(boxed)
+    }
+
+    fn native_ptr(&self) -> &WEBAUTHN_CREDENTIAL_LIST {
+        &self.native
+    }
+}

--- a/webauthn-authenticator-rs/src/win10/extensions.rs
+++ b/webauthn-authenticator-rs/src/win10/extensions.rs
@@ -1,0 +1,343 @@
+//! Wrappers for extensions.
+use crate::prelude::WebauthnCError;
+use std::ffi::c_void;
+use std::pin::Pin;
+use webauthn_rs_proto::{
+    AuthenticationExtensionsClientOutputs, CredProtect, RegistrationExtensionsClientOutputs,
+    RequestRegistrationExtensions,
+};
+
+use super::WinWrapper;
+
+use windows::{
+    core::HSTRING,
+    Win32::{Foundation::BOOL, Networking::WindowsWebServices::*},
+};
+
+/// Represents a single extension for MakeCredential requests, analogous to a
+/// single [RequestRegistrationExtensions] field.
+#[derive(Debug)]
+pub(crate) enum WinExtensionMakeCredentialRequest {
+    HmacSecret(BOOL),
+    CredProtect(WEBAUTHN_CRED_PROTECT_EXTENSION_IN),
+    MinPinLength(BOOL),
+}
+
+/// Represents a single extension for GetAssertion requests, analogous to a
+/// single [RequestAuthenticationExtensions] field.
+#[derive(Debug)]
+pub(crate) enum WinExtensionGetAssertionRequest {}
+
+/// Generic request extension trait, for abstracting between
+/// [WinExtensionMakeCredentialRequest] and [WinExtensionGetAssertionRequest].
+pub(crate) trait WinExtensionRequestType
+where
+    Self: Sized,
+{
+    /// Extension identier, as string.
+    fn identifier(&self) -> &str;
+    /// Length of the native data structure, in bytes.
+    fn len(&self) -> u32;
+    /// Pointer to the native data structure.
+    fn ptr(&mut self) -> *mut c_void;
+    /// The `webauthn-authenticator-rs` type which this wraps.
+    type WrappedType;
+    /// Converts the [Self::WrappedType] to a [Vec] of Windows API types.
+    fn to_native(e: &Self::WrappedType) -> Vec<Self>;
+}
+
+impl WinExtensionRequestType for WinExtensionMakeCredentialRequest {
+    fn identifier(&self) -> &str {
+        match self {
+            Self::HmacSecret(_) => WEBAUTHN_EXTENSIONS_IDENTIFIER_HMAC_SECRET,
+            Self::CredProtect(_) => WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_PROTECT,
+            Self::MinPinLength(_) => WEBAUTHN_EXTENSIONS_IDENTIFIER_MIN_PIN_LENGTH,
+        }
+    }
+
+    fn len(&self) -> u32 {
+        (match self {
+            Self::HmacSecret(_) => std::mem::size_of::<BOOL>(),
+            Self::CredProtect(_) => std::mem::size_of::<WEBAUTHN_CRED_PROTECT_EXTENSION_IN>(),
+            Self::MinPinLength(_) => std::mem::size_of::<BOOL>(),
+        }) as u32
+    }
+
+    fn ptr(&mut self) -> *mut c_void {
+        match self {
+            Self::HmacSecret(v) => v as *mut _ as *mut c_void,
+            Self::CredProtect(v) => v as *mut _ as *mut c_void,
+            Self::MinPinLength(v) => v as *mut _ as *mut c_void,
+        }
+    }
+
+    type WrappedType = RequestRegistrationExtensions;
+
+    fn to_native(e: &Self::WrappedType) -> Vec<Self> {
+        let mut o: Vec<Self> = Vec::new();
+        if let Some(c) = &e.cred_protect {
+            o.push(c.into());
+        }
+        if let Some(h) = &e.hmac_create_secret {
+            o.push(Self::HmacSecret(h.into()))
+        }
+        if let Some(x) = &e.min_pin_length {
+            o.push(Self::MinPinLength(x.into()));
+        }
+
+        o
+    }
+}
+
+/*
+impl WinExtensionRequestType for WinExtensionGetAssertionRequest {
+    fn identifier(&self) -> &str {
+        todo!();
+    }
+
+    fn len(&self) -> u32 {
+        todo!();
+    }
+
+    fn ptr(&mut self) -> *mut c_void {
+        todo!();
+    }
+
+    type WrappedType = RequestAuthenticationExtensions;
+
+    fn to_native(_e: &Self::WrappedType) -> Vec<Self> {
+        let o: Vec<Self> = Vec::new();
+
+        o
+    }
+}
+*/
+
+impl From<&CredProtect> for WinExtensionMakeCredentialRequest {
+    /// Converts [CredProtect] into [WEBAUTHN_CRED_PROTECT_EXTENSION_IN].
+    fn from(c: &CredProtect) -> Self {
+        Self::CredProtect(WEBAUTHN_CRED_PROTECT_EXTENSION_IN {
+            dwCredProtect: c.credential_protection_policy as u32,
+            bRequireCredProtect: c
+                .enforce_credential_protection_policy
+                .unwrap_or(false)
+                .into(),
+        })
+    }
+}
+
+/// Reads a [WEBAUTHN_EXTENSION] containing a Windows-specific primitive type,
+/// converting it into a Rust datatype.
+fn read_extension<'a, T: 'a, U: From<&'a T>>(
+    e: &'a WEBAUTHN_EXTENSION,
+) -> Result<U, WebauthnCError> {
+    if (e.cbExtension as usize) < std::mem::size_of::<T>() {
+        return Err(WebauthnCError::Internal);
+    }
+    let v = unsafe { (e.pvExtension as *mut T).as_ref() }.ok_or(WebauthnCError::Internal)?;
+    Ok(v.into())
+}
+
+/// Reads and copies a [WEBAUTHN_EXTENSION] containing a primitive type.
+fn read_extension2<'a, T: 'a + Clone>(e: &'a WEBAUTHN_EXTENSION) -> Result<T, WebauthnCError> {
+    if (e.cbExtension as usize) < std::mem::size_of::<T>() {
+        return Err(WebauthnCError::Internal);
+    }
+    let v = unsafe { (e.pvExtension as *mut T).as_ref() }.ok_or(WebauthnCError::Internal)?;
+    Ok(v.clone())
+}
+
+/// Represents a single extension for MakeCredential responses, analogous to a
+/// single [RegistrationExtensionsClientOutputs] field.
+enum WinExtensionMakeCredentialResponse {
+    HmacSecret(bool),
+    CredProtect(u32),
+    CredBlob,
+    MinPinLength(u32),
+}
+
+impl TryFrom<&WEBAUTHN_EXTENSION> for WinExtensionMakeCredentialResponse {
+    type Error = WebauthnCError;
+
+    /// Reads a [WEBAUTHN_EXTENSION] for a response to a MakeCredential call.
+    fn try_from(e: &WEBAUTHN_EXTENSION) -> Result<Self, WebauthnCError> {
+        let id = unsafe {
+            e.pwszExtensionIdentifier
+                .to_string()
+                .map_err(|_| WebauthnCError::Internal)?
+        };
+        // let id = &HSTRING::from_wide(unsafe { e.pwszExtensionIdentifier.as_wide() });
+        match id.as_str() {
+            WEBAUTHN_EXTENSIONS_IDENTIFIER_HMAC_SECRET => {
+                read_extension::<'_, BOOL, _>(e).map(WinExtensionMakeCredentialResponse::HmacSecret)
+            }
+            WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_PROTECT => {
+                read_extension2(e).map(WinExtensionMakeCredentialResponse::CredProtect)
+            }
+            // Value intentonally ignored
+            WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_BLOB => Ok(Self::CredBlob),
+            WEBAUTHN_EXTENSIONS_IDENTIFIER_MIN_PIN_LENGTH => {
+                read_extension2(e).map(WinExtensionMakeCredentialResponse::MinPinLength)
+            }
+            o => {
+                error!("unknown extension: {:?}", o);
+                Err(WebauthnCError::Internal)
+            }
+        }
+    }
+}
+
+/// Converts [WEBAUTHN_EXTENSIONS] for a response to MakeCredential call into
+/// a `webauthn-authenticator-rs` [RegistrationExtensionsClientOutputs] type.
+pub fn native_to_registration_extensions(
+    native: &WEBAUTHN_EXTENSIONS,
+) -> Result<RegistrationExtensionsClientOutputs, WebauthnCError> {
+    let mut o = RegistrationExtensionsClientOutputs::default();
+
+    for i in 0..(native.cExtensions as usize) {
+        let extn = unsafe { &*native.pExtensions.add(i) };
+        let win = WinExtensionMakeCredentialResponse::try_from(extn)?;
+        match win {
+            WinExtensionMakeCredentialResponse::HmacSecret(v) => o.hmac_secret = Some(v),
+            WinExtensionMakeCredentialResponse::CredProtect(v) => {
+                o.cred_protect = (v as u8).try_into().ok();
+            }
+            WinExtensionMakeCredentialResponse::CredBlob => (),
+            WinExtensionMakeCredentialResponse::MinPinLength(v) => {
+                o.min_pin_length = Some(v);
+            }
+        }
+    }
+
+    Ok(o)
+}
+
+/// Represents a single extension for GetAssertion responses, analogous to a
+/// single [AuthenticationExtensionsClientOutputs] field.
+enum WinExtensionGetAssertionResponse {
+    CredBlob,
+}
+
+impl TryFrom<&WEBAUTHN_EXTENSION> for WinExtensionGetAssertionResponse {
+    type Error = WebauthnCError;
+
+    /// Reads a [WEBAUTHN_EXTENSION] for a response to a GetAssertion call.
+    fn try_from(e: &WEBAUTHN_EXTENSION) -> Result<Self, Self::Error> {
+        let id = unsafe {
+            e.pwszExtensionIdentifier
+                .to_string()
+                .map_err(|_| WebauthnCError::Internal)?
+        };
+
+        match id.as_str() {
+            WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_BLOB => Ok(Self::CredBlob),
+            o => {
+                error!("unknown extension: {:?}", o);
+                Err(WebauthnCError::Internal)
+            }
+        }
+    }
+}
+
+/// Converts [WEBAUTHN_EXTENSIONS] for a response to GetAssertion call into
+/// a `webauthn-authenticator-rs` [AuthenticationExtensionsClientOutputs] type.
+pub fn native_to_assertion_extensions(
+    native: &WEBAUTHN_EXTENSIONS,
+) -> Result<AuthenticationExtensionsClientOutputs, WebauthnCError> {
+    let /* mut */ o = AuthenticationExtensionsClientOutputs::default();
+
+    for i in 0..(native.cExtensions as usize) {
+        let extn = unsafe { &*native.pExtensions.add(i) };
+        let win = WinExtensionGetAssertionResponse::try_from(extn)?;
+        match win {
+            WinExtensionGetAssertionResponse::CredBlob => (),
+        }
+    }
+
+    Ok(o)
+}
+
+pub(crate) struct WinExtensionsRequest<T>
+where
+    T: WinExtensionRequestType + std::fmt::Debug,
+{
+    native: WEBAUTHN_EXTENSIONS,
+    native_list: Vec<WEBAUTHN_EXTENSION>,
+    ids: Vec<HSTRING>,
+    extensions: Vec<T>,
+}
+
+impl<T> Default for WinExtensionsRequest<T>
+where
+    T: WinExtensionRequestType + std::fmt::Debug,
+{
+    fn default() -> Self {
+        Self {
+            native: Default::default(),
+            native_list: vec![],
+            ids: vec![],
+            extensions: vec![],
+        }
+    }
+}
+
+impl<T> WinWrapper<T::WrappedType> for WinExtensionsRequest<T>
+where
+    T: WinExtensionRequestType + std::fmt::Debug,
+    T::WrappedType: std::fmt::Debug,
+{
+    type NativeType = WEBAUTHN_EXTENSIONS;
+    fn native_ptr(&self) -> &WEBAUTHN_EXTENSIONS {
+        &self.native
+    }
+
+    fn new(e: &T::WrappedType) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        // Convert the extensions to a Windows-ish type
+        // trace!(?e);
+        let extensions = T::to_native(e);
+        let len = extensions.len();
+
+        let res = Self {
+            native: Default::default(),
+            native_list: Vec::with_capacity(len),
+            ids: extensions.iter().map(|e| e.identifier().into()).collect(),
+            extensions,
+        };
+
+        // trace!(?res.extensions);
+        // Put our final struct on the heap
+        let mut boxed = Box::pin(res);
+
+        // Put in all the "native" values
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            let mut_ptr = Pin::get_unchecked_mut(mut_ref);
+
+            let l = &mut mut_ptr.native_list;
+            let l_ptr = l.as_mut_ptr();
+            for (i, extension) in mut_ptr.extensions.iter_mut().enumerate() {
+                let id = &mut_ptr.ids[i];
+                *l_ptr.add(i) = WEBAUTHN_EXTENSION {
+                    pwszExtensionIdentifier: id.into(),
+                    cbExtension: extension.len(),
+                    pvExtension: extension.ptr(),
+                };
+            }
+
+            l.set_len(len);
+        }
+
+        // Create the native list element
+        let native = WEBAUTHN_EXTENSIONS {
+            cExtensions: len as u32,
+            pExtensions: boxed.native_list.as_ptr() as *mut _,
+        };
+
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        Ok(boxed)
+    }
+}

--- a/webauthn-authenticator-rs/src/win10/gui.rs
+++ b/webauthn-authenticator-rs/src/win10/gui.rs
@@ -1,0 +1,271 @@
+//! GUI code for Windows WebAuthn API.
+//!
+//! Windows WebAuthn API needs a [HWND] parameter to know where to attach its
+//! UI to, but the `webauthn-authenticator-rs` API doesn't know anything about
+//! [HWND]s.
+//!
+//! Also, when running in a console application, getting a _functional_ [HWND]
+//! is a broken mess, because [GetConsoleWindow] only works properly for
+//! "classical" `cmd.exe` prompts: Windows Terminal
+//! [has focus issues, even though the issue is "closed"][terminal], and VS
+//! Code [also has z-order issues][vscode]. Both make for an awful experience,
+//! and [the normal work-arounds][hack] don't work when a console app can't
+//! set the window title verbatim (such as in VS Code).
+//!
+//! There is some prior art in [windows-fido-bridge], but this ended up with
+//! a distinct design that doesn't hard-code work-arounds for single apps.
+//!
+//! **Warning:** This hasn't yet been tested in a Windows GUI application,
+//! and is subject to change based on user feedback.
+//!
+//! [Window] creates a 1x1 pixel window for Windows WebAuthn API to use:
+//!
+//! * If there is a [current foreground window][GetForegroundWindow],
+//!   our window is a child tool window, and is centred over it. This gives
+//!   focus without intervention, proper z-ordering, and handles DPI scaling.
+//!
+//! * If there is no current foreground window, our window is a pop-up layered
+//!   window, centered on the primary screen, and then made invisible.
+//!
+//! After that, the Windows WebAuthn API will centre its dialog on top of our
+//! [Window] as a child, automatically taking focus.
+//!
+//! [windows-fido-bridge]: https://github.com/mgbowen/windows-fido-bridge/blob/master/src/win32_middleware_common/src/window.cpp
+//! [GetConsoleWindow]: https://learn.microsoft.com/en-us/windows/console/getconsolewindow
+//! [hack]: https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/obtain-console-window-handle
+//! [terminal]: https://github.com/microsoft/terminal/issues/2988
+//! [vscode]: https://github.com/microsoft/vscode/issues/42356
+use crate::error::WebauthnCError;
+use std::{
+    ffi::c_void,
+    mem::size_of,
+    sync::{mpsc::sync_channel, Once},
+    thread,
+};
+use windows::{
+    core::{HSTRING, PCWSTR},
+    w,
+    Win32::{
+        Foundation::{GetLastError, HINSTANCE, HWND, LPARAM, LRESULT, RECT, WPARAM},
+        Graphics::{
+            Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS},
+            Gdi::{GetSysColorBrush, COLOR_WINDOW},
+        },
+        System::LibraryLoader::GetModuleHandleW,
+        UI::WindowsAndMessaging::{
+            CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetForegroundWindow,
+            GetMessageW, GetSystemMetrics, LoadCursorW, LoadIconW, MoveWindow, PostMessageW,
+            PostQuitMessage, RegisterClassExW, SetForegroundWindow, SetLayeredWindowAttributes,
+            TranslateMessage, CS_HREDRAW, CS_OWNDC, CS_VREDRAW, CW_USEDEFAULT, IDC_ARROW,
+            IDI_APPLICATION, LWA_ALPHA, MSG, SM_CXSCREEN, SM_CYSCREEN, WM_CLOSE, WM_DESTROY,
+            WM_QUIT, WNDCLASSEXW, WS_CHILD, WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
+            WS_POPUPWINDOW, WS_VISIBLE,
+        },
+    },
+};
+
+/// [WndProc callback handler][wndproc] for our [WINDOW_CLASS].
+///
+/// [wndproc]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wndproc
+unsafe extern "system" fn window_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    match msg {
+        WM_CLOSE => {
+            DestroyWindow(hwnd);
+            LRESULT(0)
+        }
+        WM_DESTROY => {
+            PostQuitMessage(0);
+            LRESULT(0)
+        }
+        _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}
+
+/// Window class for our [Window].
+const WINDOW_CLASS: &HSTRING = w!("webauthn-authenticator-rs");
+
+/// Gets a module handle for the current process and registers
+/// [WINDOW_CLASS] on first run.
+unsafe fn get_module_handle() -> HINSTANCE {
+    static INIT: Once = Once::new();
+    static mut MODULE_HANDLE: HINSTANCE = HINSTANCE(0);
+
+    INIT.call_once(|| {
+        MODULE_HANDLE = GetModuleHandleW(PCWSTR::null()).expect("GetModuleHandleW");
+
+        let icon = LoadIconW(None, IDI_APPLICATION).expect("LoadIconW");
+        let wnd_class = WNDCLASSEXW {
+            cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+            style: CS_OWNDC | CS_HREDRAW | CS_VREDRAW,
+            lpfnWndProc: Some(window_proc),
+            cbClsExtra: 0,
+            cbWndExtra: 0,
+            hInstance: MODULE_HANDLE,
+            hIcon: icon,
+            hCursor: LoadCursorW(None, IDC_ARROW).expect("LoadCursorW"),
+            hbrBackground: GetSysColorBrush(COLOR_WINDOW),
+            lpszMenuName: PCWSTR::null(),
+            lpszClassName: WINDOW_CLASS.into(),
+            hIconSm: icon,
+        };
+
+        RegisterClassExW(&wnd_class);
+    });
+
+    MODULE_HANDLE
+}
+
+/// Window to act as a parent for Windows WebAuthn API.
+pub struct Window {
+    hwnd: HWND,
+}
+
+impl Window {
+    /// Creates a new window and spawns an event loop in the background.
+    ///
+    /// The window will persist until dropped.
+    pub fn new() -> Result<Self, WebauthnCError> {
+        let (sender, receiver) = sync_channel::<HWND>(0);
+
+        thread::spawn(move || {
+            // trace!("spawned background");
+            // let parent = HWND(0);
+            let parent = unsafe { GetForegroundWindow() };
+            let hwnd = unsafe {
+                let hinstance = get_module_handle();
+                let (style, ex_style) = if parent != HWND(0) {
+                    // Parent: act like a child tool-window, so it doesn't
+                    // appear in alt-tab, but still gets focus.
+                    (WS_CHILD, WS_EX_TOOLWINDOW)
+                } else {
+                    // No parent: act like a normal window so we can be alt-tabbed.
+                    (WS_POPUPWINDOW, WS_EX_LAYERED)
+                };
+
+                // CreateWindowEx is virtualised for DPI scaling, so we'll need
+                // to MoveWindow later.
+                CreateWindowExW(
+                    WS_EX_TOPMOST | ex_style,
+                    WINDOW_CLASS,
+                    WINDOW_CLASS,
+                    style | WS_VISIBLE,
+                    CW_USEDEFAULT,
+                    CW_USEDEFAULT,
+                    1,
+                    1,
+                    parent,
+                    None,
+                    hinstance,
+                    None,
+                )
+            };
+            // trace!(?hwnd);
+
+            if hwnd == HWND(0) {
+                let e = unsafe { GetLastError() };
+                error!("window not created, {:?}", e);
+                sender.send(hwnd).ok();
+                return;
+            }
+
+            // Focus, foreground and reposition our window (if needed).
+            unsafe {
+                if !SetForegroundWindow(hwnd).as_bool() {
+                    trace!("Tried to set the foreground window, but the request was denied.");
+                }
+
+                if parent == HWND(0) {
+                    // When we have an un-parented window, make it invisible
+                    // and put it in the centre of the primary screen.
+                    SetLayeredWindowAttributes(hwnd, None, 0, LWA_ALPHA);
+                    Some((
+                        GetSystemMetrics(SM_CXSCREEN) / 2,
+                        GetSystemMetrics(SM_CYSCREEN) / 2,
+                    ))
+                } else {
+                    // When we have a parent window, MoveWindow is relative to the position
+                    // of the parent.
+                    get_window_rect(parent).map(half_size)
+                }
+                .map(|(x, y)| MoveWindow(hwnd, x, y, 1, 1, true));
+            }
+
+            // Now we can tell the main thread that the window is ready.
+            if sender.send(hwnd).is_err() {
+                return;
+            }
+
+            // Windows event loop
+            let mut msg: MSG = Default::default();
+            loop {
+                let res: bool = unsafe { GetMessageW(&mut msg, None, 0, 0) }.as_bool();
+                if !res {
+                    break;
+                }
+
+                if msg.message == WM_QUIT {
+                    unsafe {
+                        PostQuitMessage(msg.wParam.0 as i32);
+                    }
+                }
+                // trace!(?msg);
+                unsafe {
+                    TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                }
+            }
+            // trace!("background stopped");
+        });
+
+        let hwnd = receiver.recv();
+        match hwnd {
+            Ok(HWND(0)) | Err(_) => Err(WebauthnCError::Internal),
+            Ok(hwnd) => Ok(Self { hwnd }),
+        }
+    }
+}
+
+impl Drop for Window {
+    fn drop(&mut self) {
+        // trace!("dropping window");
+        unsafe {
+            PostMessageW(self.hwnd, WM_CLOSE, None, None);
+        }
+    }
+}
+
+impl From<&Window> for HWND {
+    fn from(w: &Window) -> HWND {
+        w.hwnd
+    }
+}
+
+/// Gets the position of a window in "true" pixels (not virtualised for DPI scaling).
+fn get_window_rect(hwnd: HWND) -> Option<RECT> {
+    let mut r: RECT = Default::default();
+    // GetClientRect and GetWindowRect are virtualised for DPI scaling,
+    // but MoveWindow is not, so we need DWMWA_EXTENDED_FRAME_BOUNDS.
+    unsafe {
+        DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            &mut r as *mut _ as *mut c_void,
+            size_of::<RECT>() as u32,
+        )
+    }
+    .is_ok()
+    .then_some(r)
+}
+
+/// Returns half the size of the [RECT] as `(width, height)`.
+const fn half_size(rect: RECT) -> (i32, i32) {
+    (
+        ((rect.right - rect.left) / 2),
+        ((rect.bottom - rect.top) / 2),
+    )
+}

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -1,0 +1,355 @@
+//! Bindings for Windows 10 WebAuthn API.
+//!
+//! This API is available in Windows 10 bulid 1903 and later.
+//!
+//! ## API docs
+//!
+//! * [MSDN: WebAuthn API](https://learn.microsoft.com/en-us/windows/win32/api/webauthn/)
+//! * [webauthn.h](github.com/microsoft/webauthn) (describes versions)
+//! * [windows-rs API](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WindowsWebServices/index.html)
+mod clientdata;
+mod cose;
+mod credential;
+mod extensions;
+mod gui;
+mod native;
+mod rp;
+mod user;
+
+use crate::error::WebauthnCError;
+use crate::win10::{
+    clientdata::{creation_to_clientdata, get_to_clientdata, WinClientData},
+    cose::WinCoseCredentialParameters,
+    credential::{native_to_transports, WinCredentialList},
+    extensions::{
+        native_to_assertion_extensions, native_to_registration_extensions,
+        WinExtensionMakeCredentialRequest, WinExtensionsRequest,
+    },
+    gui::Window,
+    native::{WinPtr, WinWrapper},
+    rp::WinRpEntityInformation,
+    user::WinUserEntityInformation,
+};
+use crate::{AuthenticatorBackend, Url};
+
+use base64urlsafedata::Base64UrlSafeData;
+use webauthn_rs_proto::{
+    AuthenticatorAssertionResponseRaw, AuthenticatorAttachment,
+    AuthenticatorAttestationResponseRaw, PublicKeyCredential, PublicKeyCredentialCreationOptions,
+    PublicKeyCredentialRequestOptions, RegisterPublicKeyCredential, UserVerificationPolicy,
+};
+
+use windows::{
+    core::{HSTRING, PCWSTR},
+    Win32::{Foundation::BOOL, Networking::WindowsWebServices::*},
+};
+
+use std::slice::from_raw_parts;
+
+/// Authenticator backend for Windows 10 WebAuthn API.
+pub struct Win10 {}
+
+impl Default for Win10 {
+    fn default() -> Self {
+        unsafe {
+            trace!(
+                "WebAuthNGetApiVersionNumber(): {}",
+                WebAuthNGetApiVersionNumber()
+            );
+            match WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable() {
+                Ok(v) => trace!(
+                    "WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable() = {:?}",
+                    <_ as Into<bool>>::into(v)
+                ),
+                Err(e) => trace!("error requesting platform authenticator: {:?}", e),
+            }
+        }
+
+        Self {}
+    }
+}
+
+impl AuthenticatorBackend for Win10 {
+    /// Perform a registration action using Windows WebAuth API.
+    ///
+    /// This wraps [WebAuthNAuthenticatorMakeCredential].
+    ///
+    /// [WebAuthnAuthenticatorMakeCredential]: https://learn.microsoft.com/en-us/windows/win32/api/webauthn/nf-webauthn-webauthnauthenticatormakecredential
+    fn perform_register(
+        &mut self,
+        origin: Url,
+        options: PublicKeyCredentialCreationOptions,
+        timeout_ms: u32,
+    ) -> Result<RegisterPublicKeyCredential, WebauthnCError> {
+        let hwnd = Window::new()?;
+        // let hwnd = get_hwnd().ok_or(WebauthnCError::CannotFindHWND)?;
+        let rp = WinRpEntityInformation::new(&options.rp)?;
+        let userinfo = WinUserEntityInformation::new(&options.user)?;
+        let pubkeycredparams = WinCoseCredentialParameters::new(&options.pub_key_cred_params)?;
+        let clientdata =
+            WinClientData::new(&creation_to_clientdata(origin, options.challenge.clone()))?;
+
+        let mut exclude_credentials = if let Some(e) = options.exclude_credentials.as_ref() {
+            Some(WinCredentialList::new(e)?)
+        } else {
+            None
+        };
+        let extensions = match &options.extensions {
+            Some(e) => WinExtensionsRequest::new(e)?,
+            None => Box::pin(WinExtensionsRequest::<WinExtensionMakeCredentialRequest>::default()),
+        };
+        // trace!("native extn: {:?}", extensions.native_ptr());
+
+        let makecredopts = WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
+            dwVersion: WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION,
+            dwTimeoutMilliseconds: timeout_ms,
+            // Superceded by pExcludeCredentialList for v3 (API v1, baseline)
+            CredentialList: WEBAUTHN_CREDENTIALS {
+                cCredentials: 0,
+                pCredentials: [].as_mut_ptr(),
+            },
+            Extensions: *extensions.native_ptr(),
+            dwAuthenticatorAttachment: attachment_to_native(
+                options
+                    .authenticator_selection
+                    .as_ref()
+                    .map(|s| s.authenticator_attachment)
+                    .unwrap_or(None),
+            ),
+            bRequireResidentKey: options
+                .authenticator_selection
+                .as_ref()
+                .map(|s| s.require_resident_key)
+                .unwrap_or(false)
+                .into(),
+            dwUserVerificationRequirement: user_verification_to_native(
+                options
+                    .authenticator_selection
+                    .as_ref()
+                    .map(|s| &s.user_verification),
+            ),
+            dwAttestationConveyancePreference: 0,
+            dwFlags: 0,
+            pCancellationId: std::ptr::null_mut(),
+            pExcludeCredentialList: match &mut exclude_credentials {
+                None => std::ptr::null(),
+                Some(l) => &l.native,
+            } as *mut _,
+            dwEnterpriseAttestation: 0,
+            dwLargeBlobSupport: 0,
+            bPreferResidentKey: false.into(),
+        };
+
+        // trace!("WebAuthNAuthenticatorMakeCredential()");
+        // trace!("native: {:?}", extensions.native_ptr());
+        // trace!(?makecredopts);
+        let a = unsafe {
+            let r = WebAuthNAuthenticatorMakeCredential(
+                &hwnd,
+                rp.native_ptr(),
+                userinfo.native_ptr(),
+                pubkeycredparams.native_ptr(),
+                clientdata.native_ptr(),
+                Some(&makecredopts),
+            )
+            .map_err(|e| {
+                // TODO: map error codes, if we learn them...
+                error!("Error: {:?}", e);
+                WebauthnCError::Internal
+            })?;
+
+            WinPtr::new(r, |a| WebAuthNFreeCredentialAttestation(Some(a)))
+                .ok_or(WebauthnCError::Internal)?
+        };
+        // These needed to live until WebAuthNAuthenticatorMakeCredential returned.
+        drop(extensions);
+        drop(hwnd);
+
+        // trace!("got result from WebAuthNAuthenticatorMakeCredential");
+        // trace!("{:?}", (*a));
+
+        unsafe {
+            let cred_id: Vec<u8> =
+                from_raw_parts(a.pbCredentialId, a.cbCredentialId as usize).into();
+            let attesation_object =
+                from_raw_parts(a.pbAttestationObject, a.cbAttestationObject as usize).into();
+            let type_: String = a
+                .pwszFormatType
+                .to_string()
+                .map_err(|_| WebauthnCError::Internal)?;
+
+            let id: String = Base64UrlSafeData(cred_id.clone()).to_string();
+
+            Ok(RegisterPublicKeyCredential {
+                id,
+                raw_id: Base64UrlSafeData(cred_id),
+                type_,
+                extensions: native_to_registration_extensions(&a.Extensions)?,
+                response: AuthenticatorAttestationResponseRaw {
+                    attestation_object: Base64UrlSafeData(attesation_object),
+                    client_data_json: Base64UrlSafeData(
+                        clientdata.client_data_json().as_bytes().to_vec(),
+                    ),
+                    transports: Some(native_to_transports(a.dwUsedTransport)),
+                },
+            })
+        }
+    }
+
+    /// Perform an authentication action using Windows WebAuth API.
+    ///
+    /// This wraps [WebAuthNAuthenticatorGetAssertion].
+    ///
+    /// [WebAuthNAuthenticatorGetAssertion]: https://learn.microsoft.com/en-us/windows/win32/api/webauthn/nf-webauthn-webauthnauthenticatorgetassertion
+    fn perform_auth(
+        &mut self,
+        origin: Url,
+        options: PublicKeyCredentialRequestOptions,
+        timeout_ms: u32,
+    ) -> Result<PublicKeyCredential, WebauthnCError> {
+        trace!(?options);
+        let hwnd = Window::new()?;
+        let rp_id: HSTRING = options.rp_id.clone().into();
+        let clientdata = WinClientData::new(&get_to_clientdata(origin, options.challenge.clone()))?;
+
+        let mut allow_credentials = WinCredentialList::new(options.allow_credentials.as_ref())?;
+
+        let app_id: Option<HSTRING> = options
+            .extensions
+            .as_ref()
+            .and_then(|e| e.appid.as_ref())
+            .map(|a| a.clone().into());
+        // Used as a *return* value from GetAssertion as to whether the U2F AppId was used,
+        // equivalent to [AuthenticationExtensionsClientOutputs::appid].
+        //
+        // Why here? Because for some reason, Windows' API decides to put a pointer for
+        // mutable *return* value inside an `_In_opt_ *const ptr` *request* value
+        // ([WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS]): `pbU2fAppId`.
+        //
+        // The documentation was very opaque here, but [Firefox's implementation][ffx]
+        // appears to correctly deal with this nonsense.
+        //
+        // However, [Chromium's implementation][chr] appears to have misunderstood this field,
+        // and always passes in pointers to `static BOOL` values `kUseAppIdTrue` or
+        // `kUseAppIdFalse` (depending on whether the extension was present) and doesn't read
+        // the response.
+        //
+        // Unfortunately, it looks like the WebAuthn API has been frozen for Windows 10, and
+        // the new revisions are only on Windows 11. So it's unlikely this will ever be
+        // properly fixed. 🙃
+        //
+        // [chr]: https://chromium.googlesource.com/chromium/src/+/f62b8f341c14be84c6c995133f485d76a58de090/device/fido/win/webauthn_api.cc#520
+        // [ffx]: https://github.com/mozilla/gecko-dev/blob/620490a051a1fc72563e1c6bbecfe7346122a6bc/dom/webauthn/WinWebAuthnManager.cpp#L714-L716
+        let mut app_id_used: BOOL = false.into();
+        // let extensions = match &options.extensions {
+        //     Some(e) => WinExtensionsRequest::new(e)?,
+        //     None => Box::pin(WinExtensionsRequest::<WinExtensionGetAssertionRequest>::default()),
+        // };
+
+        let getassertopts = WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
+            dwVersion: WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION,
+            dwTimeoutMilliseconds: timeout_ms,
+            // Supersceded by pAllowCredentialList in v4 (API v1, baseline)
+            CredentialList: WEBAUTHN_CREDENTIALS {
+                cCredentials: 0,
+                pCredentials: [].as_mut_ptr(),
+            },
+            // Extensions: *extensions.native_ptr(),
+            Extensions: Default::default(),
+            dwAuthenticatorAttachment: 0, // Not supported?
+            dwUserVerificationRequirement: user_verification_to_native(Some(
+                &options.user_verification,
+            )),
+            dwFlags: 0,
+            pwszU2fAppId: match &app_id {
+                None => PCWSTR::null(),
+                Some(l) => l.into(),
+            },
+            pbU2fAppId: std::ptr::addr_of_mut!(app_id_used),
+            pCancellationId: std::ptr::null_mut(),
+            pAllowCredentialList: &mut allow_credentials.native,
+            dwCredLargeBlobOperation: 0,
+            cbCredLargeBlob: 0,
+            pbCredLargeBlob: std::ptr::null_mut(),
+        };
+
+        // trace!("WebAuthNAuthenticatorGetAssertion()");
+        let a = unsafe {
+            let r = WebAuthNAuthenticatorGetAssertion(
+                &hwnd,
+                &rp_id,
+                clientdata.native_ptr(),
+                Some(&getassertopts),
+            )
+            .map_err(|e| {
+                // TODO: map error codes, if we learn them...
+                error!("Error: {:?}", e);
+                WebauthnCError::Internal
+            })?;
+
+            WinPtr::new(r, WebAuthNFreeAssertion).ok_or(WebauthnCError::Internal)?
+        };
+        // This needed to live until WebAuthNAuthenticatorGetAssertion returned.
+        drop(hwnd);
+        // trace!("got result from WebAuthNAuthenticatorGetAssertion");
+
+        unsafe {
+            let user_id = from_raw_parts(a.pbUserId, a.cbUserId as usize).into();
+            let authenticator_data =
+                from_raw_parts(a.pbAuthenticatorData, a.cbAuthenticatorData as usize).into();
+            let signature = from_raw_parts(a.pbSignature, a.cbSignature as usize).into();
+
+            let credential_id = Base64UrlSafeData(
+                from_raw_parts(a.Credential.pbId, a.Credential.cbId as usize).into(),
+            );
+            let type_ = a
+                .Credential
+                .pwszCredentialType
+                .to_string()
+                .map_err(|_| WebauthnCError::Internal)?;
+
+            let mut extensions = native_to_assertion_extensions(&a.Extensions)?;
+            extensions.appid = Some(app_id_used.into());
+
+            Ok(PublicKeyCredential {
+                id: credential_id.to_string(),
+                raw_id: credential_id,
+                response: AuthenticatorAssertionResponseRaw {
+                    authenticator_data: Base64UrlSafeData(authenticator_data),
+                    client_data_json: Base64UrlSafeData(
+                        clientdata.client_data_json().as_bytes().to_vec(),
+                    ),
+                    signature: Base64UrlSafeData(signature),
+                    user_handle: Some(Base64UrlSafeData(user_id)),
+                },
+                type_,
+                extensions,
+            })
+        }
+    }
+}
+
+/// Converts an [AuthenticatorAttachment] into a value for
+/// [WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS::dwAuthenticatorAttachment]
+fn attachment_to_native(attachment: Option<AuthenticatorAttachment>) -> u32 {
+    use AuthenticatorAttachment::*;
+    match attachment {
+        None => WEBAUTHN_AUTHENTICATOR_ATTACHMENT_ANY,
+        Some(CrossPlatform) => WEBAUTHN_AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM,
+        Some(Platform) => WEBAUTHN_AUTHENTICATOR_ATTACHMENT_PLATFORM,
+    }
+}
+
+/// Converts a [UserVerificationPolicy] into a value for
+/// [WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS::dwUserVerificationRequirement]
+fn user_verification_to_native(policy: Option<&UserVerificationPolicy>) -> u32 {
+    use UserVerificationPolicy::*;
+    match policy {
+        None => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_ANY,
+        Some(p) => match p {
+            Required => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            Preferred => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            Discouraged_DO_NOT_USE => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_DISCOURAGED,
+        },
+    }
+}

--- a/webauthn-authenticator-rs/src/win10/native.rs
+++ b/webauthn-authenticator-rs/src/win10/native.rs
@@ -1,0 +1,60 @@
+//! Helpers for working with Windows native types.
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::pin::Pin;
+
+use crate::error::WebauthnCError;
+
+/// Smart pointer type to automatically `free()` bare pointers we got from
+/// Windows' API when dropped.
+pub struct WinPtr<'a, T: 'a> {
+    free: unsafe fn(*const T) -> (),
+    ptr: *const T,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> WinPtr<'a, T> {
+    /// Creates a wrapper around a `*const T` pointer which automatically calls
+    /// the `free` function when dropped.
+    ///
+    /// Returns `None` if `ptr` is null.
+    ///
+    /// Unsafe if `ptr` is unaligned or does not point to a `T`.
+    pub unsafe fn new(ptr: *const T, free: unsafe fn(*const T) -> ()) -> Option<Self> {
+        if ptr.is_null() {
+            None
+        } else {
+            // trace!("new_ptr: r={:?}", ptr);
+            Some(Self {
+                free,
+                ptr,
+                phantom: PhantomData,
+            })
+        }
+    }
+}
+
+impl<'a, T> Deref for WinPtr<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &(*self.ptr) }
+    }
+}
+
+impl<'a, T> Drop for WinPtr<'a, T> {
+    fn drop(&mut self) {
+        // trace!("free_ptr: r={:?}", self.ptr);
+        unsafe { (self.free)(self.ptr) }
+    }
+}
+
+/// Wrapper for a `webauthn-authenticator-rs` type (`T`) to convert it to a
+/// Windows WebAuthn API type (`NativeType`).
+pub trait WinWrapper<T> {
+    /// Windows equivalent type for `T`
+    type NativeType;
+    /// Converts a `webauthn-authenticator-rs` type to a Windows type
+    fn new(v: &T) -> Result<Pin<Box<Self>>, WebauthnCError>;
+    /// Returns a pointer to the Windows equivalent type
+    fn native_ptr(&self) -> &Self::NativeType;
+}

--- a/webauthn-authenticator-rs/src/win10/rp.rs
+++ b/webauthn-authenticator-rs/src/win10/rp.rs
@@ -1,0 +1,52 @@
+//! Wrappers for [RelyingParty].
+use std::pin::Pin;
+
+use webauthn_rs_proto::RelyingParty;
+use windows::{
+    core::{HSTRING, PCWSTR},
+    Win32::Networking::WindowsWebServices::{
+        WEBAUTHN_RP_ENTITY_INFORMATION, WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
+    },
+};
+
+use super::WinWrapper;
+use crate::error::WebauthnCError;
+
+/// Wrapper for [WEBAUTHN_RP_ENTITY_INFORMATION] to ensure pointer lifetime.
+pub struct WinRpEntityInformation {
+    native: WEBAUTHN_RP_ENTITY_INFORMATION,
+    id: HSTRING,
+    name: HSTRING,
+}
+
+impl WinWrapper<RelyingParty> for WinRpEntityInformation {
+    type NativeType = WEBAUTHN_RP_ENTITY_INFORMATION;
+    fn new(rp: &RelyingParty) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        let res = Self {
+            native: Default::default(),
+            id: rp.id.clone().into(),
+            name: rp.name.clone().into(),
+        };
+
+        let mut boxed = Box::pin(res);
+
+        let native = WEBAUTHN_RP_ENTITY_INFORMATION {
+            dwVersion: WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
+            pwszId: (&boxed.id).into(),
+            pwszName: (&boxed.name).into(),
+            pwszIcon: PCWSTR::null(),
+        };
+
+        // Update the boxed type with the proper native object.
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        Ok(boxed)
+    }
+
+    fn native_ptr(&self) -> &WEBAUTHN_RP_ENTITY_INFORMATION {
+        &self.native
+    }
+}

--- a/webauthn-authenticator-rs/src/win10/user.rs
+++ b/webauthn-authenticator-rs/src/win10/user.rs
@@ -1,0 +1,58 @@
+//! Wrappers for [User].
+use std::pin::Pin;
+
+use webauthn_rs_proto::User;
+use windows::{
+    core::{HSTRING, PCWSTR},
+    Win32::Networking::WindowsWebServices::{
+        WEBAUTHN_USER_ENTITY_INFORMATION, WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
+    },
+};
+
+use super::WinWrapper;
+use crate::error::WebauthnCError;
+
+/// Wrapper for [WEBAUTHN_USER_ENTITY_INFORMATION] to ensure pointer lifetime, analgous to [User].
+pub struct WinUserEntityInformation {
+    native: WEBAUTHN_USER_ENTITY_INFORMATION,
+    _id: String,
+    _name: HSTRING,
+    _display_name: HSTRING,
+}
+
+impl WinWrapper<User> for WinUserEntityInformation {
+    type NativeType = WEBAUTHN_USER_ENTITY_INFORMATION;
+    fn new(u: &User) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        // Construct an incomplete type first, so that all the pointers are fixed.
+        let res = Self {
+            native: WEBAUTHN_USER_ENTITY_INFORMATION::default(),
+            _id: u.id.clone().to_string(),
+            _name: u.name.clone().into(),
+            _display_name: u.display_name.clone().into(),
+        };
+
+        let mut boxed = Box::pin(res);
+
+        // Create the real native type, which contains bare pointers.
+        let native = WEBAUTHN_USER_ENTITY_INFORMATION {
+            dwVersion: WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
+            cbId: boxed._id.len() as u32,
+            pbId: boxed._id.as_ptr() as *mut _,
+            pwszName: (&boxed._name).into(),
+            pwszIcon: PCWSTR::null(),
+            pwszDisplayName: (&boxed._display_name).into(),
+        };
+
+        // Update the boxed type with the proper native object.
+        unsafe {
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref).native = native;
+        }
+
+        Ok(boxed)
+    }
+
+    fn native_ptr(&self) -> &WEBAUTHN_USER_ENTITY_INFORMATION {
+        &self.native
+    }
+}


### PR DESCRIPTION
This adds support for Windows 10's WebAuthn API. This is effectively mandatory on Windows 10 Build 1903 and later, as it blocks direct access to FIDO authenticators for non-Administrator users.

https://user-images.githubusercontent.com/246847/194449801-4e6b89e5-0465-4dea-8dc9-bf2508373147.mp4

This also adds a new `authenticate` example, pulled from `SoftToken`'s unit tests.

Tasks remaining:

- [x] Finish populating `WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS`
- [x] Implement `perform_auth`
- [x] Come up with a reliable way to get/pass the `HWND` for the application window
- [x] Find a way to pass in application info
- [x] There's probably lifetime issues here, lots of raw pointers... Microsoft's `windows` crate has a very `unsafe` API
- [x] Make new test program for making test credentials (rather than stomping nfc_token_info...
- [x] Remove `println!` debugging
- [x] Set up CI on Windows (#212)
- [x] Split all the non-Windows changes out of this PR (#211 #210)

Fixes #

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
