### PR TITLE
Remove support for credBlob, per #206

### DIFF
--- a/compat_tester/webauthn-rs-demo-wasm/src/compat.rs
+++ b/compat_tester/webauthn-rs-demo-wasm/src/compat.rs
@@ -101,7 +101,6 @@ fn reg_extensions_full() -> RequestRegistrationExtensions {
                 CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIDList,
             enforce_credential_protection_policy: Some(false),
         }),
-        cred_blob: None,
         uvm: Some(true),
         cred_props: Some(true),
         min_pin_length: Some(true),
@@ -112,7 +111,6 @@ fn reg_extensions_full() -> RequestRegistrationExtensions {
 fn auth_extensions_full() -> RequestAuthenticationExtensions {
     RequestAuthenticationExtensions {
         appid: None,
-        get_cred_blob: None,
         uvm: Some(true),
     }
 }

--- a/compat_tester/webauthn-rs-demo/src/actors.rs
+++ b/compat_tester/webauthn-rs-demo/src/actors.rs
@@ -254,12 +254,6 @@ impl WebauthnActor {
 
         debug!("handle ChallengeRegister -> {:?}", username);
 
-        /*
-        let exts = RequestRegistrationExtensions::builder()
-            .cred_blob(vec![0xde, 0xad, 0xbe, 0xef])
-            .build();
-        */
-
         let user_unique_id = Uuid::new_v4();
 
         let (ccr, rs) = self.wan.generate_challenge_register_options(
@@ -293,12 +287,6 @@ impl WebauthnActor {
         } = auth_settings;
 
         debug!("handle ChallengeAuthenticate -> {:?}", username);
-
-        /*
-        let exts = RequestAuthenticationExtensions::builder()
-            .get_cred_blob(true)
-            .build();
-        */
 
         // If use_cred_id is set, only allow this cred to be used. This also allows
         // some extra "stuff".

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -194,8 +194,6 @@ impl WebauthnCore {
 
         // Have a UV strict?
 
-        // CredBlob needs to limit to 32 bytes.
-
         // minPinLength
 
         // hmacSecret

--- a/webauthn-rs-core/src/proto.rs
+++ b/webauthn-rs-core/src/proto.rs
@@ -46,7 +46,6 @@ pub struct RequestAuthenticationExtensionsBuilder(RequestAuthenticationExtension
 impl RequestAuthenticationExtensionsBuilder {
     pub(crate) fn new() -> Self {
         Self(RequestAuthenticationExtensions {
-            get_cred_blob: Some(CredBlobGet(false)),
             appid: None,
         })
     }
@@ -54,22 +53,6 @@ impl RequestAuthenticationExtensionsBuilder {
     /// Returns the inner extensions struct
     pub fn build(self) -> RequestAuthenticationExtensions {
         self.0
-    }
-
-    /// Set whether you want to get the credential blob extension
-    ///
-    /// # Example
-    /// ```
-    /// # use webauthn_rs_core::proto::{RequestAuthenticationExtensions, CredBlobGet};
-    /// let extensions = RequestAuthenticationExtensions::builder()
-    ///     .get_cred_blob(true)
-    ///     .build();
-    ///
-    /// assert_eq!(extensions.get_cred_blob, Some(CredBlobGet(true)));
-    /// ```
-    pub fn get_cred_blob(mut self, get_cred_blob: bool) -> Self {
-        self.0.get_cred_blob = Some(CredBlobGet(get_cred_blob));
-        self
     }
 
     /// Set the AppId extension, for backwards compatibility with FIDO U2F credentials
@@ -105,7 +88,6 @@ impl RequestRegistrationExtensionsBuilder {
     pub(crate) fn new() -> Self {
         Self(RequestRegistrationExtensions {
             cred_protect: None,
-            cred_blob: None,
         })
     }
 
@@ -131,23 +113,6 @@ impl RequestRegistrationExtensionsBuilder {
     /// ```
     pub fn cred_protect(mut self, cred_protect: CredProtect) -> Self {
         self.0.cred_protect = Some(cred_protect);
-        self
-    }
-
-    /// Set the credential blob extension options
-    ///
-    /// # Example
-    /// ```
-    /// # use webauthn_rs_core::proto::{RequestRegistrationExtensions, CredBlobSet};
-    /// let cred_blob = vec![0xde, 0xad, 0xbe, 0xef];
-    /// let extensions = RequestRegistrationExtensions::builder()
-    ///     .cred_blob(cred_blob.clone())
-    ///     .build();
-    ///
-    /// assert_eq!(extensions.cred_blob, Some(CredBlobSet::from(cred_blob)));
-    /// ```
-    pub fn cred_blob(mut self, cred_blob: Vec<u8>) -> Self {
-        self.0.cred_blob = Some(CredBlobSet(Base64UrlSafeData(cred_blob)));
         self
     }
 }

--- a/webauthn-rs-proto/src/attest.rs
+++ b/webauthn-rs-proto/src/attest.rs
@@ -68,12 +68,8 @@ impl From<CreationChallengeResponse> for web_sys::CredentialCreationOptions {
         let user = js_sys::Reflect::get(&pkcco, &"user".into()).unwrap();
         js_sys::Reflect::set(&user, &"id".into(), &userid).unwrap();
 
-        if let Some(extensions) = ccr.public_key.extensions {
-            if let Some(cred_blob) = extensions.cred_blob {
-                let exts = js_sys::Reflect::get(&pkcco, &"extensions".into()).unwrap();
-                let cred_blob = Uint8Array::from(cred_blob.0.as_ref());
-                js_sys::Reflect::set(&exts, &"credBlob".into(), &cred_blob).unwrap();
-            }
+        if let Some(_extensions) = ccr.public_key.extensions {
+            // TODO: Add registration extensions here
         }
 
         if let Some(exclude_credentials) = ccr.public_key.exclude_credentials {

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -432,7 +432,6 @@ impl Webauthn {
 
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: None,
-            cred_blob: None,
             uvm: Some(true),
             cred_props: Some(true),
             min_pin_length: None,
@@ -908,7 +907,6 @@ impl Webauthn {
 
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: None,
-            cred_blob: None,
             uvm: Some(true),
             cred_props: Some(true),
             min_pin_length: Some(true),
@@ -982,7 +980,6 @@ impl Webauthn {
         let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
 
         let extensions = Some(RequestAuthenticationExtensions {
-            get_cred_blob: None,
             appid: None,
             uvm: Some(true),
         });
@@ -1037,7 +1034,6 @@ impl Webauthn {
     ) -> WebauthnResult<(RequestChallengeResponse, DiscoverableAuthentication)> {
         let policy = UserVerificationPolicy::Required;
         let extensions = Some(RequestAuthenticationExtensions {
-            get_cred_blob: None,
             appid: None,
             uvm: Some(true),
         });
@@ -1104,7 +1100,6 @@ impl Webauthn {
                 // then enforce it there.
                 enforce_credential_protection_policy: Some(false),
             }),
-            cred_blob: None,
             // https://www.w3.org/TR/webauthn-2/#sctn-uvm-extension
             uvm: Some(true),
             cred_props: Some(true),
@@ -1167,7 +1162,6 @@ impl Webauthn {
     ) -> WebauthnResult<(RequestChallengeResponse, DeviceKeyAuthentication)> {
         let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
         let extensions = Some(RequestAuthenticationExtensions {
-            get_cred_blob: None,
             appid: None,
             uvm: Some(true),
         });


### PR DESCRIPTION
Per discussion on #206, this removes support for the `credBlob` extension:

* `webauthn-authenticator-rs` didn't implement it correctly (#206)
* I could only find _two_ keys in FIDO's MDS which support this (ATKey.Pro and YubiKey Bio)
* [The extension appears to be exclusively used for Microsoft's corporate Active Directory](https://groups.google.com/a/chromium.org/g/blink-dev/c/Vfg2o0peyYg/m/Vp0h8i5VBQAJ)
* The `User.id` supports up to 64 bytes of arbitrary data and is supported by all CTAP2 authenticators (`credBlob` is only 32 bytes)
* The [`largeBlob` extension](https://www.w3.org/TR/webauthn-2/#sctn-large-blob-extension) supports even more data, and appears to replace it

---

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
