### PR TITLE
Remove icon support from u2fhid

### DIFF
--- a/webauthn-authenticator-rs/src/u2fhid.rs
+++ b/webauthn-authenticator-rs/src/u2fhid.rs
@@ -141,12 +141,10 @@ impl AuthenticatorBackend for U2FHid {
             relying_party: RelyingParty {
                 id: options.rp.id,
                 name: Some(options.rp.name),
-                icon: None,
             },
             origin: origin.to_string(),
             user: User {
                 id: options.user.id.0,
-                icon: None,
                 name: Some(options.user.name),
                 display_name: Some(options.user.display_name),
             },


### PR DESCRIPTION
This appears to have leaked out an earlier version of #204, which added icons.