### PR TITLE
Allow checking of aaguids in attestation code.

### DIFF
--- a/base64urlsafedata/src/lib.rs
+++ b/base64urlsafedata/src/lib.rs
@@ -16,8 +16,10 @@
 
 use serde::de::{Error, SeqAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Borrow;
 use std::convert::TryFrom;
 use std::fmt;
+use std::hash::Hash;
 
 static ALLOWED_DECODING_FORMATS: &[base64::Config] = &[
     base64::URL_SAFE_NO_PAD,
@@ -26,7 +28,7 @@ static ALLOWED_DECODING_FORMATS: &[base64::Config] = &[
     base64::STANDARD_NO_PAD,
 ];
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 /// A container for binary that should be base64 encoded in serialisation. In reverse
 /// when deserializing, will decode from many different types of base64 possible.
 pub struct Base64UrlSafeData(pub Vec<u8>);
@@ -38,6 +40,12 @@ impl fmt::Display for Base64UrlSafeData {
             "{}",
             base64::encode_config(&self, base64::URL_SAFE_NO_PAD)
         )
+    }
+}
+
+impl Borrow<[u8]> for Base64UrlSafeData {
+    fn borrow(&self) -> &[u8] {
+        self.0.as_slice()
     }
 }
 

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -25,6 +25,7 @@ webauthn-rs-proto = { version = "0.4.7", path = "../webauthn-rs-proto" }
 
 tracing = "0.1"
 url = "2"
+uuid = "1"
 serde_json = "1.0"
 nom = "7.1"
 serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }

--- a/webauthn-authenticator-rs/examples/authenticate/main.rs
+++ b/webauthn-authenticator-rs/examples/authenticate/main.rs
@@ -99,7 +99,7 @@ fn main() {
             Some(RequestAuthenticationExtensions {
                 appid: Some("example.app.id".to_string()),
                 uvm: None,
-                hmac_get_secret: None
+                hmac_get_secret: None,
             }),
         )
         .unwrap();

--- a/webauthn-rs-core/src/error.rs
+++ b/webauthn-rs-core/src/error.rs
@@ -145,6 +145,12 @@ pub enum WebauthnError {
     #[error("The attestation was parsed, but is not a format valid for CA chain validation")]
     AttestationNotVerifiable,
 
+    #[error("The attestation CA that was trusted limits the aaguids allowed, this device is not a member of that set")]
+    AttestationUntrustedAaguid,
+
+    #[error("The attestation CA that was trusted limits the aaguids allowed, but this device does not have an aaguid")]
+    AttestationFormatMissingAaguid,
+
     #[error(
         "The attestation was parsed, but is not trusted by one of the selected CA certificates"
     )]


### PR DESCRIPTION
Improves #138 - This allows verification of the attested AAGUID and it's association to a specific CA that provided it. This maps cleanly to the fido MDS where a CA can sign multiple AAGUIDS, but an AAGUID must only be signed by a single CA. This is working towards the ability to do strict attestation policy. 

Next step will be to allow converting the fido-mds structures into the Attestation CA. I think I will also improve the Attestation CA and Attestation CA List code into proper builder patterns to assist with this. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
