### PR TITLE
Add basic support for caBLE authenticators / initiators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,11 @@ jobs:
         rust_version: [stable, 1.45.0]
         features:
           - ""
+          - --features cable
           - --features nfc
           - --features usb
           - --features nfc,usb
+          - --features cable,nfc,usb
         os:
           - ubuntu-latest
           - windows-latest
@@ -24,7 +26,7 @@ jobs:
             features: --features win10
             rust_version: stable
           - os: windows-latest
-            features: --features nfc,usb,win10
+            features: --features cable,nfc,usb,win10
             rust_version: stable
         exclude:
           - os: windows-latest
@@ -46,6 +48,8 @@ jobs:
         run: sudo apt-get -y install libpcsclite-dev
       - if: contains(matrix.features, 'usb') && runner.os != 'windows'
         run: sudo apt-get -y install libusb-1.0-0-dev
+      - if: contains(matrix.features, 'cable') && runner.os != 'windows'
+        run: sudo apt-get -y install libdbus-1-dev
 
       - if: runner.os == 'windows'
         uses: johnwason/vcpkg-action@v4

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -12,6 +12,11 @@ repository = "https://github.com/kanidm/webauthn-rs"
 nfc_raw_transmit = ["nfc"]
 u2fhid = ["authenticator"]
 
+# BTLE authenticators are not yet supported - this is currently only for caBLE
+bluetooth = ["btleplug"]
+
+# caBLE / hybrid authenticator
+cable = ["bluetooth", "hex", "tokio", "tokio-tungstenite", "qrcode"]
 nfc = ["pcsc"]
 usb = ["hidapi"]
 win10 = ["windows"]
@@ -52,12 +57,25 @@ async-trait = "0.1.58"
 futures = "0.3.25"
 
 qrcode = { version = "^0.12.0", optional = true }
+# btleplug pinned due to https://github.com/deviceplug/btleplug/issues/289
+# Advertisements for the same device get dropped by bluez (Linux).
+btleplug = { git = "https://github.com/deviceplug/btleplug.git", rev = "bb3212df36cfd00a1d5788de790240858847a5f1", optional = true }
+tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"], optional = true }
+tokio-tungstenite = { version = "0.18.0", features = ["native-tls"], optional = true }
+hex = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
 clap = { version = "^3.2", features = ["derive", "env"] }
 tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"] }
 tempfile = { version = "3.3.0" }
+
+# cable_tunnel - used for connecting to Bluetooth HCI controller over serial
+serialport = { version = "4.2.0" }
+serialport-hci = { git = "https://github.com/micolous/serialport-hci.git", rev = "7931ad32510ac162f9c4e1147bdd411e40cffa0e" }
+bluetooth-hci = { git = "https://github.com/micolous/bluetooth-hci.git", rev = "04f98f734b0b9f0304e433335357307f63f6bc26" }
+bardecoder = "0.4.0"
+image = "0.23"
 
 [build-dependencies]
 openssl = "0.10"

--- a/webauthn-authenticator-rs/examples/authenticate/main.rs
+++ b/webauthn-authenticator-rs/examples/authenticate/main.rs
@@ -63,6 +63,10 @@ enum Provider {
     /// Requires administrative permissions on Windows.
     Ctap,
 
+    #[cfg(feature = "cable")]
+    /// caBLE/Hybrid authenticator, using a QR code, BTLE and Websockets.
+    Cable,
+
     #[cfg(feature = "u2fhid")]
     /// Mozilla webauthn-authenticator-rs provider, supporting USB HID only.
     Mozilla,
@@ -94,6 +98,12 @@ impl Provider {
                 }
             }
             Provider::Ctap => Box::new(select_transport(ui)),
+            #[cfg(feature = "cable")]
+            Provider::Cable => Box::new(
+                webauthn_authenticator_rs::cable::connect_cable_authenticator(request_type, ui)
+                    .await
+                    .unwrap(),
+            ),
             #[cfg(feature = "u2fhid")]
             Provider::Mozilla => Box::new(webauthn_authenticator_rs::u2fhid::U2FHid::default()),
             #[cfg(feature = "win10")]

--- a/webauthn-authenticator-rs/examples/cable_tunnel/core.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel/core.rs
@@ -1,0 +1,243 @@
+use bluetooth_hci::{
+    host::{
+        uart::{CommandHeader, Hci as UartHci, Packet},
+        AdvertisingFilterPolicy, AdvertisingParameters, Channels, Hci, OwnAddressType,
+    },
+    types::{Advertisement, AdvertisingInterval, AdvertisingType},
+    BdAddr, BdAddrType,
+};
+use clap::{ArgGroup, Parser};
+use openssl::rand::rand_bytes;
+use serialport::FlowControl;
+use serialport_hci::{
+    vendor::none::{Event, Vendor},
+    SerialController,
+};
+use std::{fmt::Debug, fs::OpenOptions, time::Duration};
+
+use webauthn_authenticator_rs::{
+    cable::{share_cable_authenticator, Advertiser},
+    ctap2::CtapAuthenticator,
+    error::WebauthnCError,
+    softtoken::SoftTokenFile,
+    transport::{AnyTransport, Transport},
+    ui::Cli,
+};
+
+#[derive(Debug, clap::Parser)]
+#[clap(about = "caBLE tunneler tool")]
+#[clap(group(
+    ArgGroup::new("url")
+        .required(true)
+        .args(&["cable-url", "qr-image"])
+))]
+pub struct CliParser {
+    /// Serial port where Bluetooth HCI controller is connected to.
+    ///
+    /// This has primarily been tested using a Nordic nRF52 microcontroller
+    /// running [Apache Mynewt's NimBLE HCI demo][0].
+    ///
+    /// [0]: https://mynewt.apache.org/latest/tutorials/ble/blehci_project.html
+    #[clap(short, long)]
+    pub serial_port: String,
+
+    /// Baud rate for communication with Bluetooth HCI controller.
+    ///
+    /// By default, Apache Mynewt's NimBLE HCI demo runs at 1000000 baud.
+    #[clap(short, long, default_value = "1000000")]
+    pub baud_rate: u32,
+
+    /// Tunnel server ID to use. 0 = Google.
+    #[clap(short, long, default_value = "0")]
+    pub tunnel_server_id: u16,
+
+    /// `FIDO:/` URL from the initiator's QR code. Either this option or
+    /// --qr-image is required.
+    #[clap(short, long)]
+    pub cable_url: Option<String>,
+
+    /// Screenshot of the initator's QR code. Either this option or --cable-url
+    /// is required.
+    ///
+    /// Use `adb` to screenshot an Android device with USB debugging:
+    ///
+    /// adb exec-out screencap -p > screenshot.png
+    ///
+    /// Use Xcode to screenshot an iOS device with debugging. There is no need
+    /// to open an Xcode project: from the `Window` menu, select
+    /// `Devices and Simulators`, then select the device, and press
+    /// `Take Screenshot`. The screenshot will be saved to `~/Desktop`.
+    ///
+    /// Note: this *will not* work in the Android emulator or iOS simulator,
+    /// because they do not have access to a physical Bluetooth controller.
+    #[clap(short, long)]
+    pub qr_image: Option<String>,
+
+    /// Path to saved SoftToken.
+    ///
+    /// You can create a new SoftToken with the `softtoken` example:
+    ///
+    /// cargo run --example softtoken -- create /tmp/softtoken.dat
+    ///
+    /// If this option is not specified, `cable_tunnel` will attempt to connect
+    /// to the first supported physical token using AnyTransport. Most initators
+    /// (browsers) will *also* attempt to connect directly to *all* physical
+    /// tokens, so only use this if your initator is running on another device!
+    #[clap(long)]
+    pub softtoken_path: Option<String>,
+}
+
+struct SerialHciAdvertiser {
+    hci: SerialController<CommandHeader, Vendor>,
+}
+
+impl SerialHciAdvertiser {
+    fn new(serial_port: &str, baud_rate: u32) -> Self {
+        let port = serialport::new(serial_port, baud_rate)
+            .timeout(Duration::from_secs(2))
+            .flow_control(FlowControl::None)
+            .open()
+            .unwrap();
+        Self {
+            hci: SerialController::new(port),
+        }
+    }
+
+    fn read(&mut self) -> Packet<Event> {
+        let r = self.hci.read().unwrap();
+        trace!("<<< {:?}", r);
+        r
+    }
+}
+
+impl Advertiser for SerialHciAdvertiser {
+    fn stop_advertising(&mut self) -> Result<(), WebauthnCError> {
+        trace!("sending reset...");
+        self.hci.reset().unwrap();
+        let _ = self.read();
+
+        self.hci.le_set_advertise_enable(false).unwrap();
+        let _ = self.read();
+        Ok(())
+    }
+
+    fn start_advertising(
+        &mut self,
+        service_uuid: u16,
+        payload: &[u8],
+    ) -> Result<(), WebauthnCError> {
+        self.stop_advertising()?;
+        let advert = Advertisement::ServiceData16BitUuid(service_uuid, payload);
+        let mut service_data = [0; 31];
+        let len = advert.copy_into_slice(&mut service_data);
+
+        let p = AdvertisingParameters {
+            advertising_interval: AdvertisingInterval::for_type(
+                AdvertisingType::NonConnectableUndirected,
+            )
+            .with_range(Duration::from_millis(100), Duration::from_millis(500))
+            .unwrap(),
+            own_address_type: OwnAddressType::Random,
+            peer_address: BdAddrType::Random(bluetooth_hci::BdAddr([0xc0; 6])),
+            advertising_channel_map: Channels::all(),
+            advertising_filter_policy: AdvertisingFilterPolicy::WhiteListConnectionAllowScan,
+        };
+        let mut addr = [0u8; 6];
+        addr[5] = 0xc0;
+        rand_bytes(&mut addr[..5])?;
+
+        self.hci.le_set_random_address(BdAddr(addr)).unwrap();
+        let _ = self.read();
+
+        self.hci.le_set_advertising_parameters(&p).unwrap();
+        let _ = self.read();
+
+        self.hci
+            .le_set_advertising_data(&service_data[..len])
+            .unwrap();
+        let _ = self.read();
+
+        self.hci.le_set_advertise_enable(true).unwrap();
+        let _ = self.read();
+        Ok(())
+    }
+}
+
+#[tokio::main]
+pub(super) async fn main() {
+    let opt = CliParser::parse();
+    let cable_url = if let Some(u) = opt.cable_url {
+        u
+    } else if let Some(img) = opt.qr_image {
+        let img = image::open(img).unwrap();
+        // Optimised for screenshots from the device.
+        let img = img.adjust_contrast(9000.0);
+
+        let decoder = bardecoder::default_decoder();
+        let fido_url = decoder
+            .decode(&img)
+            .into_iter()
+            .filter_map(|r| {
+                trace!(?r);
+                r.ok()
+            })
+            .find(|u| {
+                trace!("Found QR code: {:?}", u);
+                let u = u.to_ascii_uppercase();
+                u.starts_with("FIDO:/")
+            });
+        match fido_url {
+            Some(u) => u,
+            None => {
+                panic!("Could not find any FIDO URLs in the image");
+            }
+        }
+    } else {
+        unreachable!();
+    };
+
+    let mut advertiser = SerialHciAdvertiser::new(&opt.serial_port, opt.baud_rate);
+    let ui = Cli {};
+
+    if let Some(p) = opt.softtoken_path {
+        // Use a SoftToken
+        let f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(false)
+            .open(p)
+            .unwrap();
+        let mut softtoken = SoftTokenFile::open(f).unwrap();
+        let info = softtoken.as_ref().get_info();
+
+        share_cable_authenticator(
+            &mut softtoken,
+            info,
+            cable_url.trim(),
+            opt.tunnel_server_id,
+            &mut advertiser,
+            &ui,
+            true,
+        )
+        .await
+        .unwrap();
+    } else {
+        // Use a physical authenticator
+        let mut transport = AnyTransport::new().unwrap();
+        let token = transport.tokens().unwrap().pop().unwrap();
+        let mut authenticator = CtapAuthenticator::new(token, &ui).await.unwrap();
+        let info = authenticator.get_info().to_owned();
+
+        share_cable_authenticator(
+            &mut authenticator,
+            info,
+            cable_url.trim(),
+            opt.tunnel_server_id,
+            &mut advertiser,
+            &ui,
+            true,
+        )
+        .await
+        .unwrap();
+    };
+}

--- a/webauthn-authenticator-rs/examples/cable_tunnel/main.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel/main.rs
@@ -1,0 +1,17 @@
+//! `cable_tunnel` shares a [Token] over a caBLE connection.
+
+#[macro_use]
+extern crate tracing;
+
+#[cfg(feature = "cable")]
+mod core;
+
+fn main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    #[cfg(feature = "cable")]
+    core::main();
+
+    #[cfg(not(feature = "cable"))]
+    error!("This example requires the feature \"cable\" to be enabled.");
+}

--- a/webauthn-authenticator-rs/src/cable/base10.rs
+++ b/webauthn-authenticator-rs/src/cable/base10.rs
@@ -1,0 +1,186 @@
+//! caBLE Base10 encoder.
+//!
+//! QR codes store arbitrary binary data very inefficiently, but it has
+//! alternate modes (such as numeric and alphanumeric) which can store it more
+//! efficiently.
+//!
+//! While [RFC 9285] presents an encoding for efficiently encoding binary data
+//! in QR's alphanumeric mode, there are additional issues:
+//!
+//! * caBLE pairing codes must be valid URLs (for mobile intent handling)
+//!
+//! * QR's alphanumeric mode does not allow all [URL-safe characters][url-chars],
+//!   reducing efficiency
+//!
+//! * QR's alphanumeric mode allows [non-URL-safe characters][url-chars],
+//!   reducing efficiency
+//!
+//! As a result, caBLE uses a novel Base10 encoding for the payload, which
+//! achieves comparable density (in QR code bits), though with longer URLs.
+//!
+//! In absence of a publicly-published caBLE specification, this is a port of
+//! [Chromium's `BytesToDigits` and `DigitsToBytes` functions][crbase10].
+//!
+//! [crbase10]: https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=471-568;drc=6767131b3528fefd866f604b32ebbb278c35d395
+//! [RFC 9285]: https://www.rfc-editor.org/rfc/rfc9285.html
+//! [url-chars]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.3
+
+/// Size of a chunk of data in its original form
+const CHUNK_SIZE: usize = 7;
+
+/// Size of a chunk of data in its encoded form
+const CHUNK_DIGITS: usize = 17;
+
+/// Encodes binary data into Base10 format.
+///
+/// See Chromium's `BytesToDigits`.
+pub fn encode(i: &[u8]) -> String {
+    i.chunks(CHUNK_SIZE)
+        .map(|c| {
+            let chunk_len = c.len();
+            let w = match chunk_len {
+                CHUNK_SIZE => CHUNK_DIGITS,
+                6 => 15,
+                5 => 13,
+                4 => 10,
+                3 => 8,
+                2 => 5,
+                1 => 3,
+                // This should never happen
+                _ => 0,
+            };
+
+            let mut chunk: [u8; 8] = [0; 8];
+            chunk[0..chunk_len].copy_from_slice(c);
+            let v = u64::from_le_bytes(chunk);
+            format!("{:0width$}", v, width = w)
+        })
+        .collect()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The input value contained non-ASCII-digit characters.
+    ContainsNonDigitChars,
+    /// The input value was not a valid length.
+    InvalidLength,
+    /// The input value contained a value which was out of range.
+    OutOfRange,
+}
+
+/// Decodes Base10 formatted data into binary form.
+///
+/// See Chromium's `DigitsToBytes`.
+pub fn decode(i: &str) -> Result<Vec<u8>, DecodeError> {
+    // Check that i only contains ASCII digits
+    if i.chars().any(|c| !c.is_ascii_digit()) {
+        return Err(DecodeError::ContainsNonDigitChars);
+    }
+
+    // It's safe to operate on the string in bytes now because:
+    //
+    // - we've previously thrown an error for anything containing non-ASCII digits.
+    // - each ASCII digit is exactly 1 byte in UTF-8.
+    // - &str is always valid UTF-8.
+    let mut o = Vec::with_capacity(((i.len() + CHUNK_DIGITS - 1) / CHUNK_DIGITS) * CHUNK_SIZE);
+
+    i.as_bytes()
+        .chunks(CHUNK_DIGITS)
+        .map(|b| unsafe { std::str::from_utf8_unchecked(b) })
+        .try_for_each(|s| {
+            let d = s
+                .parse::<u64>()
+                .map_err(|_| DecodeError::ContainsNonDigitChars)?;
+            let w = match s.len() {
+                CHUNK_DIGITS => CHUNK_SIZE,
+                15 => 6,
+                13 => 5,
+                10 => 4,
+                8 => 3,
+                5 => 2,
+                3 => 1,
+                _ => return Err(DecodeError::InvalidLength),
+            };
+
+            if d >> (w * 8) != 0 {
+                return Err(DecodeError::OutOfRange);
+            }
+
+            o.extend_from_slice(&d.to_le_bytes()[..w]);
+            Ok(())
+        })?;
+
+    Ok(o)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn decoder_err_test(i: &str, e: DecodeError) {
+        assert_eq!(Err(e), decode(i), "decode({:?})", i);
+    }
+
+    #[test]
+    fn invalid_decode() {
+        use DecodeError::*;
+        // Non-digit characters
+        decoder_err_test("abc", ContainsNonDigitChars);
+        decoder_err_test("abc1234", ContainsNonDigitChars);
+
+        // Full-width romaji digits
+        decoder_err_test("\u{ff11}\u{ff12}\u{ff13}", ContainsNonDigitChars);
+
+        // Digits with umlauts (decomposed combining diacriticals on digits)
+        decoder_err_test("1\u{308}2\u{308}3\u{308}", ContainsNonDigitChars);
+
+        // Incorrect lengths
+        decoder_err_test("1", InvalidLength);
+        decoder_err_test("12", InvalidLength);
+        decoder_err_test("1234", InvalidLength);
+        decoder_err_test("123456789012345678", InvalidLength);
+
+        // Valid length, but results in bytes > 0xff
+        decoder_err_test("999", OutOfRange);
+        decoder_err_test("99999999999999999", OutOfRange);
+    }
+
+    #[test]
+    fn decoding_zero() {
+        let lengths = [
+            (0, 0),
+            (1, 3),
+            (2, 5),
+            (3, 8),
+            (4, 10),
+            (5, 13),
+            (6, 15),
+            (7, 17),
+            (8, 20),
+        ];
+        for (bl, dl) in lengths {
+            let bytes = vec![0; bl];
+            let digits = "0".repeat(dl);
+
+            assert_eq!(encode(bytes.as_slice()), digits);
+            assert_eq!(decode(&digits), Ok(bytes));
+        }
+    }
+
+    #[test]
+    fn encoding_survives_roundtrips() {
+        let i: Vec<u8> = (0..255).collect();
+
+        for len in 0..i.len() {
+            let i = &i[0..len];
+            assert_eq!(decode(&encode(i)), Ok(i.to_vec()), "length = {}", len);
+        }
+    }
+
+    #[test]
+    fn encoding_should_not_change() {
+        let i: [u8; 3] = [0x61, 0x62, 0xff];
+        assert_eq!(encode(&i), "16736865");
+        assert_eq!(decode("16736865").expect("unexpected error"), i);
+    }
+}

