### PR TITLE
Add common fields from win10 branch

### DIFF
--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -74,9 +74,11 @@ pub struct User {
     /// must NOT contain personally identifying information, as this value can NEVER
     /// be changed. If in doubt, use a UUID.
     pub id: Base64UrlSafeData,
-    /// A detailed name for the account, such as an email address.
+    /// A detailed name for the account, such as an email address. This value
+    /// **can** change, so **must not** be used as a primary key.
     pub name: String,
-    /// The user's preferred name for display.
+    /// The user's preferred name for display. This value **can** change, so
+    /// **must not** be used as a primary key.
     pub display_name: String,
     // Note: "icon" is deprecated: https://github.com/w3c/webauthn/pull/1337
 }

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -63,6 +63,7 @@ pub struct RelyingParty {
     pub name: String,
     /// The id of the relying party.
     pub id: String,
+    // Note: "icon" is deprecated: https://github.com/w3c/webauthn/pull/1337
 }
 
 /// User Entity
@@ -73,10 +74,11 @@ pub struct User {
     /// must NOT contain personally identifying information, as this value can NEVER
     /// be changed. If in doubt, use a UUID.
     pub id: Base64UrlSafeData,
-    /// The users preferred name for display.
+    /// A detailed name for the account, such as an email address.
     pub name: String,
-    /// The users preferred name for display.
+    /// The user's preferred name for display.
     pub display_name: String,
+    // Note: "icon" is deprecated: https://github.com/w3c/webauthn/pull/1337
 }
 
 /// Public key cryptographic parameters
@@ -119,6 +121,8 @@ pub enum AuthenticatorTransport {
     Ble,
     /// <https://www.w3.org/TR/webauthn/#dom-authenticatortransport-internal>
     Internal,
+    /// Test transport; used for Windows 10.
+    Test,
     // ///
     // Hybrid
 }


### PR DESCRIPTION
* Add `RegistrationExtensionsClientOutputs` fields `hmac_secret`, `cred_protect`, `min_pin_length`
* Add `AuthenticatorTransport::Test`
* Note missing icon for `User` and `RelyingParty`
* Fix `User::name` docstring

Fixes #

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
