### PR TITLE
Add AuthenticationAlgorithm::rsassa_pkcsv15_sha256_raw

### DIFF
--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -289,6 +289,9 @@ pub enum AuthenticationAlgorithm {
     /// secp384r1_ecdsa_sha384_raw
     #[serde(rename = "secp384r1_ecdsa_sha384_raw")]
     Secp384r1EcdsaSha384Raw,
+    /// rsassa_pkcsv15_sha256_raw
+    #[serde(rename = "rsassa_pkcsv15_sha256_raw")]
+    RsassaPkcsv15Sha256Raw,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Running `fido-mds-tool` against [current metadata](https://mds3.fidoalliance.org/) returns an error:

```
DEBUG compact_jwt::jws: Invalid Jwt - Serde Error e=Error("unknown variant `rsassa_pkcsv15_sha256_raw`, expected one of `secp256r1_ecdsa_sha256_raw`, `secp256r1_ecdsa_sha256_der`, `secp256k1_ecdsa_sha256_raw`, `rsa_emsa_pkcs1_sha256_raw`, `ed25519_eddsa_sha512_raw`, `secp384r1_ecdsa_sha384_raw`", line: 1, column: 1206200)
ERROR fido_mds_tool: e=InvalidJwt
```

This adds the missing algorithm.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