--- a/webauthn-authenticator-rs/src/cable/btle.rs
+++ b/webauthn-authenticator-rs/src/cable/btle.rs
@@ -1,0 +1,160 @@
+//! caBLE Bluetooth Low Energy scanner.
+//!
+//! An authenticator advertises its physical proximity to the platform and some
+//! connection metadata by transmitting an encrypted service data payload.
+//!
+//! * [Scanner] uses [btleplug] for an initiator to watch for caBLE
+//!   advertisements from an authenticator.
+//!
+//! * [Advertiser] provides a trait for caBLE authenticators
+//!
+//! [btleplug] (and many platform APIs) do not support sending arbitrary service
+//! data advertisements, so authenticators using this library will need to
+//! implement the [Advertiser] trait themselves. See `examples/cable_tunnel` for
+//! an example using a serial-connected BTLE HCI controller.
+use btleplug::{
+    api::{bleuuid::uuid_from_u16, Central, CentralEvent, Manager as _, ScanFilter},
+    platform::Manager,
+};
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::error::WebauthnCError;
+
+/// Service Data UUID for caBLE assigned to Google (0xfde2).
+///
+/// This is transmitted by iOS 16 devices, and older versions of Chromium.
+///
+/// Prefer transmitting [FIDO_CABLE_SERVICE_U16].
+///
+/// Reference: [Bluetooth Assigned Numbers][], Section 3.11 (Member Services)
+///
+/// [Bluetooth Assigned Numbers]: https://www.bluetooth.com/specifications/assigned-numbers/
+const GOOGLE_CABLE_SERVICE: Uuid = uuid_from_u16(0xfde2);
+
+/// 16-bit Service Data UUID for caBLE assigned to FIDO2 (0xfff9).
+///
+/// This is used by newer versions of Chromium, and detectable by all (even
+/// iOS 16).
+///
+/// Reference: [Bluetooth Assigned Numbers][], Section 3.10 (SDO Services)
+///
+/// [Bluetooth Assigned Numbers]: https://www.bluetooth.com/specifications/assigned-numbers/
+pub(super) const FIDO_CABLE_SERVICE_U16: u16 = 0xfff9;
+
+/// Service Data UUID for caBLE assigned to FIDO2 (0xfff9).
+///
+/// Reference: [Bluetooth Assigned Numbers][], Section 3.10 (SDO Services)
+///
+/// [Bluetooth Assigned Numbers]: https://www.bluetooth.com/specifications/assigned-numbers/
+const FIDO_CABLE_SERVICE: Uuid = uuid_from_u16(FIDO_CABLE_SERVICE_U16);
+
+/// Bluetooth Low Energy advertiser trait.
+///
+/// A caBLE authenticator needs to be able to send arbitrary service data
+/// advertisements to be discoverable by the initiator (platform).
+pub trait Advertiser {
+    /// Start sending service data advertisements.
+    ///
+    /// Arguments:
+    /// * `service_uuid`: a 16-bit service UUID to send advertising data for.
+    /// * `payload`: the advertisement payload.
+    ///
+    /// Advertisements are of the type "Service Data - 16-bit UUID" (0x16).
+    ///
+    /// This should continue until [Advertiser::stop_advertising] is called.
+    fn start_advertising(
+        &mut self,
+        service_uuid: u16,
+        payload: &[u8],
+    ) -> Result<(), WebauthnCError>;
+
+    /// Stop sending service data advertisements.
+    fn stop_advertising(&mut self) -> Result<(), WebauthnCError>;
+}
+
+/// Bluetooth Low Energy service data advertisement scanner.
+pub struct Scanner {
+    manager: Manager,
+}
+
+impl Scanner {
+    /// Creates a new instance of the Bluetooth Low Energy scanner.
+    pub async fn new() -> Result<Self, WebauthnCError> {
+        Ok(Scanner {
+            manager: Manager::new().await?,
+        })
+    }
+
+    /// Gets a [ScanFilter] that matches FIDO and Google caBLE service data
+    /// advertisements.
+    fn get_scan_filter() -> ScanFilter {
+        // Sending a service filter to bluez causes it to not give us *any*
+        // advertisements *at all*, so we have to drink straight from the
+        // firehose instead.
+        #[cfg(target_os = "linux")]
+        return Default::default();
+
+        #[cfg(not(target_os = "linux"))]
+        ScanFilter {
+            services: vec![FIDO_CABLE_SERVICE, GOOGLE_CABLE_SERVICE],
+        }
+    }
+
+    /// Starts scanning for caBLE BTLE advertisements in the background.
+    ///
+    /// Returned values are the advertisement payload.
+    pub async fn scan(&self) -> Result<mpsc::Receiver<Vec<u8>>, WebauthnCError> {
+        let (tx, rx) = mpsc::channel(100);
+
+        // https://github.com/deviceplug/btleplug/blob/master/examples/event_driven_discovery.rs
+        let adapters = self.manager.adapters().await?;
+        let adapter = adapters
+            .into_iter()
+            .next()
+            .ok_or(WebauthnCError::NoBluetoothAdapter)?;
+        let mut events = adapter.events().await?;
+
+        adapter.start_scan(Self::get_scan_filter()).await?;
+
+        tokio::spawn(async move {
+            while let Some(event) = events.next().await {
+                if tx.is_closed() {
+                    break;
+                }
+
+                if let CentralEvent::ServiceDataAdvertisement {
+                    id: _,
+                    mut service_data,
+                } = event
+                {
+                    // Service data advertisement events always use the 128-bit
+                    // form, even though they're transmitted in 16-bit form.
+                    //
+                    // bluez doesn't filter properly, so we need to explicitly
+                    // check for service data UUIDs we care about.
+                    if let Some(d) = service_data.remove(&FIDO_CABLE_SERVICE) {
+                        if tx.send(d).await.is_err() {
+                            break;
+                        }
+                    }
+
+                    if let Some(d) = service_data.remove(&GOOGLE_CABLE_SERVICE) {
+                        if tx.send(d).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            adapter.stop_scan().await.ok();
+        });
+
+        Ok(rx)
+    }
+}
+
+impl Drop for Scanner {
+    fn drop(&mut self) {}
+}

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -1,0 +1,528 @@
+//! Structures for device discovery over BTLE.
+use num_traits::ToPrimitive;
+use openssl::{
+    ec::EcKey,
+    hash::MessageDigest,
+    pkey::{PKey, Private},
+    rand::rand_bytes,
+    sign::Signer,
+};
+use std::mem::size_of;
+use tokio_tungstenite::tungstenite::http::Uri;
+
+use crate::{
+    cable::{btle::*, handshake::*, tunnel::get_domain, CableRequestType, Psk},
+    crypto::{decrypt, encrypt, hkdf_sha_256, public_key_from_private, regenerate},
+    error::WebauthnCError,
+};
+
+type BleAdvert = [u8; size_of::<CableEid>() + 4];
+type RoutingId = [u8; 3];
+type BleNonce = [u8; 10];
+type QrSecret = [u8; 16];
+type EidKey = [u8; 32 + 32];
+type CableEid = [u8; 16];
+type TunnelId = [u8; 16];
+
+// const BASE64URL: base64::Config = base64::Config::new(base64::CharacterSet::UrlSafe, false);
+
+#[derive(FromPrimitive, ToPrimitive, Debug, PartialEq, Eq)]
+#[repr(u32)]
+enum DerivedValueType {
+    EIDKey = 1,
+    TunnelID = 2,
+    Psk = 3,
+    PairedSecret = 4,
+    IdentityKeySeed = 5,
+    PerContactIDSecret = 6,
+}
+
+impl DerivedValueType {
+    pub fn derive(&self, ikm: &[u8], salt: &[u8], output: &mut [u8]) -> Result<(), WebauthnCError> {
+        let typ = self.to_u32().ok_or(WebauthnCError::Internal)?.to_le_bytes();
+        hkdf_sha_256(salt, ikm, Some(&typ), output)
+    }
+}
+
+#[derive(Debug)]
+pub struct Discovery {
+    request_type: CableRequestType,
+    pub(super) local_identity: EcKey<Private>,
+    qr_secret: QrSecret,
+    eid_key: EidKey,
+}
+
+impl Discovery {
+    /// Creates a [Discovery] for a given `request_type`.
+    ///
+    /// This method generates a random `qr_secret` and `local_identity`, and is
+    /// suitable for use by an initiator.
+    pub fn new(request_type: CableRequestType) -> Result<Self, WebauthnCError> {
+        // chrome_authenticator_request_delegate.cc  ChromeAuthenticatorRequestDelegate::ConfigureCable
+        let mut qr_secret: QrSecret = [0; size_of::<QrSecret>()];
+        rand_bytes(&mut qr_secret)?;
+        Self::new_with_qr_secret(request_type, qr_secret)
+    }
+
+    /// Creates a [Discovery] for a given `request_type` and `qr_secret`.
+    ///
+    /// This method generates a random `local_identity`, and is suitable for use
+    /// by an authenticator.  See [HandshakeV2::to_discovery] for a public API.
+    pub(super) fn new_with_qr_secret(
+        request_type: CableRequestType,
+        qr_secret: QrSecret,
+    ) -> Result<Self, WebauthnCError> {
+        let local_identity = regenerate()?;
+        Self::new_with_qr_secret_and_cert(request_type, qr_secret, local_identity)
+    }
+
+    fn new_with_qr_secret_and_cert(
+        request_type: CableRequestType,
+        qr_secret: QrSecret,
+        local_identity: EcKey<Private>,
+    ) -> Result<Self, WebauthnCError> {
+        // Trying to EC_KEY_derive_from_secret is only in BoringSSL, and doesn't have openssl-rs bindings
+        // Opted to just take in an EcKey here.
+
+        let mut eid_key: EidKey = [0; size_of::<EidKey>()];
+        DerivedValueType::EIDKey.derive(&qr_secret, &[], &mut eid_key)?;
+
+        Ok(Self {
+            request_type,
+            local_identity,
+            qr_secret,
+            eid_key,
+        })
+    }
+
+    /// Decrypts a Bluetooth service data advertisement with this [Discovery]'s
+    /// `eid_key`.
+    ///
+    /// Returns `Ok(None)` when the advertisement was encrypted using a
+    /// different key, or if the advertisement length was incorrct.
+    pub fn decrypt_advert<'a>(
+        &self,
+        advert: impl TryInto<&'a BleAdvert>,
+    ) -> Result<Option<Eid>, WebauthnCError> {
+        Eid::decrypt_advert(advert, &self.eid_key)
+    }
+
+    /// Encrypts an [Eid] with this [Discovery]'s `eid_key`.
+    ///
+    /// Returns a byte array to be transmitted in as the payload of a Bluetooth
+    /// service data advertisement.
+    pub fn encrypt_advert(&self, eid: &Eid) -> Result<BleAdvert, WebauthnCError> {
+        eid.encrypt_advert(&self.eid_key)
+    }
+
+    /// Makes a [HandshakeV2] for this [Discovery].
+    ///
+    /// This payload includes the `request_type`, public key for the
+    /// `local_identity`, and `qr_secret`.
+    pub fn make_handshake(&self) -> Result<HandshakeV2, WebauthnCError> {
+        let public_key = public_key_from_private(&self.local_identity)?;
+        HandshakeV2::new(self.request_type, public_key, self.qr_secret)
+    }
+
+    /// Waits on a [Scanner] to return a BTLE advertisement which can be
+    /// decrypted by data this [Discovery]
+    pub async fn wait_for_matching_response(
+        &self,
+        scanner: &Scanner,
+    ) -> Result<Option<Eid>, WebauthnCError> {
+        let mut rx = scanner.scan().await?;
+        while let Some(a) = rx.recv().await {
+            trace!("advert: {:?}", a);
+            if let Some(eid) = self.decrypt_advert(a.as_slice())? {
+                rx.close();
+                return Ok(Some(eid));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Derives the tunnel ID associated with this [Discovery]
+    pub fn derive_tunnel_id(&self) -> Result<TunnelId, WebauthnCError> {
+        let mut tunnel_id: TunnelId = [0; size_of::<TunnelId>()];
+        DerivedValueType::TunnelID.derive(&self.qr_secret, &[], &mut tunnel_id)?;
+        Ok(tunnel_id)
+    }
+
+    /// Derives the pre-shared key for an [Eid] targetting this [Discovery]
+    pub fn derive_psk(&self, eid: &Eid) -> Result<Psk, WebauthnCError> {
+        let mut psk: Psk = [0; size_of::<Psk>()];
+        DerivedValueType::Psk.derive(&self.qr_secret, &eid.to_bytes(), &mut psk)?;
+        Ok(psk)
+    }
+
+    /// Gets the Websocket connection URI which the platform will use to connect
+    /// to the authenticator.
+    pub fn get_connect_uri(&self, eid: &Eid) -> Result<Uri, WebauthnCError> {
+        let tunnel_id = self.derive_tunnel_id()?;
+        eid.get_connect_uri(tunnel_id).ok_or_else(|| {
+            error!("Unknown WebSocket tunnel URL for {:?}", eid);
+            WebauthnCError::NotSupported
+        })
+    }
+
+    /// Gets the Websocket connection URL which the authenticator will use to
+    /// connect to the platform.
+    pub fn get_new_tunnel_uri(&self, domain_id: u16) -> Result<Uri, WebauthnCError> {
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=170;drc=de9f16dcca1d5057ba55973fa85a5b27423d414f
+        get_domain(domain_id)
+            .and_then(|domain| {
+                let tunnel_id = hex::encode_upper(self.derive_tunnel_id().ok()?);
+                Uri::builder()
+                    .scheme("wss")
+                    .authority(domain)
+                    .path_and_query(format!("/cable/new/{}", tunnel_id))
+                    .build()
+                    .ok()
+            })
+            .ok_or_else(|| {
+                error!("Unknown WebSocket tunnel URL for {:?}", domain_id);
+                WebauthnCError::NotSupported
+            })
+    }
+}
+
+/// Authenticator-provided payload, sent to the initiator as an encrypted BTLE
+/// service data advertisement, which allows it to connect to the authenticator
+/// via the tunnel server.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Eid {
+    /// The [well-known tunnel server][get_domain] to connect to, chosen by the
+    /// authenticator.
+    pub tunnel_server_id: u16,
+
+    /// A tunnel server-provided routing ID which allows the initiator to
+    /// connect to the authenticator's session.
+    pub routing_id: RoutingId,
+
+    /// An authenticator-provided nonce which is used to derive further secrets
+    /// during the [CableNoise][super::cable::CableNoise] handshake.
+    pub nonce: BleNonce,
+}
+
+impl Eid {
+    /// Creates a new [Eid] using a random nonce.
+    pub fn new(tunnel_server_id: u16, routing_id: RoutingId) -> Result<Self, WebauthnCError> {
+        let mut nonce: BleNonce = [0; size_of::<BleNonce>()];
+        rand_bytes(&mut nonce)?;
+
+        Ok(Self {
+            tunnel_server_id,
+            routing_id,
+            nonce,
+        })
+    }
+
+    /// Converts this [Eid] into unencrypted bytes.
+    fn to_bytes(&self) -> CableEid {
+        let mut o: CableEid = [0; size_of::<CableEid>()];
+        let mut p = 1;
+        let mut q = p + size_of::<BleNonce>();
+        o[p..q].copy_from_slice(&self.nonce);
+
+        p = q;
+        q += size_of::<RoutingId>();
+        o[p..q].copy_from_slice(&self.routing_id);
+
+        p = q;
+        q += size_of::<u16>();
+        o[p..q].copy_from_slice(&self.tunnel_server_id.to_le_bytes());
+
+        o
+    }
+
+    /// Parses an [Eid] from unencrypted bytes.
+    ///
+    /// `eid` must be 16 bytes long.
+    ///
+    /// Returns `None` on other errors. This generally means the [CableEid] was
+    /// encrypted with a different key, because it was intended for a different
+    /// initiator.
+    fn from_bytes<'a>(eid: impl TryInto<&'a CableEid>) -> Option<Self> {
+        let eid: &'a CableEid = eid.try_into().ok()?;
+        let mut p = 0;
+        if eid[p] != 0 {
+            warn!(
+                "reserved bits not 0 in decrypted caBLE advertisement, got 0x{:02x}",
+                eid[p]
+            );
+            return None;
+        }
+
+        p += 1;
+        let mut nonce: BleNonce = [0; size_of::<BleNonce>()];
+        let mut q = p + size_of::<BleNonce>();
+        nonce.copy_from_slice(&eid[p..q]);
+
+        p = q;
+        q += size_of::<RoutingId>();
+        let mut routing_id: RoutingId = [0; size_of::<RoutingId>()];
+        routing_id.copy_from_slice(&eid[p..q]);
+
+        p = q;
+        q += size_of::<u16>();
+        let tunnel_server_id = u16::from_le_bytes(eid[p..q].try_into().ok()?);
+
+        let eid = Self {
+            nonce,
+            routing_id,
+            tunnel_server_id,
+        };
+
+        // Invalid tunnel server ID is a parse failure
+        eid.get_domain().is_some().then_some(eid)
+    }
+
+    /// Decrypts and parses a BTLE advertisement with a given key.
+    ///
+    /// Returns `Ok(None)` if `advert` was the wrong length, `advert` was not
+    /// decryptable (or signed) with `key`, the resulting payload was invalid.
+    ///
+    /// See [Discovery::decrypt_advert] for a public API.
+    fn decrypt_advert<'a>(
+        advert: impl TryInto<&'a BleAdvert>,
+        key: &EidKey,
+    ) -> Result<Option<Eid>, WebauthnCError> {
+        let advert: &BleAdvert = match advert.try_into() {
+            Ok(a) => a,
+            Err(_) => {
+                // We want to return `None" rather than error here, because BTLE
+                // adverts may be any length. This lets us ignore junk
+                // advertisements sent with caBLE UUIDs.
+                warn!("Incorrect caBLE advertisement length");
+                return Ok(None);
+            }
+        };
+
+        trace!("Decrypting {:?} with key {:?}", advert, key);
+        let signing_key = PKey::hmac(&key[32..64])?;
+        let mut signer = Signer::new(MessageDigest::sha256(), &signing_key)?;
+        let calculated_hmac = signer.sign_oneshot_to_vec(&advert[..16])?;
+
+        if calculated_hmac[..4] != advert[16..20] {
+            warn!("incorrect HMAC when decrypting caBLE advertisement");
+            return Ok(None);
+        }
+
+        // HMAC checks out, try to decrypt
+        let plaintext = decrypt(&key[..32], None, &advert[..16])?;
+        Ok(Eid::from_bytes(plaintext.as_slice()))
+    }
+
+    /// Converts this [Eid] into an encrypted payload for BLE advertisements.
+    ///
+    /// See [Discovery::encrypt_advert] for a public API.
+    fn encrypt_advert(&self, key: &EidKey) -> Result<BleAdvert, WebauthnCError> {
+        let eid = self.to_bytes();
+        let c = encrypt(&key[..32], None, &eid)?;
+
+        let mut crypted: BleAdvert = [0; size_of::<BleAdvert>()];
+        crypted[..size_of::<CableEid>()].copy_from_slice(&c);
+
+        // Sign the advertisement with HMAC-SHA-256
+        let signing_key = PKey::hmac(&key[32..64])?;
+        let mut signer = Signer::new(MessageDigest::sha256(), &signing_key)?;
+        let calculated_hmac = signer.sign_oneshot_to_vec(&crypted[..16])?;
+
+        // Take the first 4 bytes of the signature
+        crypted[size_of::<CableEid>()..].copy_from_slice(&calculated_hmac[..4]);
+
+        Ok(crypted)
+    }
+
+    /// Gets the tunnel server domain for this [Eid].
+    fn get_domain(&self) -> Option<String> {
+        get_domain(self.tunnel_server_id)
+    }
+
+    /// Gets the Websocket connection URI which the platform will use to connect
+    /// to the authenticator.
+    ///
+    /// `tunnel_id` is provided by [Discovery::derive_tunnel_id].
+    fn get_connect_uri(&self, tunnel_id: TunnelId) -> Option<Uri> {
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=179;drc=de9f16dcca1d5057ba55973fa85a5b27423d414f
+        self.get_domain().and_then(|domain| {
+            let routing_id = hex::encode_upper(self.routing_id);
+            let tunnel_id = hex::encode_upper(tunnel_id);
+
+            Uri::builder()
+                .scheme("wss")
+                .authority(domain)
+                .path_and_query(format!("/cable/connect/{}/{}", routing_id, tunnel_id))
+                .build()
+                .ok()
+        })
+    }
+
+    // TODO: needed for pairing
+    // fn get_contact_uri(&self) -> Option<Uri> {
+    //     self.get_domain().and_then(|domain| {
+    //         let routing_id = base64::encode_config(&self.routing_id, BASE64URL);
+    //         Uri::builder()
+    //             .scheme("wss")
+    //             .authority(domain)
+    //             .path_and_query(format!("/cable/contact/{}", routing_id))
+    //             .build()
+    //             .ok()
+    //     })
+    // }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn eid_from_bytes() {
+        let eid = [
+            // Reserved byte
+            0, //
+            // Nonce
+            9, 139, 115, 107, 54, 169, 140, 185, 164, 47, //
+            // Routing ID
+            9, 10, 11, //
+            // Tunnel ID
+            255, 1,
+        ];
+        let expected = Eid {
+            tunnel_server_id: 0x01FF,
+            routing_id: [9, 10, 11],
+            nonce: [9, 139, 115, 107, 54, 169, 140, 185, 164, 47],
+        };
+        assert_eq!(Some(expected), Eid::from_bytes(&eid));
+
+        // Reading wrong lengths should fail
+        for x in 0..15 {
+            assert!(Eid::from_bytes(&eid[..x]).is_none());
+        }
+        assert!(Eid::from_bytes(&[0; 17][..]).is_none());
+
+        // Setting tunnel server ID to invalid value should fail
+        let mut bad = eid;
+        bad[15] = 0;
+        assert!(Eid::from_bytes(&bad).is_none());
+
+        // Setting reserved byte should fail
+        let mut bad = eid;
+        bad[0] = 1;
+        assert!(Eid::from_bytes(&bad).is_none());
+    }
+
+    #[test]
+    fn encrypt_decrypt() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let d = Discovery::new_with_qr_secret(CableRequestType::MakeCredential, [0; 16]).unwrap();
+        let c = Eid {
+            tunnel_server_id: 0xf980,
+            routing_id: [9, 10, 11],
+            nonce: [9, 139, 115, 107, 54, 169, 140, 185, 164, 47],
+        };
+
+        let advert = d.encrypt_advert(&c).unwrap();
+
+        // Decrypt the encrypted advertisement => same value
+        let c2 = d.decrypt_advert(&advert).unwrap().unwrap();
+        assert_eq!(c, c2);
+
+        // Make sure URLs stay consistent
+        assert_eq!(
+            "wss://cable.my4kstlhndi4c.net/cable/new/3EEF97097986413B059EAA2A30D653D4",
+            d.get_new_tunnel_uri(c.tunnel_server_id)
+                .unwrap()
+                .to_string()
+        );
+        assert_eq!(
+            "wss://cable.my4kstlhndi4c.net/cable/connect/090A0B/3EEF97097986413B059EAA2A30D653D4",
+            d.get_connect_uri(&c).unwrap().to_string()
+        );
+
+        // Changing the tunnel server ID should work too
+        let mut google_eid = c;
+        google_eid.tunnel_server_id = 0;
+        assert_eq!(
+            "wss://cable.ua5v.com/cable/connect/090A0B/3EEF97097986413B059EAA2A30D653D4",
+            d.get_connect_uri(&google_eid).unwrap().to_string()
+        );
+
+        let mut apple_eid = c;
+        apple_eid.tunnel_server_id = 1;
+        assert_eq!(
+            "wss://cable.auth.com/cable/connect/090A0B/3EEF97097986413B059EAA2A30D653D4",
+            d.get_connect_uri(&apple_eid).unwrap().to_string()
+        );
+
+        // Changing bits fails
+        let mut bad = advert;
+        bad[0] ^= 1;
+        assert!(d.decrypt_advert(&bad).unwrap().is_none());
+
+        // Changing HMAC fails
+        let mut bad = advert;
+        bad[size_of::<CableEid>()] ^= 1;
+        assert!(d.decrypt_advert(&bad).unwrap().is_none());
+
+        // Decrypting an advert with the wrong length returns None, not error
+        for x in 0..(advert.len() - 1) {
+            assert!(d.decrypt_advert(&advert[..x]).unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn decrypt_known() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let test_key = [
+            45, 45, 45, 45, 45, 66, 69, 71, 73, 78, 32, 69, 67, 32, 80, 82, 73, 86, 65, 84, 69, 32,
+            75, 69, 89, 45, 45, 45, 45, 45, 10, 77, 72, 99, 67, 65, 81, 69, 69, 73, 80, 114, 54,
+            76, 105, 83, 120, 81, 73, 82, 55, 69, 51, 72, 81, 90, 98, 78, 114, 57, 80, 78, 66, 114,
+            105, 50, 110, 56, 83, 66, 99, 89, 67, 65, 73, 56, 89, 69, 89, 57, 85, 113, 68, 111, 65,
+            111, 71, 67, 67, 113, 71, 83, 77, 52, 57, 10, 65, 119, 69, 72, 111, 85, 81, 68, 81,
+            103, 65, 69, 90, 68, 103, 112, 55, 66, 76, 82, 82, 47, 79, 100, 116, 89, 104, 118, 83,
+            43, 109, 88, 65, 51, 82, 87, 121, 51, 85, 65, 86, 112, 48, 49, 115, 52, 73, 111, 83,
+            78, 56, 47, 65, 114, 68, 77, 57, 56, 73, 88, 57, 104, 88, 102, 10, 70, 116, 47, 119,
+            65, 109, 68, 79, 119, 78, 78, 55, 66, 100, 84, 57, 84, 48, 86, 109, 110, 70, 73, 99,
+            55, 84, 49, 116, 106, 97, 105, 84, 68, 103, 61, 61, 10, 45, 45, 45, 45, 45, 69, 78, 68,
+            32, 69, 67, 32, 80, 82, 73, 86, 65, 84, 69, 32, 75, 69, 89, 45, 45, 45, 45, 45, 10,
+        ];
+        let qr_secret = [
+            1, 254, 166, 247, 196, 128, 116, 147, 220, 37, 111, 158, 172, 247, 86, 201,
+        ];
+        let local_identity = EcKey::private_key_from_pem(&test_key).unwrap();
+
+        let discovery = Discovery::new_with_qr_secret_and_cert(
+            CableRequestType::DiscoverableMakeCredential,
+            qr_secret,
+            local_identity,
+        )
+        .unwrap();
+
+        assert_eq!(
+            "wss://cable.ua5v.com/cable/new/367CBBF5F5085DF4098476AFE4B9B1D2",
+            discovery.get_new_tunnel_uri(0).unwrap().to_string(),
+        );
+
+        let advert = [
+            2, 125, 132, 237, 96, 118, 181, 94, 36, 124, 131, 15, 130, 149, 94, 77, 18, 110, 127,
+            67,
+        ];
+
+        let r = discovery.decrypt_advert(&advert).unwrap().unwrap();
+        trace!("eid: {:?}", r);
+
+        let expected = Eid {
+            tunnel_server_id: 0,
+            routing_id: [2, 101, 85],
+            nonce: [139, 181, 197, 201, 164, 77, 145, 58, 94, 178],
+        };
+        assert_eq!(expected, r);
+        assert_eq!(
+            "wss://cable.ua5v.com/cable/connect/026555/367CBBF5F5085DF4098476AFE4B9B1D2",
+            discovery.get_connect_uri(&r).unwrap().to_string()
+        );
+    }
+}

--- a/webauthn-authenticator-rs/src/cable/framing.rs
+++ b/webauthn-authenticator-rs/src/cable/framing.rs
@@ -1,0 +1,406 @@
+//! caBLE message framing types
+
+use crate::{
+    ctap2::{
+        commands::{GetAssertionRequest, MakeCredentialRequest},
+        CBORCommand, CBORResponse,
+    },
+    error::WebauthnCError,
+};
+
+/// Prefix byte for messages sent to the authenticator
+///
+/// Not used for protocol version 0
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CableFrameType {
+    /// caBLE shutdown message
+    Shutdown = 0,
+    /// CTAP 2.x command
+    Ctap = 1,
+    /// Linking information
+    Update = 2,
+    Unknown,
+}
+
+impl From<u8> for CableFrameType {
+    fn from(v: u8) -> Self {
+        use CableFrameType::*;
+        match v {
+            0 => Shutdown,
+            1 => Ctap,
+            2 => Update,
+            _ => Unknown,
+        }
+    }
+}
+
+pub const SHUTDOWN_COMMAND: CableFrame = CableFrame {
+    protocol_version: 1,
+    message_type: CableFrameType::Shutdown,
+    data: vec![],
+};
+
+/// caBLE request and response framing.
+///
+/// These frames are encrypted ([Crypter][super::noise::Crypter])
+/// and sent as binary Websocket messages.
+///
+/// ## Protocol description
+///
+/// ### Version 0
+///
+/// All frames are of the type [CableFrameType::Ctap], and the wire format is the
+/// same as CTAP 2.0.
+///
+/// ### Version 1
+///
+/// Version 1 adds an initial [CableFrameType] byte before the payload (`data`):
+///
+/// * [CableFrameType::Shutdown]: no payload
+/// * [CableFrameType::Ctap]: payload is CTAP 2.0 command / response
+/// * [CableFrameType::Update]: payload is linking information (not implemented)
+#[derive(Debug, PartialEq, Eq)]
+pub struct CableFrame {
+    pub protocol_version: u32,
+    pub message_type: CableFrameType,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum RequestType {
+    MakeCredential(MakeCredentialRequest),
+    GetAssertion(GetAssertionRequest),
+}
+
+impl CableFrame {
+    /// Serialises a [CableFrame] into bytes.
+    ///
+    /// Returns `None` if the `protocol_version` or `message_type` is not
+    /// supported, or invalid.
+    pub fn to_bytes(&self) -> Option<Vec<u8>> {
+        if self.protocol_version == 0 && self.message_type == CableFrameType::Ctap {
+            Some(self.data.to_owned())
+        } else if self.protocol_version == 1 && self.message_type != CableFrameType::Unknown {
+            let mut o = self.data.to_owned();
+            o.insert(0, self.message_type as u8);
+            Some(o)
+        } else {
+            warn!(
+                "Unsupported caBLE protocol version {} or message type {:?}",
+                self.protocol_version, self.message_type
+            );
+            None
+        }
+    }
+
+    /// Deserialises a [CableFrame] from bytes.
+    pub fn from_bytes(protocol_version: u32, i: &[u8]) -> Self {
+        let message_type: CableFrameType = if protocol_version > 0 {
+            i[0].into()
+        } else {
+            CableFrameType::Ctap
+        };
+
+        let data = if protocol_version == 0 { i } else { &i[1..] }.to_vec();
+
+        Self {
+            protocol_version,
+            message_type,
+            data,
+        }
+    }
+
+    /// Parses a [CableFrame] (from an initiator) as a CBOR request type.
+    ///
+    /// Returns [WebauthnCError::NotSupported] on unknown command types, or if
+    /// `message_type` is not [CableFrameType::Ctap].
+    pub fn parse_request(&self) -> Result<RequestType, WebauthnCError> {
+        if self.message_type != CableFrameType::Ctap {
+            return Err(WebauthnCError::NotSupported);
+        }
+        match self.data[0] {
+            MakeCredentialRequest::CMD => Ok(RequestType::MakeCredential(
+                <MakeCredentialRequest as CBORResponse>::try_from(&self.data[1..])?,
+            )),
+            GetAssertionRequest::CMD => Ok(RequestType::GetAssertion(
+                <GetAssertionRequest as CBORResponse>::try_from(&self.data[1..])?,
+            )),
+            _ => Err(WebauthnCError::NotSupported),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use base64urlsafedata::Base64UrlSafeData;
+    use serde_cbor::Value;
+    use webauthn_rs_proto::{PubKeyCredParams, RelyingParty, User};
+
+    use crate::ctap2::commands::MakeCredentialResponse;
+
+    use super::*;
+
+    #[test]
+    fn sample_make_credential_request() {
+        let _ = tracing_subscriber::fmt::try_init();
+        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#example-1a030b94
+        /*
+        {
+        Integer(1): Bytes([104, 113, 52, 150, 130, 34, 236, 23, 32, 46, 66, 80, 95, 142, 210, 177, 106, 226, 47, 22, 187, 5, 184, 140, 37, 219, 158, 96, 38, 69, 241, 65]),
+        Integer(2): Map({Text("id"): Text("test.ctap"), Text("name"): Text("test.ctap")}),
+        Integer(3): Map({Text("id"): Bytes([43, 102, 137, 187, 24, 244, 22, 159, 6, 159, 188, 223, 80, 203, 110, 163, 198, 10, 134, 27, 154, 123, 99, 148, 105, 131, 224, 181, 119, 183, 140, 112]),
+            Text("name"): Text("testctap@ctap.com"), Text("displayName"): Text("Test Ctap")}),
+        Integer(4): Array([
+            Map({Text("alg"): Integer(-7), Text("type"): Text("public-key")}),
+            Map({Text("alg"): Integer(-257), Text("type"): Text("public-key")}),
+            Map({Text("alg"): Integer(-37), Text("type"): Text("public-key")})]),
+        Integer(7): Map({Text("rk"): Bool(true)}),
+        }
+         */
+        let request = vec![
+            1, // CableFrameType::Cbor
+            1, // Command
+            // Extensions not yet supported, PIN/UV not relevant for caBLE
+            // 168,
+            165, //
+            // ClientDataHash
+            1, 88, 32, 104, 113, 52, 150, 130, 34, 236, 23, 32, 46, 66, 80, 95, 142, 210, 177, 106,
+            226, 47, 22, 187, 5, 184, 140, 37, 219, 158, 96, 38, 69, 241, 65, //
+            // RelyingParty
+            2, 162, 98, 105, 100, 105, 116, 101, 115, 116, 46, 99, 116, 97, 112, 100, 110, 97, 109,
+            101, 105, 116, 101, 115, 116, 46, 99, 116, 97, 112, //
+            // User
+            3, 163, 98, 105, 100, 88, 32, 43, 102, 137, 187, 24, 244, 22, 159, 6, 159, 188, 223, 80,
+            203, 110, 163, 198, 10, 134, 27, 154, 123, 99, 148, 105, 131, 224, 181, 119, 183, 140,
+            112, 100, 110, 97, 109, 101, 113, 116, 101, 115, 116, 99, 116, 97, 112, 64, 99, 116,
+            97, 112, 46, 99, 111, 109, 107, 100, 105, 115, 112, 108, 97, 121, 78, 97, 109, 101,
+            105, 84, 101, 115, 116, 32, 67, 116, 97, 112, //
+            // PubKeyCredParams
+            4, 131, 162, 99, 97, 108, 103, 38, 100, 116, 121, 112, 101, 106, 112, 117, 98, 108, 105,
+            99, 45, 107, 101, 121, 162, 99, 97, 108, 103, 57, 1, 0, 100, 116, 121, 112, 101, 106,
+            112, 117, 98, 108, 105, 99, 45, 107, 101, 121, 162, 99, 97, 108, 103, 56, 36, 100, 116,
+            121, 112, 101, 106, 112, 117, 98, 108, 105, 99, 45, 107, 101, 121,
+            // Extensions not yet supported
+            // 6, 161, 107, 104, 109, 97, 99, 45, 115, 101, 99, 114, 101, 116, 245,
+            // Options
+            7, 161, 98, 114, 107, 245, //
+        ];
+
+        let expected_request = MakeCredentialRequest {
+            client_data_hash: vec![
+                104, 113, 52, 150, 130, 34, 236, 23, 32, 46, 66, 80, 95, 142, 210, 177, 106, 226,
+                47, 22, 187, 5, 184, 140, 37, 219, 158, 96, 38, 69, 241, 65,
+            ],
+            rp: RelyingParty {
+                name: "test.ctap".to_owned(),
+                id: "test.ctap".to_owned(),
+            },
+            user: User {
+                id: Base64UrlSafeData(vec![
+                    43, 102, 137, 187, 24, 244, 22, 159, 6, 159, 188, 223, 80, 203, 110, 163, 198,
+                    10, 134, 27, 154, 123, 99, 148, 105, 131, 224, 181, 119, 183, 140, 112,
+                ]),
+                name: "testctap@ctap.com".to_owned(),
+                display_name: "Test Ctap".to_owned(),
+            },
+            pub_key_cred_params: vec![
+                PubKeyCredParams {
+                    type_: "public-key".to_owned(),
+                    alg: -7,
+                },
+                PubKeyCredParams {
+                    type_: "public-key".to_owned(),
+                    alg: -257,
+                },
+                PubKeyCredParams {
+                    type_: "public-key".to_owned(),
+                    alg: -37,
+                },
+            ],
+            exclude_list: vec![],
+            options: Some(BTreeMap::from([("rk".to_owned(), true)])),
+            pin_uv_auth_param: None,
+            pin_uv_auth_proto: None,
+            enterprise_attest: None,
+        };
+
+        let expected_response = MakeCredentialResponse {
+            fmt: Some("packed".to_owned()),
+            auth_data: Some(Value::Bytes(vec![
+                0, 33, 245, 252, 11, 133, 205, 34, 230, 6, 35, 188, 215, 209, 202, 72, 148, 137, 9,
+                36, 155, 71, 118, 235, 81, 81, 84, 229, 123, 102, 174, 18, 197, 0, 0, 0, 85, 248,
+                160, 17, 243, 140, 10, 77, 21, 128, 6, 23, 17, 31, 158, 220, 125, 0, 16, 244, 213,
+                123, 35, 221, 12, 183, 133, 104, 12, 218, 167, 247, 228, 79, 96, 165, 1, 2, 3, 38,
+                32, 1, 33, 88, 32, 223, 1, 125, 11, 40, 103, 149, 190, 161, 83, 209, 102, 160, 161,
+                91, 79, 107, 103, 163, 175, 74, 16, 30, 16, 232, 73, 111, 61, 211, 197, 209, 169,
+                34, 88, 32, 148, 178, 37, 81, 230, 50, 93, 119, 51, 196, 27, 178, 245, 166, 66,
+                173, 238, 65, 124, 151, 224, 144, 97, 151, 181, 176, 205, 139, 141, 108, 107, 167,
+                161, 107, 104, 109, 97, 99, 45, 115, 101, 99, 114, 101, 116, 245,
+            ])),
+            att_stmt: Some(Value::Map(BTreeMap::from([
+                (Value::Text("alg".to_owned()), Value::Integer(-7)),
+                (
+                    Value::Text("sig".to_owned()),
+                    Value::Bytes(vec![
+                        48, 69, 2, 32, 124, 202, 197, 122, 30, 67, 223, 36, 176, 132, 126, 235,
+                        241, 25, 210, 141, 205, 197, 4, 143, 125, 205, 142, 221, 121, 231, 151, 33,
+                        196, 27, 207, 45, 2, 33, 0, 216, 158, 199, 91, 146, 206, 143, 249, 228,
+                        111, 231, 248, 200, 121, 149, 105, 74, 99, 229, 183, 138, 184, 92, 71, 185,
+                        218, 28, 88, 10, 142, 200, 58,
+                    ]),
+                ),
+                (
+                    Value::Text("x5c".to_owned()),
+                    Value::Array(vec![Value::Bytes(vec![
+                        48, 130, 1, 147, 48, 130, 1, 56, 160, 3, 2, 1, 2, 2, 9, 0, 133, 155, 114,
+                        108, 178, 75, 76, 41, 48, 10, 6, 8, 42, 134, 72, 206, 61, 4, 3, 2, 48, 71,
+                        49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 85, 83, 49, 20, 48, 18, 6, 3, 85, 4,
+                        10, 12, 11, 89, 117, 98, 105, 99, 111, 32, 84, 101, 115, 116, 49, 34, 48,
+                        32, 6, 3, 85, 4, 11, 12, 25, 65, 117, 116, 104, 101, 110, 116, 105, 99, 97,
+                        116, 111, 114, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110, 48,
+                        30, 23, 13, 49, 54, 49, 50, 48, 52, 49, 49, 53, 53, 48, 48, 90, 23, 13, 50,
+                        54, 49, 50, 48, 50, 49, 49, 53, 53, 48, 48, 90, 48, 71, 49, 11, 48, 9, 6,
+                        3, 85, 4, 6, 19, 2, 85, 83, 49, 20, 48, 18, 6, 3, 85, 4, 10, 12, 11, 89,
+                        117, 98, 105, 99, 111, 32, 84, 101, 115, 116, 49, 34, 48, 32, 6, 3, 85, 4,
+                        11, 12, 25, 65, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 111, 114,
+                        32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110, 48, 89, 48, 19, 6,
+                        7, 42, 134, 72, 206, 61, 2, 1, 6, 8, 42, 134, 72, 206, 61, 3, 1, 7, 3, 66,
+                        0, 4, 173, 17, 235, 14, 136, 82, 229, 58, 213, 223, 237, 134, 180, 30, 97,
+                        52, 161, 142, 196, 225, 175, 143, 34, 26, 60, 125, 110, 99, 108, 128, 234,
+                        19, 195, 213, 4, 255, 46, 118, 33, 27, 180, 69, 37, 177, 150, 196, 76, 180,
+                        132, 153, 121, 207, 111, 137, 110, 205, 43, 184, 96, 222, 27, 244, 55, 107,
+                        163, 13, 48, 11, 48, 9, 6, 3, 85, 29, 19, 4, 2, 48, 0, 48, 10, 6, 8, 42,
+                        134, 72, 206, 61, 4, 3, 2, 3, 73, 0, 48, 70, 2, 33, 0, 233, 163, 159, 27,
+                        3, 25, 117, 37, 247, 55, 62, 16, 206, 119, 231, 128, 33, 115, 27, 148, 208,
+                        192, 63, 63, 218, 31, 210, 45, 179, 208, 48, 231, 2, 33, 0, 196, 250, 236,
+                        52, 69, 168, 32, 207, 67, 18, 156, 219, 0, 170, 190, 253, 154, 226, 216,
+                        116, 249, 197, 211, 67, 203, 47, 17, 61, 162, 55, 35, 243,
+                    ])]),
+                ),
+            ]))),
+            ..Default::default()
+        };
+
+        let frame = CableFrame::from_bytes(1, &request);
+        trace!(?frame);
+        let decoded = frame.parse_request().unwrap();
+        let decoded = if let RequestType::MakeCredential(req) = decoded {
+            req
+        } else {
+            panic!("Unexpected request type: {:?}", decoded);
+        };
+
+        // re-serialising these should have some result
+        assert_eq!(expected_request.cbor().unwrap(), decoded.cbor().unwrap());
+        let frame = CableFrame {
+            protocol_version: 1,
+            message_type: CableFrameType::Ctap,
+            data: expected_request.cbor().unwrap(),
+        };
+        assert_eq!(frame.to_bytes().unwrap(), request);
+
+        let response = vec![
+            1, 163, 1, 102, 112, 97, 99, 107, 101, 100, 2, 88, 162, 0, 33, 245, 252, 11, 133, 205,
+            34, 230, 6, 35, 188, 215, 209, 202, 72, 148, 137, 9, 36, 155, 71, 118, 235, 81, 81, 84,
+            229, 123, 102, 174, 18, 197, 0, 0, 0, 85, 248, 160, 17, 243, 140, 10, 77, 21, 128, 6,
+            23, 17, 31, 158, 220, 125, 0, 16, 244, 213, 123, 35, 221, 12, 183, 133, 104, 12, 218,
+            167, 247, 228, 79, 96, 165, 1, 2, 3, 38, 32, 1, 33, 88, 32, 223, 1, 125, 11, 40, 103,
+            149, 190, 161, 83, 209, 102, 160, 161, 91, 79, 107, 103, 163, 175, 74, 16, 30, 16, 232,
+            73, 111, 61, 211, 197, 209, 169, 34, 88, 32, 148, 178, 37, 81, 230, 50, 93, 119, 51,
+            196, 27, 178, 245, 166, 66, 173, 238, 65, 124, 151, 224, 144, 97, 151, 181, 176, 205,
+            139, 141, 108, 107, 167, 161, 107, 104, 109, 97, 99, 45, 115, 101, 99, 114, 101, 116,
+            245, 3, 163, 99, 97, 108, 103, 38, 99, 115, 105, 103, 88, 71, 48, 69, 2, 32, 124, 202,
+            197, 122, 30, 67, 223, 36, 176, 132, 126, 235, 241, 25, 210, 141, 205, 197, 4, 143,
+            125, 205, 142, 221, 121, 231, 151, 33, 196, 27, 207, 45, 2, 33, 0, 216, 158, 199, 91,
+            146, 206, 143, 249, 228, 111, 231, 248, 200, 121, 149, 105, 74, 99, 229, 183, 138, 184,
+            92, 71, 185, 218, 28, 88, 10, 142, 200, 58, 99, 120, 53, 99, 129, 89, 1, 151, 48, 130,
+            1, 147, 48, 130, 1, 56, 160, 3, 2, 1, 2, 2, 9, 0, 133, 155, 114, 108, 178, 75, 76, 41,
+            48, 10, 6, 8, 42, 134, 72, 206, 61, 4, 3, 2, 48, 71, 49, 11, 48, 9, 6, 3, 85, 4, 6, 19,
+            2, 85, 83, 49, 20, 48, 18, 6, 3, 85, 4, 10, 12, 11, 89, 117, 98, 105, 99, 111, 32, 84,
+            101, 115, 116, 49, 34, 48, 32, 6, 3, 85, 4, 11, 12, 25, 65, 117, 116, 104, 101, 110,
+            116, 105, 99, 97, 116, 111, 114, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111,
+            110, 48, 30, 23, 13, 49, 54, 49, 50, 48, 52, 49, 49, 53, 53, 48, 48, 90, 23, 13, 50,
+            54, 49, 50, 48, 50, 49, 49, 53, 53, 48, 48, 90, 48, 71, 49, 11, 48, 9, 6, 3, 85, 4, 6,
+            19, 2, 85, 83, 49, 20, 48, 18, 6, 3, 85, 4, 10, 12, 11, 89, 117, 98, 105, 99, 111, 32,
+            84, 101, 115, 116, 49, 34, 48, 32, 6, 3, 85, 4, 11, 12, 25, 65, 117, 116, 104, 101,
+            110, 116, 105, 99, 97, 116, 111, 114, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105,
+            111, 110, 48, 89, 48, 19, 6, 7, 42, 134, 72, 206, 61, 2, 1, 6, 8, 42, 134, 72, 206, 61,
+            3, 1, 7, 3, 66, 0, 4, 173, 17, 235, 14, 136, 82, 229, 58, 213, 223, 237, 134, 180, 30,
+            97, 52, 161, 142, 196, 225, 175, 143, 34, 26, 60, 125, 110, 99, 108, 128, 234, 19, 195,
+            213, 4, 255, 46, 118, 33, 27, 180, 69, 37, 177, 150, 196, 76, 180, 132, 153, 121, 207,
+            111, 137, 110, 205, 43, 184, 96, 222, 27, 244, 55, 107, 163, 13, 48, 11, 48, 9, 6, 3,
+            85, 29, 19, 4, 2, 48, 0, 48, 10, 6, 8, 42, 134, 72, 206, 61, 4, 3, 2, 3, 73, 0, 48, 70,
+            2, 33, 0, 233, 163, 159, 27, 3, 25, 117, 37, 247, 55, 62, 16, 206, 119, 231, 128, 33,
+            115, 27, 148, 208, 192, 63, 63, 218, 31, 210, 45, 179, 208, 48, 231, 2, 33, 0, 196,
+            250, 236, 52, 69, 168, 32, 207, 67, 18, 156, 219, 0, 170, 190, 253, 154, 226, 216, 116,
+            249, 197, 211, 67, 203, 47, 17, 61, 162, 55, 35, 243,
+        ];
+
+        // Deserialise response in caBLE v2.1
+        let frame = CableFrame::from_bytes(1, &response);
+        let v1_response = <MakeCredentialResponse as CBORResponse>::try_from(&frame.data)
+            .expect("Failed to decode message");
+        trace!(?v1_response);
+        assert_eq!(expected_response, v1_response);
+
+        // Serialise expected response
+        let resp: BTreeMap<u32, Value> = expected_response.clone().into();
+        let resp = serde_cbor::ser::to_vec_packed(&resp).unwrap();
+        let frame = CableFrame {
+            protocol_version: 1,
+            message_type: CableFrameType::Ctap,
+            data: resp.clone(),
+        };
+
+        assert_eq!(frame.to_bytes().unwrap(), response);
+
+        // Cable v2.0 should omit header byte
+        let frame = CableFrame::from_bytes(0, &response[1..]);
+        let v0_response = <MakeCredentialResponse as CBORResponse>::try_from(&frame.data)
+            .expect("Failed to decode message");
+        trace!(?v0_response);
+        assert_eq!(expected_response, v0_response);
+
+        // Serialise expected response
+        let frame = CableFrame {
+            protocol_version: 0,
+            message_type: CableFrameType::Ctap,
+            data: resp,
+        };
+        assert_eq!(frame.to_bytes().unwrap(), &response[1..]);
+    }
+
+    #[test]
+    fn shutdown() {
+        let shutdown_bytes = vec![0];
+        assert_eq!(shutdown_bytes, SHUTDOWN_COMMAND.to_bytes().unwrap());
+        assert_eq!(SHUTDOWN_COMMAND, CableFrame::from_bytes(1, &shutdown_bytes));
+    }
+
+    #[test]
+    fn update() {
+        let update_bytes = vec![2, 1, 2, 3, 4];
+        let update = CableFrame {
+            protocol_version: 1,
+            message_type: CableFrameType::Update,
+            data: vec![1, 2, 3, 4],
+        };
+
+        assert_eq!(update_bytes, update.to_bytes().unwrap());
+        assert_eq!(update, CableFrame::from_bytes(1, &update_bytes));
+    }
+
+    #[test]
+    fn unknown_frame_type() {
+        let unknown_bytes = [0xff; 16];
+        let unknown = CableFrame::from_bytes(1, &unknown_bytes);
+        assert_eq!(unknown.protocol_version, 1);
+        assert_eq!(unknown.message_type, CableFrameType::Unknown);
+        assert_eq!(&unknown.data, &[0xff; 15]);
+        assert_eq!(unknown.to_bytes(), None);
+    }
+}

--- a/webauthn-authenticator-rs/src/cable/handshake.rs
+++ b/webauthn-authenticator-rs/src/cable/handshake.rs
@@ -1,0 +1,237 @@
+use openssl::{ec::EcKey, pkey::Public};
+use serde::Serialize;
+use serde_cbor::Value;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use crate::{
+    cable::{base10, discovery::Discovery, tunnel::ASSIGNED_DOMAINS_COUNT, CableRequestType},
+    crypto::{point_to_bytes, public_key_from_bytes},
+    ctap2::commands::{
+        value_to_bool, value_to_string, value_to_u32, value_to_u64, value_to_vec_u8,
+    },
+    error::WebauthnCError,
+};
+
+const URL_PREFIX: &str = "FIDO:/";
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(into = "BTreeMap<u32, Value>", try_from = "BTreeMap<u32, Value>")]
+pub struct HandshakeV2 {
+    pub(super) peer_identity: EcKey<Public>,
+    secret: [u8; 16],
+    known_domains_count: u32,
+    timestamp: SystemTime,
+    supports_linking_info: bool,
+    pub(super) request_type: CableRequestType,
+    supports_non_discoverable_make_credential: bool,
+}
+
+impl From<HandshakeV2> for BTreeMap<u32, Value> {
+    fn from(value: HandshakeV2) -> Self {
+        let HandshakeV2 {
+            peer_identity,
+            secret,
+            known_domains_count,
+            timestamp,
+            supports_linking_info,
+            request_type,
+            supports_non_discoverable_make_credential,
+        } = value;
+
+        let mut o = BTreeMap::from([
+            (1, Value::Bytes(secret.to_vec())),
+            (2, Value::Integer(known_domains_count.into())),
+            (
+                3,
+                Value::Integer(
+                    timestamp
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs()
+                        .into(),
+                ),
+            ),
+            // Chrome omits this field when false, but Safari always includes it.
+            // Presence of this field = v2.1, missing = v2.0
+            (4, Value::Bool(supports_linking_info)),
+            (5, Value::Text(request_type.to_cable_string())),
+        ]);
+
+        if let Ok(v) = point_to_bytes(peer_identity.public_key(), true) {
+            o.insert(0, Value::Bytes(v));
+        }
+
+        if supports_non_discoverable_make_credential
+            && request_type == CableRequestType::MakeCredential
+        {
+            o.insert(6, Value::Bool(true));
+        }
+
+        o
+    }
+}
+
+impl TryFrom<BTreeMap<u32, Value>> for HandshakeV2 {
+    type Error = WebauthnCError;
+
+    fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
+        // trace!(?raw);
+        let peer_identity = raw
+            .remove(&0)
+            .and_then(|v| value_to_vec_u8(v, "0x00"))
+            .ok_or(WebauthnCError::MissingRequiredField)?;
+
+        let peer_identity = public_key_from_bytes(&peer_identity)?;
+
+        let secret = raw
+            .remove(&1)
+            .and_then(|v| value_to_vec_u8(v, "0x01"))
+            .ok_or(WebauthnCError::MissingRequiredField)?
+            .try_into()
+            .map_err(|_| WebauthnCError::InvalidAlgorithm)?;
+
+        let known_domains_count = raw
+            .remove(&2)
+            .and_then(|v| value_to_u32(&v, "0x02"))
+            .unwrap_or_default();
+
+        let timestamp = raw
+            .remove(&3)
+            .and_then(|v| value_to_u64(&v, "0x03"))
+            .unwrap_or_default();
+        let timestamp = UNIX_EPOCH + Duration::from_secs(timestamp);
+
+        let supports_linking_info = raw
+            .remove(&4)
+            .and_then(|v| value_to_bool(&v, "0x04"))
+            .unwrap_or_default();
+
+        let supports_non_discoverable_make_credential = raw
+            .remove(&6)
+            .and_then(|v| value_to_bool(&v, "0x06"))
+            .unwrap_or_default();
+
+        let request_type = raw
+            .remove(&5)
+            .and_then(|v| value_to_string(v, "0x05"))
+            .and_then(|v| {
+                CableRequestType::from_cable_string(
+                    v.as_str(),
+                    supports_non_discoverable_make_credential,
+                )
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            peer_identity,
+            secret,
+            known_domains_count,
+            timestamp,
+            supports_linking_info,
+            request_type,
+            supports_non_discoverable_make_credential,
+        })
+    }
+}
+
+impl HandshakeV2 {
+    pub fn new(
+        request_type: CableRequestType,
+        public_key: EcKey<Public>,
+        qr_key: [u8; 16],
+    ) -> Result<Self, WebauthnCError> {
+        Ok(Self {
+            peer_identity: public_key,
+            secret: qr_key,
+            known_domains_count: ASSIGNED_DOMAINS_COUNT,
+            timestamp: SystemTime::now(),
+            supports_linking_info: false,
+            request_type,
+            supports_non_discoverable_make_credential: false,
+        })
+    }
+
+    /// Encodes a [HandshakeV2] into a `FIDO:/` QR code.
+    pub fn to_qr_url(&self) -> Result<String, WebauthnCError> {
+        let payload: Vec<u8> =
+            serde_cbor::ser::to_vec_packed(self).map_err(|_| WebauthnCError::Cbor)?;
+        Ok(format!("{}{}", URL_PREFIX, base10::encode(&payload)))
+    }
+
+    /// Decodes a `FIDO:/` QR code into a [HandshakeV2].
+    pub fn from_qr_url(url: &str) -> Result<Self, WebauthnCError> {
+        let url = url.to_ascii_uppercase();
+        if !url.starts_with(URL_PREFIX) || url.len() <= URL_PREFIX.len() {
+            return Err(WebauthnCError::InvalidCableUrl);
+        }
+
+        let (_, payload) = url.split_at(URL_PREFIX.len());
+        let payload = base10::decode(payload)?;
+        let v: BTreeMap<u32, Value> =
+            serde_cbor::from_slice(&payload).map_err(|_| WebauthnCError::Cbor)?;
+
+        Self::try_from(v)
+    }
+
+    /// Converts a [HandshakeV2] payload (from a QR code) into a [Discovery]
+    /// which can be used to respond to the request.
+    pub fn to_discovery(&self) -> Result<Discovery, WebauthnCError> {
+        Discovery::new_with_qr_secret(self.request_type, self.secret.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn invalid_urls() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        use base10::DecodeError::*;
+        use WebauthnCError::*;
+        const URLS: [(&str, WebauthnCError); 7] = [
+            ("http://example.com", InvalidCableUrl),
+            ("fido:/", InvalidCableUrl),
+            ("FIDO:/", InvalidCableUrl),
+            ("FIDO://", Base10(ContainsNonDigitChars)),
+            ("FIDO:/0", Base10(InvalidLength)),
+            ("FIDO:/999", Base10(OutOfRange)),
+            ("FIDO:/000", Cbor),
+        ];
+
+        for (u, e) in URLS {
+            assert_eq!(Some(e), HandshakeV2::from_qr_url(u).err(), "url = {:?}", u);
+        }
+    }
+
+    #[test]
+    fn decode_chrome() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        // URL generated by Chrome
+        let u = "FIDO:/162870791865632382552704231438327900152302540348097243854039966655366469794954476199158014113179232779520163209900691930075274801398564434658077048963842109321447142660";
+
+        let h = HandshakeV2::from_qr_url(u).unwrap();
+        trace!(?h);
+
+        // Can we round-trip the handshake?
+        let e = h.to_qr_url().unwrap();
+        assert_eq!(e.as_str(), u);
+    }
+
+    #[test]
+    fn decode_safari_ios() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let u = "FIDO:/089962132878132862898875319509818655951233947060166026934941652203853844930597225184066237811614893181300344014421205790072080843938838513707157859599106109321447142404";
+        let h = HandshakeV2::from_qr_url(u).unwrap();
+        trace!(?h);
+
+        // Can we round-trip the handshake?
+        let e = h.to_qr_url().unwrap();
+        assert_eq!(e.as_str(), u);
+    }
+}

--- a/webauthn-authenticator-rs/src/cable/mod.rs
+++ b/webauthn-authenticator-rs/src/cable/mod.rs
@@ -1,0 +1,481 @@
+//! caBLE / Hybrid Authenticator
+//!
+//! **tl;dr:** scan a QR code with a `FIDO:/` URL, mobile device sends a BTLE
+//! advertisement, this is used to establish a doubly-encrypted (TLS and
+//! [Noise][]) Websocket tunnel over which the platform can send a single CTAP
+//! 2.x command and get a response.
+//!
+//! This module implements both the [initator][connect_cable_authenticator] and
+//! [authenticator][share_cable_authenticator] side of caBLE, provided
+//! [you have appropriate hardware](#requirements).
+//!
+//! The initiator implementation provides a [`CtapAuthenticator`][] (so works
+//! like other authenticator backends), and uses a [`UiCallback`][]
+//! implementation to display the QR code the user. Authenticators on Android
+//! and iOS only allow the initiator to send a single command before hanging up,
+//! so other features like credential management won't work.
+//!
+//! The authenticator implementation takes an input URL (parsed from the QR
+//! code), a [`AuthenticatorBackendHashedClientData`] and an [`Advertiser`] to
+//! establish a tunnel and respond to an initator's request. This allows one to
+//! share many of the authenticator backends this library already supports over
+//! a caBLE tunnel.
+//!
+//! ## Warning
+//!
+//! **This implementation is incomplete, and has not been reviewed from a
+//! cryptography standpoint.**
+//!
+//! There is **no** publicly-published spec from this protocol, aside from
+//! [Chromium's C++ implementation][crcable], so this aims to do whatever
+//! Chromium does.
+//!
+//! We've attempted to document and untangle things as best we can, but there
+//! are probably errors in this implementation and its documentation. caBLE's
+//! design appears to have changed multiple times during its development, aiming
+//! for compatibility with older versions of Chromium.
+//!
+//! ## Features
+//!
+//! There are two major versions of caBLE, and this only implements caBLE v2.
+//! There are also several minor versions of caBLE v2, which aren't fully
+//! explained (or implemented here); this mostly implements what we *think* is
+//! caBLE v2.1 as both an initiator and an authenticator.
+//!
+//! Known-missing functionality includes:
+//!
+//! * caBLE v1: protocol is significantly different
+//! * caBLE v2.0: this has some quirks that this doesn't fully implement
+//! * [caBLE over AOA][cableaoa] (Android Open Accessory Protocol)
+//! * [caBLE over Firebase Cloud Messaging][cablefcm]
+//! * Pairing (aka: "contact lists", "remember this computer")
+//!
+//! It is impossible to know for certain how many gaps there are until the caBLE
+//! working group publishes documentation *publicly*.
+//!
+//! The library is complete enough as an initiator to communicate with
+//! authenticators on Android and iOS 16, and complete enough as an
+//! authenticator to work with Chrome and Safari as initiators.
+//!
+//! ## Requirements
+//!
+//! The initator (or "browser") requires:
+//!
+//! * a Bluetooth Low Energy (BTLE) adaptor
+//!
+//! * an internet connection
+//!
+//! The authenticator (mobile device) requires:
+//!
+//! * a caBLE implementation, such as:
+//!
+//!   * [Android 7 or later][android-ver] with
+//!     [a recent version of Chrome and Google Play Services (October 2022)][android]
+//!
+//!   * [iOS 16 or later][ios][^ios15]
+//!
+//! * a Bluetooth Low Energy (BTLE) radio which can transmit service data
+//!   advertisements
+//!
+//! * a camera and QR code scanner[^qr]
+//!
+//! * an internet connection
+//!
+//! **On Android,** Chrome handles the `FIDO:/` URL and establishes the
+//! Websocket tunnel, and proxies commands to
+//! [Google Play's FIDO2 API][gpfido2]. The authenticator
+//! [is stored in Google Password Manager][android-sec], and it also supports
+//! [devicePubKey][] to attest a specific device's identity.
+//!
+//! **On iOS,** the authenticator is stored in the iCloud Keychain and shared
+//! with all devices signed in to that iCloud account. There is no way to
+//! identify *which* device was used.
+//!
+//! In both cases, the credential is cached in the device's secure element, and
+//! requires user verification (lock screen pattern, PIN, password or biometric
+//! authentication) to access. This user verification is performed on-device,
+//! and is entirely separate to CTAP2's PIN/UV auth.
+//!
+//! [^ios15]: iOS 15 will recognise caBLE QR codes and offer to authenticate,
+//! but this version of the protocol is not supported.
+//!
+//! ## Protocol overview
+//!
+//! Entities in a caBLE transaction:
+//!
+//! * The _initator_ (typically a web browser) starts the caBLE session for a
+//!   `MakeCredential` or `GetAssertion` request on behalf of a relying party.
+//!
+//! * The _authenticator_ (or mobile device) stores credential(s) for the user
+//!   in a secure fashion, with some sort of local authentication.
+//!
+//! * The _tunnel server_ provides a two-way channel for the initator and
+//!   authenticator to communicate over WebSockets. There are well-known servers
+//!   operated by Apple (`wss://cable.auth.com`) and Google
+//!   (`wss://cable.ua5v.com`), and an algorithm to generate tunnel server
+//!   domain names from a hash to allow for future expansion.
+//!
+//! The user attempts to register or sign in using WebAuthn, and chooses to use
+//! caBLE ("create a passkey on another device", "save a passkey on a device
+//! with a camera"). This application becomes the _initator_ of the caBLE
+//! session.
+//!
+//! The initator generates a CBOR message ([HandshakeV2][]) containing the
+//! desired transaction type (`MakeCredential` or `GetAssertion`),
+//! [a shared secret][qr-secret] and some protocol version information. It
+//! encodes the message as a `FIDO:/` URL by encoding the CBOR as [base10], and
+//! then displays it as a QR code for the user to scan with their authenticator.
+//!
+//! The user scans this QR code using their authenticator (mobile device), which
+//! deserialises the [HandshakeV2][] message.
+//!
+//! Both the initiator and authenticator
+//! [derive the tunnel ID][discovery::Discovery::derive_tunnel_id] from the QR
+//! code's [shared secret][qr-secret].
+//!
+//! The authenticator establishes a connection to
+//! [a well-known WebSocket tunnel server][tunnel::get_domain] of *its*
+//! choosing. Once established, the tunnel server provides a routing ID, which
+//! allows the initiator to connect to this session.
+//!
+//! The authenticator takes [the routing ID][routing_id],
+//! [tunnel server ID][tunnel_server_id], and
+//! [a nonce of its choosing][nonce] (not shared with the tunnel server) into an
+//! [Eid][], and then encrypts and signs it using a secret derived from the QR
+//! code's [shared secret][qr-secret]. It then broadcasts this encrypted [Eid][]
+//! as a BTLE service data advertisement.
+//!
+//! Meanwhile, the initiator scans for caBLE BTLE service data advertisements,
+//! and [tries to decrypt and parse them][discovery::Discovery::decrypt_advert].
+//! On success, it can then find which
+//! [tunnel server to connect to][tunnel_server_id], the
+//! [routing ID][routing_id], and [the nonce][nonce].
+//!
+//! Both the initator and the authenticator
+//! [derive a pre-shared key][discovery::Discovery::derive_psk] from the
+//! [shared secret][qr-secret] and [nonce][].
+//!
+//! The initator connects to the tunnel server, and starts a handshake with the
+//! authenticator using a non-standard version of the [Noise protocol][Noise]
+//! ([CableNoise][]), using the pre-shared key and a new
+//! ephemeral session key.
+//!
+//! They use the [CableNoise][] to derive traffic keys for [Crypter][]. All
+//! further communications between the initiator and authenticator occur over
+//! the [Crypter][] channel.
+//!
+//! The authenticator immediately sends a [GetInfoResponse][], and will also
+//! send a pairing payload once the user has accepted or refused consent[^pair].
+//!
+//! The initiator can then send a *single* `MakeCredential` or `GetAssertion`
+//! command to the authenticator in CTAP 2.0 format. This request *does not* use
+//! PIN/UV auth – user verification is handled internally by the authenticator
+//! *outside* the CTAP 2.0 protocol[^uv].
+//!
+//! Once the command is sent, the authenticator will prompt the user to approve
+//! the request in a user-verifying way (biometric or lock screen pattern,
+//! password or PIN), showing the user and relying party name.
+//!
+//! Once approved or rejected, the authenticator returns the response to the
+//! command, and then closes the Websocket channel. A new handshake must be
+//! performed if the user wishes to perform another transaction.
+//!
+//! The initiator then sends the authenticator's response to the relying party
+//! using the usual WebAuthn APIs.
+//!
+//! [android]: https://developers.google.com/identity/passkeys/supported-environments
+//! [android-sec]: https://security.googleblog.com/2022/10/SecurityofPasskeysintheGooglePasswordManager.html
+//! [android-ver]: https://source.chromium.org/chromium/chromium/src/+/main:chrome/android/features/cablev2_authenticator/java/src/org/chromium/chrome/browser/webauth/authenticator/CableAuthenticatorUI.java;l=170-171;drc=4a8573cb240df29b0e4d9820303538fb28e31d84
+//! [cableaoa]: https://source.chromium.org/chromium/chromium/src/+/main:device/fido/aoa/
+//! [CableNoise]: noise::CableNoise
+//! [cablefcm]: https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_authenticator.h;l=150-161;drc=eef4e6f76aff3defa06b9f8d921fcd46bb3e4dc1
+//! [crcable]: https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/
+//! [Crypter]: noise::Crypter
+//! [devicePubKey]: https://w3c.github.io/webauthn/#sctn-device-publickey-extension
+//! [Eid]: discovery::Eid
+//! [GetInfoResponse]: crate::ctap2::GetInfoResponse
+//! [gpfido2]: https://developers.google.com/android/reference/com/google/android/gms/fido/fido2/Fido2PrivilegedApiClient
+//! [HandshakeV2]: handshake::HandshakeV2
+//! [ios]: https://developer.apple.com/videos/play/wwdc2022/10092/
+//! [Noise]: http://noiseprotocol.org/noise.html
+//! [nonce]: discovery::Eid::nonce
+//! [qr-secret]: handshake::HandshakeV2::secret
+//! [routing_id]: discovery::Eid::routing_id
+//! [tunnel_server_id]: discovery::Eid::tunnel_server_id
+//!
+//! [^pair]: Pairing payloads are only supported on Android. Where supported,
+//! pairing payloads will always be sent, padded to a constant size,
+//! *regardless* of whether the user consented to pairing. If the user did not
+//! consent, the payload will just be null bytes.
+//!
+//! [^uv]: Chromium and Safari won't even attempt PIN/UV auth, even if the
+//! [GetInfoResponse][] suggested it was required.
+//!
+//! [^qr]: Most mobile device camera apps have an integrated QR code scanner.
+#[allow(rustdoc::private_intra_doc_links)]
+mod base10;
+mod btle;
+mod discovery;
+mod framing;
+mod handshake;
+mod noise;
+mod tunnel;
+
+use std::collections::BTreeMap;
+
+pub use base10::DecodeError;
+pub use btle::Advertiser;
+
+use crate::{
+    authenticator_hashed::{
+        perform_auth_with_request, perform_register_with_request,
+        AuthenticatorBackendHashedClientData,
+    },
+    cable::{
+        btle::Scanner,
+        discovery::Discovery,
+        framing::{CableFrameType, RequestType, SHUTDOWN_COMMAND},
+        handshake::HandshakeV2,
+        tunnel::Tunnel,
+    },
+    ctap2::{CtapAuthenticator, GetInfoResponse},
+    error::{CtapError, WebauthnCError},
+    transport::Token,
+    types::{CableRequestType, CableState},
+    ui::UiCallback,
+};
+
+type Psk = [u8; 32];
+
+impl CableRequestType {
+    fn to_cable_string(self) -> String {
+        use CableRequestType::*;
+        match self {
+            GetAssertion => String::from("ga"),
+            DiscoverableMakeCredential => String::from("mc"),
+            MakeCredential => String::from("mc"),
+        }
+    }
+
+    fn from_cable_string(
+        val: &str,
+        supports_non_discoverable_make_credential: bool,
+    ) -> Option<Self> {
+        use CableRequestType::*;
+        match val {
+            "ga" => Some(GetAssertion),
+            "mc" => Some(if supports_non_discoverable_make_credential {
+                MakeCredential
+            } else {
+                DiscoverableMakeCredential
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Establishes a connection to a caBLE authenticator using QR codes, Bluetooth
+/// Low Energy and a Websocket tunnel.
+///
+/// The QR code to be displayed will be passed via [UiCallback::cable_qr_code].
+///
+/// The resulting connection is passed as a [CtapAuthenticator], but the remote
+/// device will only accept a single command (specified in the `request_type`
+/// parameter) and then close the underlying Websocket.
+pub async fn connect_cable_authenticator<'a, U: UiCallback + 'a>(
+    request_type: CableRequestType,
+    ui_callback: &'a U,
+) -> Result<CtapAuthenticator<'a, Tunnel, U>, WebauthnCError> {
+    // TODO: it may be better to return a caBLE-specific authenticator object,
+    // rather than CtapAuthenticator, because the device will close the
+    // Websocket connection as soon as we've sent a single command.
+    trace!("Creating discovery QR code...");
+    let disco = Discovery::new(request_type)?;
+    let handshake = disco.make_handshake()?;
+    let url = handshake.to_qr_url()?;
+    ui_callback.cable_qr_code(request_type, url);
+
+    trace!("Opening BTLE...");
+    let scanner = Scanner::new().await?;
+    trace!("Waiting for beacon...");
+    let eid = disco
+        .wait_for_matching_response(&scanner)
+        .await?
+        .ok_or_else(|| {
+            error!("No caBLE EID received!");
+            WebauthnCError::NoSelectedToken
+        })?;
+    ui_callback.dismiss_qr_code();
+    drop(scanner);
+
+    let psk = disco.derive_psk(&eid)?;
+
+    let connect_url = disco.get_connect_uri(&eid)?;
+    let tun = Tunnel::connect_initiator(
+        &connect_url,
+        psk,
+        disco.local_identity.as_ref(),
+        ui_callback,
+    )
+    .await?;
+
+    tun.get_authenticator(ui_callback).ok_or_else(|| {
+        error!("no supported protocol versions!");
+        WebauthnCError::NotSupported
+    })
+}
+
+/// Share an authenicator using caBLE.
+///
+/// * `backend` is a [AuthenticatorBackendHashedClientData] implementation.
+///
+/// * `url` is a `FIDO:/` URL from the initator's QR code.
+///
+/// * `tunnel_server_id` is the well-known tunnel server to use. Set this to 0
+///   to use Google's tunnel server.
+///
+/// * `advertiser` is reference to an [Advertiser] for starting and stopping
+///   Bluetooth Low Energy advertisements.
+///
+/// * `ui_callback` trait for prompting for user interaction where needed.
+pub async fn share_cable_authenticator<'a, U>(
+    backend: &mut impl AuthenticatorBackendHashedClientData,
+    mut info: GetInfoResponse,
+    url: &str,
+    tunnel_server_id: u16,
+    advertiser: &mut impl Advertiser,
+    ui_callback: &'a U,
+    close_after_one_command: bool,
+) -> Result<(), WebauthnCError>
+where
+    U: UiCallback + 'a,
+{
+    // Because AuthenticatorBackendWithRequests does PIN/UV auth for us, we need
+    // to remove anything from GetInfoResponse that would suggest the remote
+    // side should attempt PIN/UV auth.
+    //
+    // Chromium and Safari appear to ignore these options, but we actually do
+    // this properly. For now, we're just going to set this to "known" values.
+    info.options = Some(BTreeMap::from([
+        // Possibly a lie.
+        ("uv".to_string(), true),
+    ]));
+    info.pin_protocols = None;
+    let transports = info.transports.get_or_insert(Default::default());
+    transports.push("cable".to_string());
+    transports.push("hybrid".to_string());
+
+    let handshake = HandshakeV2::from_qr_url(url)?;
+    let discovery = handshake.to_discovery()?;
+
+    let mut tunnel = Tunnel::connect_authenticator(
+        &discovery,
+        tunnel_server_id,
+        &handshake.peer_identity,
+        info,
+        advertiser,
+        ui_callback,
+    )
+    .await?;
+
+    trace!("tunnel established");
+    let timeout_ms = 30000;
+
+    loop {
+        ui_callback.cable_status_update(CableState::WaitingForInitiatorCommand);
+        let msg = tunnel.recv().await?.ok_or(WebauthnCError::Closed)?;
+
+        ui_callback.cable_status_update(CableState::Processing);
+        let resp = match msg.message_type {
+            CableFrameType::Shutdown => {
+                break;
+            }
+            CableFrameType::Ctap => match (handshake.request_type, msg.parse_request()?) {
+                (CableRequestType::MakeCredential, RequestType::MakeCredential(mc))
+                | (CableRequestType::DiscoverableMakeCredential, RequestType::MakeCredential(mc)) => {
+                    perform_register_with_request(backend, mc, timeout_ms)
+                }
+                (CableRequestType::GetAssertion, RequestType::GetAssertion(ga)) => {
+                    perform_auth_with_request(backend, ga, timeout_ms)
+                }
+                (c, v) => {
+                    error!("Unhandled command {:02x?} for {:?}", v, c);
+                    Err(WebauthnCError::NotSupported)
+                }
+            },
+            CableFrameType::Update => {
+                warn!("Linking information is not supported, ignoring update message");
+                continue;
+            }
+
+            _ => {
+                error!("unhandled command: {:?}", msg);
+                Err(WebauthnCError::NotSupported)
+            }
+        };
+
+        // Re-insert the error code as needed.
+        let resp = match resp {
+            Err(e) => match e {
+                WebauthnCError::Ctap(c) => vec![c.into()],
+                _ => vec![CtapError::Ctap1InvalidParameter.into()],
+            },
+            Ok(mut resp) => {
+                resp.reserve(1);
+                resp.insert(0, CtapError::Ok.into());
+                resp
+            }
+        };
+
+        // Send the response to the command
+        tunnel
+            .send(framing::CableFrame {
+                protocol_version: 1,
+                message_type: CableFrameType::Ctap,
+                data: resp,
+            })
+            .await?;
+
+        if close_after_one_command {
+            tunnel.send(SHUTDOWN_COMMAND).await?;
+            break;
+        }
+    }
+
+    // Hang up
+    tunnel.close().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cable_request_type() {
+        assert_eq!(
+            Some(CableRequestType::DiscoverableMakeCredential),
+            CableRequestType::from_cable_string("mc", false)
+        );
+        assert_eq!(
+            Some(CableRequestType::MakeCredential),
+            CableRequestType::from_cable_string("mc", true)
+        );
+        assert_eq!(
+            Some(CableRequestType::GetAssertion),
+            CableRequestType::from_cable_string("ga", false)
+        );
+        assert_eq!(
+            Some(CableRequestType::GetAssertion),
+            CableRequestType::from_cable_string("ga", true)
+        );
+        assert_eq!(None, CableRequestType::from_cable_string("nonsense", false));
+
+        assert_eq!(
+            "mc",
+            CableRequestType::DiscoverableMakeCredential.to_cable_string()
+        );
+        assert_eq!("mc", CableRequestType::MakeCredential.to_cable_string());
+        assert_eq!("ga", CableRequestType::GetAssertion.to_cable_string());
+    }
+}

--- a/webauthn-authenticator-rs/src/cable/mod.rs
+++ b/webauthn-authenticator-rs/src/cable/mod.rs
@@ -171,6 +171,10 @@
 //! These controls **do not** apply to applications compiled locally, or
 //! distributed outside of the Windows Store.
 //!
+//! The Windows WebAuthn API does not (presently) support caBLE authenticators,
+//! nor does it limit direct access to them, so this does *not* need to run as
+//! Administrator.
+//!
 //! ## Protocol overview
 //!
 //! The user attempts to register or sign in using WebAuthn, and chooses to use

--- a/webauthn-authenticator-rs/src/cable/noise.rs
+++ b/webauthn-authenticator-rs/src/cable/noise.rs
@@ -1,0 +1,876 @@
+//! caBLE version of [Noise protocol][].
+//!
+//! caBLE uses a variant of [Noise protocol][] to establish a secure channel
+//! between the initiator and authenticator in a way that the tunnel server
+//! can't decrypt.
+//!
+//! [Noise protocol]: http://noiseprotocol.org/noise.html
+use std::mem::size_of;
+
+use openssl::{
+    ec::{EcKey, EcKeyRef, EcPointRef},
+    pkey::{Private, Public},
+    symm::{decrypt_aead, encrypt_aead, Cipher},
+};
+
+use crate::{
+    cable::Psk,
+    crypto::{ecdh, hkdf_sha_256, point_to_bytes, public_key_from_bytes, regenerate},
+    prelude::WebauthnCError,
+    util::compute_sha256_2,
+};
+
+const NOISE_KN_PROTOCOL: &[u8; 32] = b"Noise_KNpsk0_P256_AESGCM_SHA256\0";
+const NOISE_NK_PROTOCOL: &[u8; 32] = b"Noise_NKpsk0_P256_AESGCM_SHA256\0";
+const PADDING_MUL: usize = 32;
+pub type EncryptionKey = [u8; 32];
+pub type Nonce = [u8; 12];
+const OLD_ADDITIONAL_BYTES: [u8; 1] = [/* version */ 2];
+const NEW_ADDITIONAL_BYTES: [u8; 0] = [];
+
+#[derive(Clone, Copy)]
+pub enum HandshakeType {
+    KNpsk0,
+    NKpsk0,
+}
+
+/// Variations of the Noise protocol used by caBLE.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum NonceType {
+    /// Old [Crypter] mode.
+    ///
+    /// This uses a little-endian nonce and extra additional bytes.
+    #[default]
+    Old,
+
+    /// New [Crypter] mode.
+    ///
+    /// This follows the Noise standard with a big-endian nonce and no
+    /// additional bytes.
+    New,
+
+    /// Handshake ([CableNoise]) mode.
+    ///
+    /// This uses a big-endian nonce at the wrong byte offset.
+    Handshake,
+}
+
+/// Implements the Noise [CipherState][0] object, with variations for caBLE's
+/// non-standard behaviour.
+///
+/// Unlike regular Noise, this uses a 32-bit nonce value.
+///
+/// [0]: https://noiseprotocol.org/noise.html#the-cipherstate-object
+pub struct CipherState {
+    n: u32,
+    nonce_type: NonceType,
+    padding: bool,
+    k: Option<EncryptionKey>,
+}
+
+impl CipherState {
+    fn new(nonce_type: NonceType, padding: bool) -> Self {
+        Self {
+            k: None,
+            n: 0,
+            nonce_type,
+            padding,
+        }
+    }
+
+    fn init_key(&mut self, key: EncryptionKey) {
+        self.k = Some(key);
+        self.n = 0;
+    }
+
+    pub fn encrypt(&mut self, pt: &[u8], aad: Option<&[u8]>) -> Result<Vec<u8>, WebauthnCError> {
+        if let Some(k) = self.k.as_ref() {
+            if self.n == u32::MAX {
+                return Err(WebauthnCError::NonceOverflow);
+            }
+
+            let aad = aad.unwrap_or_else(|| {
+                if self.nonce_type == NonceType::Old {
+                    &OLD_ADDITIONAL_BYTES
+                } else {
+                    &NEW_ADDITIONAL_BYTES
+                }
+            });
+
+            let padded = self.padding.then(|| pad(pt));
+
+            let nonce = self.construct_nonce();
+            self.n += 1;
+
+            let cipher = Cipher::aes_256_gcm();
+            let mut tag = [0; 16];
+
+            let mut encrypted = encrypt_aead(
+                cipher,
+                k,
+                Some(&nonce),
+                aad,
+                padded.as_deref().unwrap_or(pt),
+                &mut tag,
+            )?;
+            encrypted.reserve(16);
+            encrypted.extend_from_slice(&tag);
+
+            Ok(encrypted)
+        } else {
+            Ok(pt.to_vec())
+        }
+    }
+
+    pub fn decrypt(&mut self, ct: &[u8], aad: Option<&[u8]>) -> Result<Vec<u8>, WebauthnCError> {
+        if let Some(k) = self.k.as_ref() {
+            if self.n == u32::MAX {
+                return Err(WebauthnCError::NonceOverflow);
+            }
+
+            let aad = aad.unwrap_or_else(|| {
+                if self.nonce_type == NonceType::Old {
+                    &OLD_ADDITIONAL_BYTES
+                } else {
+                    &NEW_ADDITIONAL_BYTES
+                }
+            });
+
+            let msg_len = ct.len() - 16;
+            let nonce = self.construct_nonce();
+
+            let cipher = Cipher::aes_256_gcm();
+
+            let decrypted =
+                decrypt_aead(cipher, k, Some(&nonce), aad, &ct[..msg_len], &ct[msg_len..]);
+
+            let mut decrypted = match decrypted {
+                Err(e) => {
+                    if self.nonce_type == NonceType::Old && self.n == 0 {
+                        // Switch to new construction mode
+                        trace!("trying new construction");
+                        self.nonce_type = NonceType::New;
+                        return self.decrypt(ct, None);
+                    } else {
+                        // throw original error
+                        return Err(e.into());
+                    }
+                }
+                Ok(d) => d,
+            };
+
+            self.n += 1;
+
+            if self.padding {
+                unpad(&mut decrypted)?;
+            }
+
+            Ok(decrypted)
+        } else {
+            Ok(ct.to_vec())
+        }
+    }
+
+    fn construct_nonce(&self) -> Nonce {
+        let mut nonce = [0; size_of::<Nonce>()];
+
+        use NonceType::*;
+        match self.nonce_type {
+            // First 4 bytes are little-endian nonce
+            Old => nonce[..size_of::<u32>()].copy_from_slice(&self.n.to_le_bytes()),
+            // Last 4 bytes are big-endian nonce
+            New => nonce[size_of::<Nonce>() - size_of::<u32>()..]
+                .copy_from_slice(&self.n.to_be_bytes()),
+            // First 4 bytes are big-endian nonce
+            Handshake => nonce[..size_of::<u32>()].copy_from_slice(&self.n.to_be_bytes()),
+        }
+
+        nonce
+    }
+}
+
+/// Implements the [SymmetricState][] object in Noise, using caBLE's variant of
+/// the Noise protocol.
+///
+/// [SymmetricState]: https://noiseprotocol.org/noise.html#the-symmetricstate-object
+pub struct CableNoise {
+    ck: [u8; 32],
+    h: [u8; 32],
+
+    cipher_state: CipherState,
+
+    ephemeral_key: EcKey<Private>,
+    local_identity: Option<EcKey<Private>>,
+}
+
+impl CableNoise {
+    /// InitializeSymmetric
+    fn new(handshake_type: HandshakeType) -> Result<Self, WebauthnCError> {
+        // Protocol name is always HASHLEN bytes
+        let protocol_name = match handshake_type {
+            HandshakeType::KNpsk0 => *NOISE_KN_PROTOCOL,
+            HandshakeType::NKpsk0 => *NOISE_NK_PROTOCOL,
+        };
+
+        let ephemeral_key = regenerate()?;
+
+        Ok(Self {
+            ck: protocol_name,
+            h: protocol_name,
+            cipher_state: CipherState::new(NonceType::Handshake, false),
+            ephemeral_key,
+            local_identity: None,
+        })
+    }
+
+    /// `SymmetricState.MixHash(data)`
+    ///
+    /// Sets `h = HASH(h || data}`
+    fn mix_hash(&mut self, data: &[u8]) {
+        self.h = compute_sha256_2(&self.h, data);
+    }
+
+    fn mix_hash_point(&mut self, point: &EcPointRef) -> Result<(), WebauthnCError> {
+        let point = point_to_bytes(point, false)?;
+        self.mix_hash(&point);
+        Ok(())
+    }
+
+    /// `SymmetricState.MixKey(input_key_material)`
+    fn mix_key(&mut self, ikm: &[u8]) -> Result<(), WebauthnCError> {
+        let mut o = [0; 64];
+        hkdf_sha_256(&self.ck, ikm, None, &mut o)?;
+        let (ck, temp_k) = o.split_at(32);
+        self.ck.copy_from_slice(ck);
+        self.cipher_state
+            .init_key(temp_k.try_into().expect("incorrect temp_k length"));
+        Ok(())
+    }
+
+    /// `SymmetricState.MixKeyAndHash(input_key_material)`
+    fn mix_key_and_hash(&mut self, ikm: &[u8]) -> Result<(), WebauthnCError> {
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/noise.cc;l=90;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29
+        let mut o = [0; 32 * 3];
+        hkdf_sha_256(&self.ck, ikm, None, &mut o)?;
+        let (ck, temp) = o.split_at(32);
+        let (temp_h, temp_k) = temp.split_at(32);
+
+        self.ck.copy_from_slice(ck);
+        self.mix_hash(temp_h);
+        self.cipher_state
+            .init_key(temp_k.try_into().expect("incorrect temp_k length"));
+        Ok(())
+    }
+
+    /// `SymmetricState.EncryptAndHash(plaintext)`
+    fn encrypt_and_hash(&mut self, pt: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
+        let ct = self.cipher_state.encrypt(pt, Some(&self.h))?;
+        self.mix_hash(&ct);
+        Ok(ct)
+    }
+
+    /// `SymmetricState.DecryptAndHash(ciphertext)`
+    fn decrypt_and_hash(&mut self, ct: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
+        let pt = self.cipher_state.decrypt(ct, Some(&self.h))?;
+        trace!("decrypted: {:?}", pt);
+        self.mix_hash(ct);
+        Ok(pt)
+    }
+
+    /// `SymmetricState.Split()`
+    ///
+    /// Returns `write_key, read_key` to create a [Crypter] for encrypting
+    /// further transport messages. `write_key` is for messages sent by the
+    /// initiator, `read_key` is for messages sent by the authenticator.
+    fn traffic_keys(&self) -> Result<(EncryptionKey, EncryptionKey), WebauthnCError> {
+        let mut o = [0; size_of::<EncryptionKey>() * 2];
+        hkdf_sha_256(&self.ck, &[], None, &mut o)?;
+
+        let mut a = [0; size_of::<EncryptionKey>()];
+        let mut b = [0; size_of::<EncryptionKey>()];
+        a.copy_from_slice(&o[..size_of::<EncryptionKey>()]);
+        b.copy_from_slice(&o[size_of::<EncryptionKey>()..]);
+        Ok((a, b))
+    }
+
+    fn get_ephemeral_key_public_bytes(&self) -> Result<[u8; 65], WebauthnCError> {
+        let mut o = [0; 65];
+        let v = point_to_bytes(self.ephemeral_key.public_key(), false)?;
+        if v.len() != o.len() {
+            error!("unexpected public key length {} != {}", v.len(), o.len());
+            return Err(WebauthnCError::Internal);
+        }
+        o.copy_from_slice(&v);
+        Ok(o)
+    }
+
+    /// Starts a Noise handshake with a peer as the initiating party (platform).
+    ///
+    /// Returns `(CableNoise, initial_message)`. `initial_message` is sent to
+    /// the responding party ([CableNoise::build_responder]).
+    pub fn build_initiator(
+        local_identity: Option<&EcKeyRef<Private>>,
+        psk: Psk,
+        peer_identity: Option<[u8; 65]>,
+    ) -> Result<(Self, Vec<u8>), WebauthnCError> {
+        // BuildInitialMessage
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=880;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29
+
+        let mut noise = if let Some(peer_identity) = peer_identity {
+            // TODO: test
+            let mut noise = Self::new(HandshakeType::NKpsk0)?;
+            let prologue = [0];
+            noise.mix_hash(&prologue);
+            noise.mix_hash(&peer_identity);
+            noise
+        } else if let Some(local_identity) = local_identity {
+            let mut noise = Self::new(HandshakeType::KNpsk0)?;
+            let prologue = [1];
+            noise.mix_hash(&prologue);
+            noise.mix_hash_point(local_identity.public_key())?;
+            noise.local_identity = Some(local_identity.to_owned());
+            noise
+        } else {
+            error!("build_initiator requires local_identity or peer_identity");
+            return Err(WebauthnCError::Internal);
+        };
+
+        noise.mix_key_and_hash(&psk)?;
+
+        let ephemeral_key_public_bytes = noise.get_ephemeral_key_public_bytes()?;
+
+        noise.mix_hash(&ephemeral_key_public_bytes);
+        noise.mix_key(&ephemeral_key_public_bytes)?;
+
+        if let Some(peer_identity) = peer_identity {
+            // TODO: test
+            let peer_identity_point = public_key_from_bytes(&peer_identity)?;
+            let mut es_key = [0; 32];
+            ecdh(
+                noise.ephemeral_key.to_owned(),
+                peer_identity_point,
+                &mut es_key,
+            )?;
+            noise.mix_key(&es_key)?;
+        }
+
+        let ct = noise.encrypt_and_hash(&[])?;
+
+        let mut handshake_message = Vec::with_capacity(ephemeral_key_public_bytes.len() + ct.len());
+        handshake_message.extend_from_slice(&ephemeral_key_public_bytes);
+        handshake_message.extend_from_slice(&ct);
+
+        Ok((noise, handshake_message))
+    }
+
+    /// Processes the response from the responding party (authenticator) and
+    /// creates a [Crypter] for further message passing.
+    ///
+    /// * `response` is the message from the responding party ([CableNoise::build_responder])
+    ///
+    /// ## Warning
+    ///
+    /// This function mutates the state of `self`, *even on errors*. This
+    /// renders the internal state invalid for "retrying" or future
+    /// transactions.
+    pub fn process_response(mut self, response: &[u8]) -> Result<Crypter, WebauthnCError> {
+        if response.len() < 65 {
+            error!("Handshake response too short ({} bytes)", response.len());
+            return Err(WebauthnCError::MessageTooShort);
+        }
+
+        // ProcessResponse
+        let (peer_point_bytes, ct) = response.split_at(65);
+
+        let peer_key = public_key_from_bytes(peer_point_bytes)?;
+        let mut shared_key_ee = [0; 32];
+        ecdh(
+            self.ephemeral_key.to_owned(),
+            peer_key.to_owned(),
+            &mut shared_key_ee,
+        )?;
+        self.mix_hash(peer_point_bytes);
+        self.mix_key(peer_point_bytes)?;
+        self.mix_key(&shared_key_ee)?;
+
+        if let Some(local_identity) = &self.local_identity {
+            let mut shared_key_se = [0; 32];
+            ecdh(local_identity.to_owned(), peer_key, &mut shared_key_se)?;
+            self.mix_key(&shared_key_se)?;
+        }
+
+        let pt = self.decrypt_and_hash(ct)?;
+        if !pt.is_empty() {
+            error!(
+                "expected handshake to be empty, got {} bytes: {:02x?}",
+                pt.len(),
+                &pt
+            );
+            return Err(WebauthnCError::MessageTooLarge);
+        }
+
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=982;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29
+        let (write_key, read_key) = self.traffic_keys()?;
+
+        trace!(?write_key);
+        trace!(?read_key);
+        Ok(Crypter::new(read_key, write_key))
+    }
+
+    /// Starts a Noise handshake with a peer as the responding party (authenticator):
+    ///
+    /// * `message` is the value from the initiating party ([CableNoise::build_initiator])
+    ///
+    /// Returns `(crypter, response)`. `response` is sent to the initiating party ([CableNoise::process_response]).
+    pub fn build_responder(
+        local_identity: Option<&EcKeyRef<Private>>,
+        psk: Psk,
+        peer_identity: Option<&EcKeyRef<Public>>,
+        message: &[u8],
+    ) -> Result<(Crypter, Vec<u8>), WebauthnCError> {
+        if message.len() < 65 {
+            error!("Initiator message too short ({} bytes)", message.len());
+            return Err(WebauthnCError::MessageTooShort);
+        }
+
+        // RespondToHandshake
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=987;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29
+        let (peer_point_bytes, ct) = message.split_at(65);
+
+        let mut noise = if let Some(local_identity) = local_identity {
+            let mut noise = Self::new(HandshakeType::NKpsk0)?;
+            let prologue = [0];
+            noise.mix_hash(&prologue);
+            noise.mix_hash_point(local_identity.public_key())?;
+            noise.local_identity = Some(local_identity.to_owned());
+
+            noise
+        } else if let Some(peer_identity) = peer_identity {
+            let mut noise = Self::new(HandshakeType::KNpsk0)?;
+            let prologue = [1];
+            noise.mix_hash(&prologue);
+            noise.mix_hash_point(peer_identity.public_key())?;
+            noise
+        } else {
+            error!("build_initiator requires local_identity or peer_identity");
+            return Err(WebauthnCError::Internal);
+        };
+
+        noise.mix_key_and_hash(&psk)?;
+        noise.mix_hash(peer_point_bytes);
+        noise.mix_key(peer_point_bytes)?;
+
+        let peer_point = public_key_from_bytes(peer_point_bytes)?;
+
+        if let Some(local_identity) = local_identity {
+            let mut es_key = [0; 32];
+            ecdh(
+                local_identity.to_owned(),
+                peer_point.to_owned(),
+                &mut es_key,
+            )?;
+            noise.mix_key(&es_key)?;
+        }
+
+        let pt = noise.decrypt_and_hash(ct)?;
+        if !pt.is_empty() {
+            error!(
+                "expected handshake to be empty, got {} bytes: {:02x?}",
+                pt.len(),
+                &pt
+            );
+            return Err(WebauthnCError::MessageTooLarge);
+        }
+
+        let ephemeral_key_public_bytes = noise.get_ephemeral_key_public_bytes()?;
+        noise.mix_hash(&ephemeral_key_public_bytes);
+        noise.mix_key(&ephemeral_key_public_bytes)?;
+
+        let mut shared_key_ee = [0; 32];
+        ecdh(
+            noise.ephemeral_key.to_owned(),
+            peer_point,
+            &mut shared_key_ee,
+        )?;
+        noise.mix_key(&shared_key_ee)?;
+
+        if let Some(peer_identity) = peer_identity {
+            let mut shared_key_se = [0; 32];
+            ecdh(
+                noise.ephemeral_key.to_owned(),
+                peer_identity.to_owned(),
+                &mut shared_key_se,
+            )?;
+            noise.mix_key(&shared_key_se)?;
+        }
+
+        let ct = noise.encrypt_and_hash(&[])?;
+        let mut response_message = Vec::with_capacity(ephemeral_key_public_bytes.len() + ct.len());
+        response_message.extend_from_slice(&ephemeral_key_public_bytes);
+        response_message.extend_from_slice(&ct);
+
+        let (read_key, write_key) = noise.traffic_keys()?;
+        trace!(?read_key);
+        trace!(?write_key);
+        Ok((Crypter::new(read_key, write_key), response_message))
+    }
+}
+
+/// Encrypted message passing channel for caBLE.
+///
+/// This is a pair of [CipherState] objects, one used by the initiator, one used
+/// by the authenticator. Messages are encrypted with AES-GCM.
+///
+/// This has two different construction modes: "old" and "new". This object
+/// defaults to "old" mode, and will switch to "new" mode automatically if the
+/// first message decrypted was sent in "new" mode.
+///
+/// "new" mode acts as a pair of regular Noise [CipherState][] objects, with
+/// padding.
+///
+/// "old" mode differences:
+///
+/// * it always sets an additional byte of `0x02`.
+/// * it encodes the nonce as little-endian, rather than big-endian.
+///
+/// [CipherState]: https://noiseprotocol.org/noise.html#the-cipherstate-object
+pub struct Crypter {
+    reader: CipherState,
+    writer: CipherState,
+}
+
+impl Crypter {
+    fn new(read_key: EncryptionKey, write_key: EncryptionKey) -> Self {
+        let mut reader = CipherState::new(NonceType::Old, true);
+        reader.init_key(read_key);
+
+        let mut writer = CipherState::new(NonceType::Old, true);
+        writer.init_key(write_key);
+
+        Self { reader, writer }
+    }
+
+    /// Switches to "new construction", for caBLE v2.1+.
+    pub fn use_new_construction(&mut self) {
+        self.reader.nonce_type = NonceType::New;
+        self.writer.nonce_type = NonceType::New;
+    }
+
+    pub fn encrypt(&mut self, pt: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
+        self.writer.encrypt(pt, None)
+    }
+
+    pub fn decrypt(&mut self, ct: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
+        let pt = self.reader.decrypt(ct, None)?;
+        self.writer.nonce_type = self.reader.nonce_type;
+        Ok(pt)
+    }
+
+    #[cfg(test)]
+    /// Returns `true` if the `other` [Crypter] uses "remote side" (swapped)
+    /// read and write keys.
+    ///
+    /// This function is only useful for testing.
+    pub(super) fn is_counterparty(&self, other: &Self) -> bool {
+        self.reader.k == other.writer.k && self.writer.k == other.reader.k
+    }
+}
+
+/// Pads a message to a multiple of [PADDING_MUL] bytes.
+///
+/// See also: [unpad]
+fn pad(msg: &[u8]) -> Vec<u8> {
+    let padded_len = (msg.len() + PADDING_MUL) & !(PADDING_MUL - 1);
+    assert!(padded_len > msg.len());
+    let zeros = padded_len - msg.len() - 1;
+    assert!(zeros < 256);
+
+    let mut padded = vec![0; padded_len];
+    padded[..msg.len()].copy_from_slice(msg);
+    padded[padded_len - 1] = zeros as u8;
+    padded
+}
+
+/// Unpads a message padded with [pad].
+fn unpad(msg: &mut Vec<u8>) -> Result<(), WebauthnCError> {
+    let padding_len = (msg.last().copied().unwrap_or_default() as usize) + 1;
+    if padding_len > msg.len() {
+        error!(
+            "Invalid caBLE message (padding length {} > message length {})",
+            padding_len,
+            msg.len()
+        );
+        return Err(WebauthnCError::Internal);
+    }
+
+    msg.truncate(msg.len() - padding_len);
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use base64urlsafedata::Base64UrlSafeData;
+    use webauthn_rs_proto::{PubKeyCredParams, PublicKeyCredentialDescriptor, RelyingParty, User};
+
+    use crate::{
+        cable::framing::{CableFrame, CableFrameType},
+        crypto::public_key_from_private,
+        ctap2::{commands::MakeCredentialRequest, CBORCommand},
+    };
+
+    use super::*;
+
+    #[test]
+    fn noise() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let identity_key = regenerate().unwrap();
+        let identity_pub = public_key_from_private(&identity_key).unwrap();
+        let psk = [0; size_of::<Psk>()];
+
+        let (initiator_noise, initiator_msg) =
+            CableNoise::build_initiator(Some(&identity_key), psk.to_owned(), None).unwrap();
+
+        let (mut responder_crypt, responder_msg) =
+            CableNoise::build_responder(None, psk, Some(&identity_pub), &initiator_msg).unwrap();
+
+        let mut initiator_crypt = initiator_noise.process_response(&responder_msg).unwrap();
+
+        assert!(initiator_crypt.is_counterparty(&responder_crypt));
+        responder_crypt.use_new_construction();
+
+        let ct = responder_crypt.encrypt(b"Hello, world!").unwrap();
+        let pt = initiator_crypt.decrypt(&ct).unwrap();
+        assert_eq!(b"Hello, world!", pt.as_slice());
+        // Decrypting the same ciphertext twice should fail, because of the nonce change
+        assert!(initiator_crypt.decrypt(&ct).is_err());
+
+        let ct2 = initiator_crypt
+            .encrypt(b"The quick brown fox jumps over the lazy dog")
+            .unwrap();
+
+        // Decrypting responder's initial ciphertext should fail because of different keys from Noise
+        assert!(responder_crypt.decrypt(&ct).is_err());
+
+        // A failure in Crypter shouldn't impact our ability to receive correct ciphertexts, if they're in order
+        let pt2 = responder_crypt.decrypt(&ct2).unwrap();
+        assert_eq!(
+            b"The quick brown fox jumps over the lazy dog",
+            pt2.as_slice()
+        );
+        assert!(responder_crypt.decrypt(&ct).is_err());
+    }
+
+    #[test]
+    fn encrypt_decrypt() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let key0 = [123; 32];
+        let key1 = [231; 32];
+
+        let mut alice = Crypter::new(key0, key1);
+        let mut bob = Crypter::new(key1, key0);
+        let mut corrupted = Crypter::new(key1, key0);
+
+        for l in 0..530 {
+            let msg = vec![0xff; l];
+            let mut crypted = alice.encrypt(&msg).unwrap();
+            let decrypted = bob.decrypt(&crypted).unwrap();
+
+            assert_eq!(msg, decrypted);
+            assert_eq!(bob.reader.nonce_type, NonceType::Old);
+            if l > 0 {
+                crypted[(l * 3) % l] ^= 0x01;
+            }
+            corrupted.reader.n = bob.reader.n;
+            assert!(corrupted.decrypt(&crypted).is_err());
+        }
+    }
+
+    #[test]
+    fn encrypt_decrypt_new() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let key0 = [123; 32];
+        let key1 = [231; 32];
+
+        let mut alice = Crypter::new(key0, key1);
+        alice.use_new_construction();
+        let mut bob = Crypter::new(key1, key0);
+        let mut corrupted = Crypter::new(key1, key0);
+
+        for l in 1..5 {
+            let msg = vec![0xff; l];
+            let mut crypted = alice.encrypt(&msg).unwrap();
+            let decrypted = bob.decrypt(&crypted).unwrap();
+
+            assert!(bob.writer.nonce_type == NonceType::New);
+            assert_eq!(msg, decrypted);
+            if l > 0 {
+                crypted[(l * 3) % l] ^= 0x01;
+            }
+            corrupted.reader.nonce_type = bob.reader.nonce_type;
+            corrupted.reader.n = bob.reader.n;
+            assert!(corrupted.decrypt(&crypted).is_err());
+        }
+    }
+
+    #[test]
+    fn unencrypted() {
+        let mut c = CipherState::new(NonceType::New, true);
+        let pt = b"Hello, world!";
+
+        // When CipherState has no key, it should pass through as plaintext and
+        // not affect the nonce value.
+        let r = c.encrypt(pt, None).unwrap();
+        assert_eq!(pt, r.as_slice());
+        assert_eq!(0, c.n);
+
+        let r = c.decrypt(pt, None).unwrap();
+        assert_eq!(pt, r.as_slice());
+        assert_eq!(0, c.n);
+    }
+
+    #[test]
+    fn construction() {
+        let _ = tracing_subscriber::fmt::try_init();
+        // Patched chromium to leak its key data
+        let write_key = [
+            0x1f, 0xba, 0x3c, 0xce, 0x17, 0x62, 0x2c, 0x68, 0x26, 0x8d, 0x9f, 0x75, 0xb5, 0xa8,
+            0xa3, 0x35, 0x1b, 0x51, 0x7f, 0x9, 0x6f, 0xb5, 0xe2, 0x94, 0x94, 0x1a, 0xf7, 0xe3,
+            0xa6, 0xa8, 0xd6, 0xe1,
+        ];
+        let read_key = [
+            0xe3, 0x4f, 0x1a, 0xa3, 0x74, 0x72, 0x38, 0xc0, 0x4d, 0x3b, 0xd2, 0x5e, 0x7, 0xef,
+            0x1b, 0x35, 0xfe, 0xf3, 0x59, 0x0, 0xd, 0x75, 0x56, 0x15, 0xcd, 0x85, 0xbe, 0x27, 0xcf,
+            0xc8, 0x7, 0xd1,
+        ];
+        let req = MakeCredentialRequest {
+            client_data_hash: vec![
+                0x38, 0x89, 0x28, 0x5c, 0x8c, 0x63, 0x23, 0x95, 0xc, 0xed, 0x7, 0x49, 0x84, 0xf9,
+                0xf9, 0x46, 0x3b, 0xc1, 0x73, 0x9b, 0xb6, 0x21, 0xa9, 0xe5, 0xf1, 0xee, 0x8d, 0xd9,
+                0x39, 0x3b, 0xa2, 0x80,
+            ],
+            rp: RelyingParty {
+                name: String::from("webauthn.firstyear.id.au"),
+                id: String::from("webauthn.firstyear.id.au"),
+            },
+            user: User {
+                id: Base64UrlSafeData::from(vec![
+                    0xd6, 0xd7, 0xaa, 0x29, 0x8f, 0xe8, 0x4a, 0x6, 0xaa, 0xde, 0xd7, 0xe4, 0x9d,
+                    0x90, 0xa, 0x62,
+                ]),
+                name: String::from("a"),
+                display_name: String::from("a"),
+            },
+            pub_key_cred_params: vec![
+                PubKeyCredParams {
+                    type_: String::from("public-key"),
+                    alg: -7,
+                },
+                PubKeyCredParams {
+                    type_: String::from("public-key"),
+                    alg: -257,
+                },
+            ],
+            exclude_list: vec![PublicKeyCredentialDescriptor {
+                type_: String::from("public-key"),
+                id: Base64UrlSafeData::from(vec![0, 1, 2, 3]),
+                transports: None,
+            }],
+            options: Some(BTreeMap::from([(String::from("uv"), true)])),
+            pin_uv_auth_param: None,
+            pin_uv_auth_proto: None,
+            enterprise_attest: None,
+        };
+
+        let req = CableFrame {
+            protocol_version: 1,
+            message_type: CableFrameType::Ctap,
+            data: req.cbor().unwrap(),
+        };
+
+        let expected_req_encoding = [
+            0x1, 0x1, 0xa6, 0x1, 0x58, 0x20, 0x38, 0x89, 0x28, 0x5c, 0x8c, 0x63, 0x23, 0x95, 0xc,
+            0xed, 0x7, 0x49, 0x84, 0xf9, 0xf9, 0x46, 0x3b, 0xc1, 0x73, 0x9b, 0xb6, 0x21, 0xa9,
+            0xe5, 0xf1, 0xee, 0x8d, 0xd9, 0x39, 0x3b, 0xa2, 0x80, 0x2, 0xa2, 0x62, 0x69, 0x64,
+            0x78, 0x18, 0x77, 0x65, 0x62, 0x61, 0x75, 0x74, 0x68, 0x6e, 0x2e, 0x66, 0x69, 0x72,
+            0x73, 0x74, 0x79, 0x65, 0x61, 0x72, 0x2e, 0x69, 0x64, 0x2e, 0x61, 0x75, 0x64, 0x6e,
+            0x61, 0x6d, 0x65, 0x78, 0x18, 0x77, 0x65, 0x62, 0x61, 0x75, 0x74, 0x68, 0x6e, 0x2e,
+            0x66, 0x69, 0x72, 0x73, 0x74, 0x79, 0x65, 0x61, 0x72, 0x2e, 0x69, 0x64, 0x2e, 0x61,
+            0x75, 0x3, 0xa3, 0x62, 0x69, 0x64, 0x50, 0xd6, 0xd7, 0xaa, 0x29, 0x8f, 0xe8, 0x4a, 0x6,
+            0xaa, 0xde, 0xd7, 0xe4, 0x9d, 0x90, 0xa, 0x62, 0x64, 0x6e, 0x61, 0x6d, 0x65, 0x61,
+            0x61, 0x6b, 0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65, 0x61,
+            0x61, 0x4, 0x82, 0xa2, 0x63, 0x61, 0x6c, 0x67, 0x26, 0x64, 0x74, 0x79, 0x70, 0x65,
+            0x6a, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d, 0x6b, 0x65, 0x79, 0xa2, 0x63, 0x61,
+            0x6c, 0x67, 0x39, 0x1, 0x0, 0x64, 0x74, 0x79, 0x70, 0x65, 0x6a, 0x70, 0x75, 0x62, 0x6c,
+            0x69, 0x63, 0x2d, 0x6b, 0x65, 0x79, 0x5, 0x81, 0xa2, 0x62, 0x69, 0x64, 0x44, 0x0, 0x1,
+            0x2, 0x3, 0x64, 0x74, 0x79, 0x70, 0x65, 0x6a, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d,
+            0x6b, 0x65, 0x79, 0x7, 0xa1, 0x62, 0x75, 0x76, 0xf5,
+        ];
+
+        let r = req.to_bytes().unwrap();
+
+        assert_eq!(r, expected_req_encoding);
+
+        let expected_req_padded = [
+            0x1, 0x1, 0xa6, 0x1, 0x58, 0x20, 0x38, 0x89, 0x28, 0x5c, 0x8c, 0x63, 0x23, 0x95, 0xc,
+            0xed, 0x7, 0x49, 0x84, 0xf9, 0xf9, 0x46, 0x3b, 0xc1, 0x73, 0x9b, 0xb6, 0x21, 0xa9,
+            0xe5, 0xf1, 0xee, 0x8d, 0xd9, 0x39, 0x3b, 0xa2, 0x80, 0x2, 0xa2, 0x62, 0x69, 0x64,
+            0x78, 0x18, 0x77, 0x65, 0x62, 0x61, 0x75, 0x74, 0x68, 0x6e, 0x2e, 0x66, 0x69, 0x72,
+            0x73, 0x74, 0x79, 0x65, 0x61, 0x72, 0x2e, 0x69, 0x64, 0x2e, 0x61, 0x75, 0x64, 0x6e,
+            0x61, 0x6d, 0x65, 0x78, 0x18, 0x77, 0x65, 0x62, 0x61, 0x75, 0x74, 0x68, 0x6e, 0x2e,
+            0x66, 0x69, 0x72, 0x73, 0x74, 0x79, 0x65, 0x61, 0x72, 0x2e, 0x69, 0x64, 0x2e, 0x61,
+            0x75, 0x3, 0xa3, 0x62, 0x69, 0x64, 0x50, 0xd6, 0xd7, 0xaa, 0x29, 0x8f, 0xe8, 0x4a, 0x6,
+            0xaa, 0xde, 0xd7, 0xe4, 0x9d, 0x90, 0xa, 0x62, 0x64, 0x6e, 0x61, 0x6d, 0x65, 0x61,
+            0x61, 0x6b, 0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65, 0x61,
+            0x61, 0x4, 0x82, 0xa2, 0x63, 0x61, 0x6c, 0x67, 0x26, 0x64, 0x74, 0x79, 0x70, 0x65,
+            0x6a, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d, 0x6b, 0x65, 0x79, 0xa2, 0x63, 0x61,
+            0x6c, 0x67, 0x39, 0x1, 0x0, 0x64, 0x74, 0x79, 0x70, 0x65, 0x6a, 0x70, 0x75, 0x62, 0x6c,
+            0x69, 0x63, 0x2d, 0x6b, 0x65, 0x79, 0x5, 0x81, 0xa2, 0x62, 0x69, 0x64, 0x44, 0x0, 0x1,
+            0x2, 0x3, 0x64, 0x74, 0x79, 0x70, 0x65, 0x6a, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d,
+            0x6b, 0x65, 0x79, 0x7, 0xa1, 0x62, 0x75, 0x76, 0xf5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1f,
+        ];
+        let p = pad(&r);
+        assert_eq!(p, expected_req_padded);
+
+        let expected_req_crypted = [
+            0x50, 0x62, 0xcf, 0x34, 0x57, 0x1e, 0x8, 0x27, 0xa7, 0xc0, 0x20, 0x7f, 0x7c, 0x0, 0x18,
+            0x45, 0x67, 0xd6, 0x13, 0xea, 0xb0, 0xda, 0x8, 0xa, 0xd0, 0x42, 0xd8, 0x6, 0x64, 0xc5,
+            0x9d, 0xf7, 0xb0, 0x1a, 0x13, 0xdb, 0x17, 0xfd, 0x27, 0x75, 0x75, 0xcc, 0xff, 0x53,
+            0xb6, 0xa3, 0x4f, 0xdb, 0x4f, 0xbc, 0xf8, 0x32, 0xf3, 0xd3, 0x60, 0xf8, 0xe5, 0xa7,
+            0xda, 0xee, 0x7f, 0x26, 0x5a, 0x92, 0x53, 0xa9, 0x4, 0xd6, 0xeb, 0xff, 0x2f, 0x93,
+            0x70, 0xd3, 0x55, 0x36, 0xd8, 0xbf, 0x5, 0x48, 0x30, 0xaa, 0xad, 0xff, 0xb9, 0x96,
+            0xb4, 0x20, 0xb2, 0xb3, 0x17, 0xa, 0xc8, 0xa, 0x83, 0x79, 0x68, 0x23, 0xed, 0x3c, 0x28,
+            0x4b, 0x17, 0x7c, 0x23, 0x40, 0xc, 0xa0, 0x12, 0x4d, 0x6a, 0x68, 0x26, 0x3d, 0x39,
+            0x78, 0x3c, 0xfe, 0xf0, 0x27, 0x3f, 0xdf, 0x3b, 0xfc, 0xfa, 0xa, 0x6c, 0x33, 0xdf,
+            0x31, 0x9b, 0x12, 0x6f, 0x6e, 0x82, 0x90, 0xd2, 0x2c, 0x4c, 0xd3, 0x2a, 0x7a, 0x97,
+            0x88, 0x56, 0xba, 0x22, 0x73, 0xd1, 0xbe, 0x1c, 0xa, 0x29, 0x1e, 0x5e, 0xe1, 0x97,
+            0x41, 0x6a, 0xa0, 0xf7, 0xa1, 0x4, 0xe4, 0xd0, 0xac, 0x58, 0x2b, 0x70, 0x84, 0x82,
+            0x32, 0x6d, 0x5f, 0xf0, 0xf1, 0x76, 0x8c, 0x14, 0x16, 0xd0, 0x16, 0xb1, 0xf8, 0x92,
+            0x42, 0xe7, 0xe, 0x80, 0x31, 0x2f, 0xe6, 0xb6, 0xd4, 0x2, 0x9a, 0x40, 0xad, 0xa3, 0x74,
+            0xb3, 0x1e, 0x7d, 0x66, 0xfa, 0xc3, 0xba, 0x72, 0x83, 0x94, 0x4b, 0x9b, 0x60, 0xda,
+            0x4b, 0x98, 0xf6, 0x78, 0x4, 0x9, 0x5f, 0xd3, 0x9c, 0xd1, 0xd4, 0x5d, 0x75, 0xc9, 0x3d,
+            0x2d, 0x86, 0xcb, 0xfc, 0x21, 0x61, 0x6f, 0x9f, 0x1a, 0x57, 0x6c, 0xcf, 0x8c, 0x86,
+            0x2e, 0xe1, 0x85, 0x12, 0x5f, 0xc1, 0xed, 0x7e, 0xd2, 0x48, 0x6e, 0x2c, 0x5f, 0xbf,
+            0xc3, 0x9c, 0x91, 0x95, 0x97, 0xdd, 0x86, 0xc3, 0x38, 0xe7, 0xdf, 0x55, 0x3d, 0x51,
+            0xe8,
+        ];
+        let mut crypter = Crypter::new(read_key, write_key);
+        crypter.use_new_construction();
+
+        let ct = crypter.encrypt(&r).unwrap();
+
+        assert_eq!(ct.len(), expected_req_crypted.len());
+        assert_eq!(&ct, &expected_req_crypted);
+
+        let mut peer_crypter = Crypter::new(write_key, read_key);
+        let pt = peer_crypter.decrypt(&ct).unwrap();
+        assert_eq!(pt, r);
+        let msg = CableFrame::from_bytes(1, &pt);
+        assert_eq!(msg.message_type, CableFrameType::Ctap);
+    }
+}

--- a/webauthn-authenticator-rs/src/cable/tunnel.rs
+++ b/webauthn-authenticator-rs/src/cable/tunnel.rs
@@ -1,0 +1,485 @@
+//! Tunnel functions
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
+use openssl::{
+    ec::EcKeyRef,
+    pkey::{Private, Public},
+};
+use serde::Serialize;
+use serde_cbor::{ser::to_vec_packed, Value};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{HeaderValue, Uri},
+        Message,
+    },
+    MaybeTlsStream, WebSocketStream,
+};
+use webauthn_rs_proto::AuthenticatorTransport;
+
+use crate::{
+    cable::{
+        btle::{Advertiser, FIDO_CABLE_SERVICE_U16},
+        discovery::{Discovery, Eid},
+        framing::{CableFrame, CableFrameType, SHUTDOWN_COMMAND},
+        noise::{CableNoise, Crypter},
+        CableState, Psk,
+    },
+    ctap2::{
+        commands::{value_to_vec_u8, GetInfoResponse},
+        CBORResponse, CtapAuthenticator,
+    },
+    error::CtapError,
+    prelude::WebauthnCError,
+    transport::Token,
+    ui::UiCallback,
+    util::compute_sha256,
+};
+
+/// Manually-assigned domains.
+///
+/// Source: <https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=123-125;drc=6767131b3528fefd866f604b32ebbb278c35d395>
+const ASSIGNED_DOMAINS: [&str; 2] = [
+    // Google
+    "cable.ua5v.com",
+    // Apple
+    "cable.auth.com",
+];
+
+/// The number of manually-assigned domains known by this module.
+pub const ASSIGNED_DOMAINS_COUNT: u32 = ASSIGNED_DOMAINS.len() as u32;
+
+const TUNNEL_SERVER_SALT: &[u8] = b"caBLEv2 tunnel server domain\0\0\0";
+const TUNNEL_SERVER_ID_OFFSET: usize = TUNNEL_SERVER_SALT.len() - 3;
+const TUNNEL_SERVER_TLDS: [&str; 4] = [".com", ".org", ".net", ".info"];
+const BASE32_CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+/// Decodes a `domain_id` into an actual domain name.
+///
+/// See Chromium's `tunnelserver::DecodeDomain`.
+pub fn get_domain(domain_id: u16) -> Option<String> {
+    if domain_id < 256 {
+        return match ASSIGNED_DOMAINS.get(usize::from(domain_id)) {
+            Some(d) => Some(d.to_string()),
+            None => {
+                warn!("Invalid tunnel server ID {:04x}", domain_id);
+                None
+            }
+        };
+    }
+
+    let mut buf = TUNNEL_SERVER_SALT.to_vec();
+    buf[TUNNEL_SERVER_ID_OFFSET..TUNNEL_SERVER_ID_OFFSET + 2]
+        .copy_from_slice(&domain_id.to_le_bytes());
+    let digest = compute_sha256(&buf);
+    let mut result = u64::from_le_bytes(digest[..8].try_into().ok()?);
+
+    let tld = TUNNEL_SERVER_TLDS[(result & 3) as usize];
+
+    let mut o = String::from("cable.");
+    result >>= 2;
+    while result != 0 {
+        o.push(char::from_u32(BASE32_CHARS[(result & 31) as usize].into())?);
+        result >>= 5;
+    }
+    o.push_str(tld);
+
+    Some(o)
+}
+
+/// Websocket tunnel to a caBLE authenticator.
+///
+/// This implements [Token], but unlike most transports:
+///
+/// * this only allows a single command to be executed
+/// * the command must be specified in the [HandshakeV2][super::handshake::HandshakeV2] QR code
+/// * the remote side "hangs up" after a single command
+pub struct Tunnel {
+    // psk: Psk,
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    crypter: Crypter,
+    info: GetInfoResponse,
+}
+
+impl Tunnel {
+    pub(super) async fn connect(
+        uri: &Uri,
+    ) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Option<Vec<u8>>), WebauthnCError> {
+        let mut request = IntoClientRequest::into_client_request(uri)?;
+        let headers = request.headers_mut();
+        headers.insert(
+            "Sec-WebSocket-Protocol",
+            HeaderValue::from_static("fido.cable"),
+        );
+        let origin = format!("wss://{}", uri.host().unwrap_or_default());
+        headers.insert(
+            "Origin",
+            HeaderValue::from_str(&origin).map_err(|_| WebauthnCError::Internal)?,
+        );
+
+        trace!(?request);
+        let (stream, response) = connect_async(request).await.map_err(|e| {
+            error!("websocket error: {:?}", e);
+            WebauthnCError::Internal
+        })?;
+
+        trace!(?response);
+        // Get the routing-id from the response header
+        let routing_id = response
+            .headers()
+            .get("X-caBLE-Routing-ID")
+            .and_then(|v| hex::decode(v.as_bytes()).ok());
+        trace!("Routing ID: {:02x?}", routing_id);
+
+        Ok((stream, routing_id))
+    }
+
+    pub async fn connect_initiator(
+        uri: &Uri,
+        psk: Psk,
+        local_identity: &EcKeyRef<Private>,
+        ui: &impl UiCallback,
+    ) -> Result<Tunnel, WebauthnCError> {
+        ui.cable_status_update(CableState::ConnectingToTunnelServer);
+        let (mut stream, _) = Self::connect(uri).await?;
+
+        // BuildInitialMessage
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=880;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29
+        ui.cable_status_update(CableState::Handshaking);
+        let (noise, handshake_message) =
+            CableNoise::build_initiator(Some(local_identity), psk, None)?;
+        trace!(">>> {:02x?}", &handshake_message);
+        stream.send(Message::Binary(handshake_message)).await?;
+
+        // Handshake sent, get response
+        ui.cable_status_update(CableState::WaitingForAuthenticatorResponse);
+        let resp = stream.next().await.ok_or(WebauthnCError::Closed)??;
+        trace!("<<< {:?}", resp);
+        ui.cable_status_update(CableState::Handshaking);
+        let mut crypter = if let Message::Binary(v) = resp {
+            noise.process_response(&v)?
+        } else {
+            error!("Unexpected websocket response type");
+            return Err(WebauthnCError::Unknown);
+        };
+
+        // Waiting for post-handshake message
+        ui.cable_status_update(CableState::WaitingForAuthenticatorResponse);
+        trace!("Waiting for post-handshake message...");
+        let resp = stream.next().await.ok_or(WebauthnCError::Closed)??;
+        trace!("Post-handshake message:");
+        trace!("<<< {:?}", resp);
+        ui.cable_status_update(CableState::Handshaking);
+
+        let v = if let Message::Binary(v) = resp {
+            v
+        } else {
+            error!("Unexpected websocket response type");
+            return Err(WebauthnCError::Unknown);
+        };
+
+        trace!("decrypted:");
+        let decrypted = crypter.decrypt(&v)?;
+        trace!("<<< {:?}", decrypted);
+
+        // If Chromium on Android uses caBLE v2.0 if the supports_linking field
+        // is missing, or v2.1 if it is present (even if false)[0]. When using
+        // v2.0, it sends a different initial message with extra padded CBOR and
+        // linking info.
+        //
+        // As an initiator, Chromium will try to decode this message as v2.1,
+        // falling back to v2.0[1] on a parser error. However, serde_cbor is
+        // happy to parse the padded value regardless.
+        //
+        // [0]: https://source.chromium.org/chromium/chromium/src/+/main:chrome/android/features/cablev2_authenticator/native/cablev2_authenticator_android.cc;l=688-693;drc=9d8024e69625a0c457a4999f4d1aca32c24eb494
+        // [1]: https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/fido_tunnel_device.cc;l=368-375;drc=52fa5a7f263b37149bcfbac06da00fec5abcc416
+        let v: BTreeMap<u32, Value> =
+            serde_cbor::from_slice(&decrypted).map_err(|_| WebauthnCError::Cbor)?;
+
+        let frame = CablePostHandshake::try_from(v)?;
+        trace!(?frame);
+
+        let info = frame.info;
+
+        let t = Self {
+            // psk,
+            stream,
+            crypter,
+            info,
+        };
+
+        Ok(t)
+    }
+
+    pub async fn connect_authenticator(
+        discovery: &Discovery,
+        tunnel_server_id: u16,
+        peer_identity: &EcKeyRef<Public>,
+        info: GetInfoResponse,
+        advertiser: &mut impl Advertiser,
+        ui: &impl UiCallback,
+    ) -> Result<Tunnel, WebauthnCError> {
+        let uri = discovery.get_new_tunnel_uri(tunnel_server_id)?;
+        ui.cable_status_update(CableState::ConnectingToTunnelServer);
+        let (mut stream, routing_id) = Self::connect(&uri).await?;
+
+        let eid = if let Some(routing_id) = routing_id {
+            Eid::new(
+                tunnel_server_id,
+                routing_id.try_into().map_err(|_| {
+                    error!("Incorrect routing-id header length");
+                    WebauthnCError::Internal
+                })?,
+            )?
+        } else {
+            error!("Missing or invalid routing-id header");
+            return Err(WebauthnCError::Internal);
+        };
+
+        let psk = discovery.derive_psk(&eid)?;
+        let encrypted_eid = discovery.encrypt_advert(&eid)?;
+        advertiser.start_advertising(FIDO_CABLE_SERVICE_U16, &encrypted_eid)?;
+
+        // Wait for initial message from initiator
+        trace!("Advertising started, waiting for initiator...");
+        ui.cable_status_update(CableState::WaitingForInitiatorConnection);
+        let resp = stream.next().await.ok_or(WebauthnCError::Closed)??;
+        trace!("<<< {:?}", resp);
+
+        advertiser.stop_advertising()?;
+        ui.cable_status_update(CableState::Handshaking);
+        let resp = if let Message::Binary(v) = resp {
+            v
+        } else {
+            error!("Unexpected websocket response type");
+            return Err(WebauthnCError::Unknown);
+        };
+
+        let (mut crypter, response) =
+            CableNoise::build_responder(None, psk, Some(peer_identity), &resp)?;
+        trace!("Sending response to initiator challenge");
+        trace!(">!> {:02x?}", response);
+        stream.send(Message::Binary(response)).await?;
+
+        // Send post-handshake message
+        let phm = CablePostHandshake {
+            info: info.to_owned(),
+            linking_info: None,
+        };
+        trace!("Sending post-handshake message");
+        trace!(">>> {:02x?}", &phm);
+        let phm = serde_cbor::to_vec(&phm).map_err(|_| WebauthnCError::Cbor)?;
+        crypter.use_new_construction();
+
+        let mut t = Self {
+            // psk,
+            stream,
+            crypter,
+            info,
+        };
+
+        t.send_raw(&phm).await?;
+
+        // Now we're ready for our first command
+        Ok(t)
+    }
+
+    /// Establishes a [CtapAuthenticator] connection for communicating with a
+    /// caBLE authenticator using CTAP 2.x.
+    ///
+    /// See [CtapAuthenticator::new] for further detail.
+    pub fn get_authenticator<U: UiCallback>(
+        self,
+        ui_callback: &U,
+    ) -> Option<CtapAuthenticator<'_, Self, U>> {
+        CtapAuthenticator::new_with_info(self.info.to_owned(), self, ui_callback)
+    }
+
+    pub(super) async fn send(&mut self, cmd: CableFrame) -> Result<(), WebauthnCError> {
+        let cmd = cmd.to_bytes().ok_or(WebauthnCError::ApduConstruction)?;
+        self.send_raw(&cmd).await
+    }
+
+    async fn send_raw(&mut self, cmd: &[u8]) -> Result<(), WebauthnCError> {
+        trace!(">>> {:02x?}", cmd);
+        let encrypted = self.crypter.encrypt(cmd)?;
+        trace!("ENC {:02x?}", encrypted);
+        self.stream.send(Message::Binary(encrypted)).await?;
+        Ok(())
+    }
+
+    pub(super) async fn recv(&mut self) -> Result<Option<CableFrame>, WebauthnCError> {
+        let resp = match self.stream.next().await {
+            None => return Ok(None),
+            Some(r) => r?,
+        };
+
+        let resp = if let Message::Binary(v) = resp {
+            v
+        } else {
+            error!("Incorrect message type");
+            return Err(WebauthnCError::Unknown);
+        };
+
+        trace!("DEC {:02x?}", resp);
+        let decrypted = self.crypter.decrypt(&resp)?;
+        trace!("<<< {:02x?}", decrypted);
+        // TODO: protocol version
+        Ok(Some(CableFrame::from_bytes(1, &decrypted)))
+    }
+}
+
+impl Debug for Tunnel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Tunnel")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl Token for Tunnel {
+    fn get_transport(&self) -> AuthenticatorTransport {
+        AuthenticatorTransport::Hybrid
+    }
+
+    async fn transmit_raw<U>(&mut self, cbor: &[u8], ui: &U) -> Result<Vec<u8>, WebauthnCError>
+    where
+        U: UiCallback,
+    {
+        let f = CableFrame {
+            // TODO: handle protocol versions
+            protocol_version: 1,
+            message_type: CableFrameType::Ctap,
+            data: cbor.to_vec(),
+        };
+        self.send(f).await?;
+        ui.cable_status_update(CableState::WaitingForAuthenticatorResponse);
+        let mut data = loop {
+            let resp = match self.recv().await? {
+                Some(r) => r,
+                None => {
+                    // end of stream
+                    self.close().await?;
+                    return Err(WebauthnCError::Closed);
+                }
+            };
+
+            if resp.message_type == CableFrameType::Ctap {
+                break resp.data;
+            } else {
+                // TODO: handle these.
+                warn!("unhandled message type: {:?}", resp);
+            }
+        };
+        self.close().await?;
+        ui.cable_status_update(CableState::Processing);
+
+        let err = CtapError::from(data.remove(0));
+        if !err.is_ok() {
+            return Err(err.into());
+        }
+        Ok(data)
+    }
+
+    fn cancel(&self) -> Result<(), WebauthnCError> {
+        // There is no way to cancel transactions without closing in caBLE
+        Ok(())
+    }
+
+    async fn init(&mut self) -> Result<(), WebauthnCError> {
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), WebauthnCError> {
+        // We don't care if this errors
+        self.send(SHUTDOWN_COMMAND).await.ok();
+        self.stream.close(None).await.ok();
+        Ok(())
+    }
+}
+
+/// Message sent by the authenticator after completing the CableNoise handshake.
+///
+/// <https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/fido_tunnel_device.cc;l=368-395;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29>
+///
+/// * Two protocol versions here, protocol 1 and protocol 0.
+/// * Protocol 1 has a CBOR map:
+///   * 1: GetInfoResponse bytes
+///   * 2: linking info (optional)
+/// * Protocol 0: Padded map (not implemented)
+#[derive(Debug, Clone, Serialize)]
+#[serde(try_from = "BTreeMap<u32, Value>", into = "BTreeMap<u32, Value>")]
+struct CablePostHandshake {
+    info: GetInfoResponse,
+    linking_info: Option<Vec<u8>>,
+}
+
+impl TryFrom<BTreeMap<u32, Value>> for CablePostHandshake {
+    type Error = WebauthnCError;
+
+    fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
+        // trace!("raw = {:?}", raw);
+        let info = raw
+            .remove(&0x01)
+            .and_then(|v| value_to_vec_u8(v, "0x01"))
+            .ok_or(WebauthnCError::MissingRequiredField)?;
+        let info = <GetInfoResponse as CBORResponse>::try_from(info.as_slice())?;
+
+        let linking_info = raw.remove(&0x02).and_then(|v| value_to_vec_u8(v, "0x02"));
+
+        Ok(Self { info, linking_info })
+    }
+}
+
+impl From<CablePostHandshake> for BTreeMap<u32, Value> {
+    fn from(h: CablePostHandshake) -> Self {
+        let mut o = BTreeMap::new();
+
+        if let Ok(info) = to_vec_packed(&h.info) {
+            o.insert(0x01, Value::Bytes(info));
+        }
+
+        if let Some(linking_info) = h.linking_info {
+            o.insert(0x02, Value::Bytes(linking_info));
+        }
+
+        o
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn check_known_tunnel_server_domains() {
+        assert_eq!(get_domain(0), Some(String::from("cable.ua5v.com")));
+        assert_eq!(get_domain(1), Some(String::from("cable.auth.com")));
+        assert_eq!(
+            get_domain(266),
+            Some(String::from("cable.wufkweyy3uaxb.com"))
+        );
+
+        assert_eq!(get_domain(255), None);
+
+        // 🦀 = \u{1f980}
+        assert_eq!(
+            get_domain(0xf980),
+            Some(String::from("cable.my4kstlhndi4c.net"))
+        )
+    }
+
+    #[test]
+    fn check_all_hashed_tunnel_servers() {
+        for x in 256..u16::MAX {
+            assert_ne!(get_domain(x), None);
+        }
+    }
+}

--- a/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
@@ -180,6 +180,18 @@ pub(crate) fn value_to_u32(v: &Value, loc: &str) -> Option<u32> {
     }
 }
 
