### PR TITLE
Improve OpenSSL error handling, and pull sha256 function into util

### DIFF
--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -10,7 +10,7 @@ pub enum WebauthnCError {
     PlatformAuthenticator,
     Internal,
     ParseNOMFailure,
-    OpenSSL,
+    OpenSSL(String),
     ApduConstruction,
     ApduTransmission,
     InvalidAlgorithm,
@@ -26,5 +26,11 @@ impl From<Error> for WebauthnCError {
             Error::DataTooLong => WebauthnCError::MessageTooLarge,
             _ => WebauthnCError::Internal,
         }
+    }
+}
+
+impl From<openssl::error::ErrorStack> for WebauthnCError {
+    fn from(v: openssl::error::ErrorStack) -> Self {
+        Self::OpenSSL(v.to_string())
     }
 }

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -37,6 +37,7 @@ pub mod error;
 pub mod softpasskey;
 pub mod softtoken;
 pub mod transport;
+mod util;
 
 #[cfg(feature = "nfc")]
 pub mod nfc;

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -1,4 +1,5 @@
 use crate::error::WebauthnCError;
+use crate::util::compute_sha256;
 use crate::AuthenticatorBackend;
 use crate::Url;
 use openssl::x509::{
@@ -12,8 +13,6 @@ use std::collections::HashMap;
 use std::iter;
 use uuid::Uuid;
 
-use openssl::sha;
-
 use base64urlsafedata::Base64UrlSafeData;
 
 use webauthn_rs_proto::{
@@ -22,12 +21,6 @@ use webauthn_rs_proto::{
     PublicKeyCredential, PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
     RegisterPublicKeyCredential, RegistrationExtensionsClientOutputs, UserVerificationPolicy,
 };
-
-fn compute_sha256(data: &[u8]) -> [u8; 32] {
-    let mut hasher = sha::Sha256::new();
-    hasher.update(data);
-    hasher.finish()
-}
 
 pub const AAGUID: Uuid = uuid::uuid!("0fb9bcbc-a0d4-4042-bbb0-559bc1631e28");
 
@@ -167,10 +160,7 @@ fn build_intermediate(
 
 impl SoftToken {
     pub fn new() -> Result<(Self, X509), WebauthnCError> {
-        let (ca_key, ca_cert) = build_ca().map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let (ca_key, ca_cert) = build_ca()?;
 
         let ca = ca_cert.clone();
         /*
@@ -184,11 +174,7 @@ impl SoftToken {
         );
         */
 
-        let (intermediate_key, intermediate_cert) =
-            build_intermediate(&ca_key, &ca_cert).map_err(|e| {
-                error!("OpenSSL Error -> {:?}", e);
-                WebauthnCError::OpenSSL
-            })?;
+        let (intermediate_key, intermediate_cert) = build_intermediate(&ca_key, &ca_cert)?;
 
         /*
         // Disabled as older openssl versions can't provide this.
@@ -403,46 +389,23 @@ impl AuthenticatorBackend for SoftToken {
         // Generate a random credential id
         let mut key_handle: Vec<u8> = Vec::with_capacity(32);
         key_handle.resize_with(32, Default::default);
-        rand::rand_bytes(key_handle.as_mut_slice()).map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        rand::rand_bytes(key_handle.as_mut_slice())?;
 
         // Create a new key.
-        let ecgroup = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1).map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let ecgroup = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1)?;
 
-        let eckey = ec::EcKey::generate(&ecgroup).map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let eckey = ec::EcKey::generate(&ecgroup)?;
 
         // Extract the public x and y coords.
         let ecpub_points = eckey.public_key();
 
-        let mut bnctx = bn::BigNumContext::new().map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let mut bnctx = bn::BigNumContext::new()?;
 
-        let mut xbn = bn::BigNum::new().map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let mut xbn = bn::BigNum::new()?;
 
-        let mut ybn = bn::BigNum::new().map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let mut ybn = bn::BigNum::new()?;
 
-        ecpub_points
-            .affine_coordinates_gfp(&ecgroup, &mut xbn, &mut ybn, &mut bnctx)
-            .map_err(|e| {
-                error!("OpenSSL Error -> {:?}", e);
-                WebauthnCError::OpenSSL
-            })?;
+        ecpub_points.affine_coordinates_gfp(&ecgroup, &mut xbn, &mut ybn, &mut bnctx)?;
 
         let mut public_key_x = Vec::with_capacity(32);
         let mut public_key_y = Vec::with_capacity(32);
@@ -460,10 +423,7 @@ impl AuthenticatorBackend for SoftToken {
         y_fill.copy_from_slice(&ybnv);
 
         // Extract the DER cert for later
-        let ecpriv_der = eckey.private_key_to_der().map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let ecpriv_der = eckey.private_key_to_der()?;
 
         // =====
 
@@ -531,20 +491,12 @@ impl AuthenticatorBackend for SoftToken {
 
         // Now setup to sign.
         // NOTE: for the token version we use the intermediate!
-        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &self.intermediate_key)
-            .map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &self.intermediate_key)?;
 
         // Do the signature
         let signature = signer
             .update(verification_data.as_slice())
-            .and_then(|_| signer.sign_to_vec())
-            .map_err(|e| {
-                error!("OpenSSL Error -> {:?}", e);
-                WebauthnCError::OpenSSL
-            })?;
+            .and_then(|_| signer.sign_to_vec())?;
 
         let mut attest_map = BTreeMap::new();
 
@@ -555,10 +507,7 @@ impl AuthenticatorBackend for SoftToken {
         let mut att_stmt_map = BTreeMap::new();
         att_stmt_map.insert(Value::Text("alg".to_string()), Value::Integer(-7));
 
-        let x509_bytes = Value::Bytes(self.intermediate_cert.to_der().map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?);
+        let x509_bytes = Value::Bytes(self.intermediate_cert.to_der()?);
 
         att_stmt_map.insert(
             Value::Text("x5c".to_string()),
@@ -728,20 +677,11 @@ impl U2FToken for SoftToken {
 
         debug!("Using -> {:?}", key_handle);
 
-        let eckey = ec::EcKey::private_key_from_der(pkder.as_slice()).map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let eckey = ec::EcKey::private_key_from_der(pkder.as_slice())?;
 
-        let pkey = pkey::PKey::from_ec_key(eckey).map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let pkey = pkey::PKey::from_ec_key(eckey)?;
 
-        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &pkey).map_err(|e| {
-            error!("OpenSSL Error -> {:?}", e);
-            WebauthnCError::OpenSSL
-        })?;
+        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &pkey)?;
 
         // Increment the counter.
         self.counter += 1;
@@ -758,11 +698,7 @@ impl U2FToken for SoftToken {
 
         let signature = signer
             .update(verification_data.as_slice())
-            .and_then(|_| signer.sign_to_vec())
-            .map_err(|e| {
-                error!("OpenSSL Error -> {:?}", e);
-                WebauthnCError::OpenSSL
-            })?;
+            .and_then(|_| signer.sign_to_vec())?;
 
         Ok(U2FSignData {
             key_handle,

--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -178,7 +178,7 @@ impl Token for USBToken {
     fn init(&mut self) -> Result<(), WebauthnCError> {
         // Setup a channel to communicate with the device (CTAPHID_INIT).
         let mut nonce: [u8; 8] = [0; 8];
-        rand_bytes(&mut nonce).map_err(|_| WebauthnCError::OpenSSL)?;
+        rand_bytes(&mut nonce)?;
 
         self.send(&U2FHIDFrame {
             cid: CID_BROADCAST,

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -1,0 +1,7 @@
+use openssl::sha;
+
+pub fn compute_sha256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = sha::Sha256::new();
+    hasher.update(data);
+    hasher.finish()
+}


### PR DESCRIPTION
Splitting up https://github.com/kanidm/webauthn-rs/pull/215 to make it smaller:

* Improves OpenSSL error handling by making a nice conversion from `ErrorStack` to `WebauthnCError`
* Refactor `softtoken` and `softpasskey` to use simplified code
* Pull `compute_sha256` into `util` module to de-dupe

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
