### PR TITLE
Add hybrid transport

### DIFF
--- a/webauthn-authenticator-rs/src/win10/credential.rs
+++ b/webauthn-authenticator-rs/src/win10/credential.rs
@@ -30,6 +30,8 @@ fn transport_to_native(transport: &AuthenticatorTransport) -> u32 {
         AuthenticatorTransport::Nfc => WEBAUTHN_CTAP_TRANSPORT_NFC,
         AuthenticatorTransport::Test => WEBAUTHN_CTAP_TRANSPORT_TEST,
         AuthenticatorTransport::Usb => WEBAUTHN_CTAP_TRANSPORT_USB,
+        // This transport has not platform equivalent on windows, mask to 0.
+        AuthenticatorTransport::Hybrid => 0,
     }
 }
 

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -123,10 +123,11 @@ pub enum AuthenticatorTransport {
     Ble,
     /// <https://www.w3.org/TR/webauthn/#dom-authenticatortransport-internal>
     Internal,
+    /// Hybrid transport, formerly caBLE. Part of the level 3 draft specification.
+    /// <https://w3c.github.io/webauthn/#dom-authenticatortransport-hybrid>
+    Hybrid,
     /// Test transport; used for Windows 10.
     Test,
-    // ///
-    // Hybrid
 }
 
 /// <https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor>


### PR DESCRIPTION
Fixes #219 - Add hybrid transport. This is technically only part of the level 3 draft specification, but according to #219 it's now out in the wild. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