+#[cfg(feature = "cable")]
+pub(crate) fn value_to_u64(v: &Value, loc: &str) -> Option<u64> {
+    if let Value::Integer(i) = v {
+        u64::try_from(*i)
+            .map_err(|_| error!("Invalid value inside {}: {:?}", loc, i))
+            .ok()
+    } else {
+        error!("Invalid type for {}: {:?}", loc, v);
+        None
+    }
+}
+
 /// Converts a [`Value::Bool`] into [`Option<bool>`]. Returns [`Option::None`] for other [`Value`] types.
 pub(crate) fn value_to_bool(v: &Value, loc: &str) -> Option<bool> {
     if let Value::Bool(b) = v {

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -67,6 +67,7 @@ pub enum WebauthnCError {
     WebsocketError(String),
     /// The value of the nonce for this object has exceeded the limit.
     NonceOverflow,
+    PermissionDenied,
 }
 
 #[cfg(feature = "nfc")]
@@ -128,7 +129,11 @@ impl From<tokio_tungstenite::tungstenite::error::Error> for WebauthnCError {
 #[cfg(feature = "bluetooth")]
 impl From<btleplug::Error> for WebauthnCError {
     fn from(v: btleplug::Error) -> Self {
-        Self::BluetoothError(v.to_string())
+        use btleplug::Error::*;
+        match v {
+            PermissionDenied => WebauthnCError::PermissionDenied,
+            _ => Self::BluetoothError(v.to_string()),
+        }
     }
 }
 

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -56,6 +56,17 @@ pub enum WebauthnCError {
     /// The card reported as a PC/SC storage card, rather than a smart card.
     StorageCard,
     IoError(String),
+    InvalidCableUrl,
+    #[cfg(feature = "cable")]
+    Base10(crate::cable::DecodeError),
+    BluetoothError(String),
+    NoBluetoothAdapter,
+    /// Attempt to communicate with an authenticator for which the connection
+    /// has been closed.
+    Closed,
+    WebsocketError(String),
+    /// The value of the nonce for this object has exceeded the limit.
+    NonceOverflow,
 }
 
 #[cfg(feature = "nfc")]
@@ -97,6 +108,27 @@ impl From<openssl::error::ErrorStack> for WebauthnCError {
 impl From<std::io::Error> for WebauthnCError {
     fn from(v: std::io::Error) -> Self {
         Self::IoError(v.to_string())
+    }
+}
+
+#[cfg(feature = "cable")]
+impl From<crate::cable::DecodeError> for WebauthnCError {
+    fn from(v: crate::cable::DecodeError) -> Self {
+        Self::Base10(v)
+    }
+}
+
+#[cfg(feature = "cable")]
+impl From<tokio_tungstenite::tungstenite::error::Error> for WebauthnCError {
+    fn from(v: tokio_tungstenite::tungstenite::error::Error) -> Self {
+        Self::WebsocketError(v.to_string())
+    }
+}
+
+#[cfg(feature = "bluetooth")]
+impl From<btleplug::Error> for WebauthnCError {
+    fn from(v: btleplug::Error) -> Self {
+        Self::BluetoothError(v.to_string())
     }
 }
 

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -46,6 +46,9 @@ pub mod types;
 pub mod ui;
 mod util;
 
+#[cfg(feature = "cable")]
+pub mod cable;
+
 #[cfg(feature = "nfc")]
 pub mod nfc;
 

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -14,6 +14,15 @@ pub fn compute_sha256(data: &[u8]) -> [u8; 32] {
     hasher.finish()
 }
 
+#[cfg(feature = "cable")]
+/// Computes the SHA256 of `a || b`.
+pub fn compute_sha256_2(a: &[u8], b: &[u8]) -> [u8; 32] {
+    let mut hasher = sha::Sha256::new();
+    hasher.update(a);
+    hasher.update(b);
+    hasher.finish()
+}
+
 pub fn creation_to_clientdata(origin: Url, challenge: Base64UrlSafeData) -> CollectedClientData {
     // Let collectedClientData be a new CollectedClientData instance whose fields are:
     //    type


### PR DESCRIPTION
This implements a subset of caBLE v2.1 based on Chromium's implementation, and can act as both an initiator (acting as a transport for `CtapAuthenticator`) and an authenticator (proxying requests to `AuthenticatorBackendHashedClientData`, handling PIN/UV auth), and is the MVP for #259.

This handles all the Websockets and Noise-like tunnelling needed to make things work:

* If you're using this as an initiator (to authenticate with a mobile device), this generates a QR code, and works with platform Bluetooth APIs (bluez / CoreBluetooth / WinRT) to listen for the service data advertisement.
* If you want to use this as an authenticator (to pretend to be a mobile device) you'll need to provide a way to send service data advertisements (as macOS and Windows don't allow this); there's an example in `cable_tunnel` which uses a serial-connected Bluetooth HCI adapter. It's also best to do this on a separate device from the initiator, because it'll conflict with the initiator's local device access unless you're using `SoftToken`.

This works for me as an initiator with Android and iOS 16 authenticators, and as an authenticator with Chrome and Safari initiators (using Google's tunnel server).

Deferred work listed in #259.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)

<details>
  <summary><strong>In-development screenshots</strong></summary>
  
  ### MakeCredential flow on iOS 16:
  
  ![MakeCredential QR scanning on iOS](https://user-images.githubusercontent.com/246847/208235351-c4fad1e7-6f51-4e4a-910d-c0e2717fbd97.png)
  
  ![MakeCredential TouchID prompt](https://user-images.githubusercontent.com/246847/208235357-86126f3b-3a69-413c-9dda-14d85620140b.png)
  
  ### GetAssertion flow on iOS 16:
  
  ![GetAssertion QR scanning on iOS](https://user-images.githubusercontent.com/246847/208235360-3cdd8b08-b4a3-48f5-98df-7d540ae47598.png)
  
  ![GetAssertion TouchID prompt](https://user-images.githubusercontent.com/246847/208235363-30840112-f993-438b-99a8-fd32b6fd5e72.png)

</details>
