### PR TITLE
Common code changes from transport-auth (#215)

### DIFF
--- a/webauthn-rs-core/src/crypto.rs
+++ b/webauthn-rs-core/src/crypto.rs
@@ -664,6 +664,7 @@ impl TryFrom<(COSEAlgorithm, &x509::X509)> for COSEKey {
             | COSEAlgorithm::PS384
             | COSEAlgorithm::PS512
             | COSEAlgorithm::EDDSA
+            | COSEAlgorithm::PinUvProtocol
             | COSEAlgorithm::INSECURE_RS1 => {
                 error!(
                     "unsupported X509 to COSE conversion for COSE algorithm type {:?}",

--- a/webauthn-rs-proto/src/cose.rs
+++ b/webauthn-rs-proto/src/cose.rs
@@ -34,6 +34,10 @@ pub enum COSEAlgorithm {
     /// Identifies this as an INSECURE RS1 aka RSASSA-PKCS1-v1_5 using SHA-1. This is not
     /// used by validators, but can exist in some windows hello tpm's
     INSECURE_RS1 = -65535,
+    /// Identifies this key as the protocol used for [PIN/UV Auth Protocol One](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto1)
+    ///
+    /// This reports as algorithm `-25`, but it is a lie. Don't include this in any algorithm lists.
+    PinUvProtocol,
 }
 
 impl COSEAlgorithm {


### PR DESCRIPTION
* `AuthenticatorTransport`: add `FromStr` and `ToString` impls – avoids calling out to `serde` for string conversions
* `COSEAlgorithm`: add the fake `PinUvProtocol` key type needed for PIN/UV auth
* `cose`: add helpers for conversion to/from `openssl` types

- [x] cargo fmt has been run
- [ ] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
