### PR TITLE
Doc and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build and Test
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,6 @@ jobs:
           triplet: x64-windows-static-md
 
       - run: cargo build --release ${{ matrix.features }}
+      - run: cargo fmt --check
       - run: cargo clippy --all-targets ${{ matrix.features }}
       - run: cargo test --all ${{ matrix.features }}

--- a/fido-mds-tool/src/main.rs
+++ b/fido-mds-tool/src/main.rs
@@ -57,13 +57,11 @@ pub enum Opt {
 impl Opt {
     fn debug(&self) -> bool {
         match self {
-            Opt::ListU2f(CommonOpt { debug, .. }) | 
-            Opt::ListFido2{
+            Opt::ListU2f(CommonOpt { debug, .. })
+            | Opt::ListFido2 {
                 common: CommonOpt { debug, .. },
                 ..
-            } => {
-                *debug
-            }
+            } => *debug,
             Opt::QueryAaguid(QueryOpt {
                 common: CommonOpt { debug, .. },
                 ..
@@ -128,7 +126,7 @@ fn main() {
                 }
             }
         }
-        Opt::ListFido2 { 
+        Opt::ListFido2 {
             common: CommonOpt { debug: _, path },
             extra_details,
         } => {
@@ -166,9 +164,7 @@ fn main() {
                                 }
                                 println!("");
                             }
-
                         }
-
                     }
                 }
                 Err(e) => {

--- a/fido-mds/src/lib.rs
+++ b/fido-mds/src/lib.rs
@@ -1130,7 +1130,9 @@ impl From<RawFidoMds> for FidoMds {
                 FidoDevice::FIDO2(dev) => {
                     let dev = rc::Rc::new(dev);
                     assert!(fido2.insert(dev.aaguid, dev.clone()).is_none());
-                    assert!(fido2_description.insert(dev.description.clone(), dev).is_none());
+                    assert!(fido2_description
+                        .insert(dev.description.clone(), dev)
+                        .is_none());
                 }
             });
 
@@ -1138,7 +1140,7 @@ impl From<RawFidoMds> for FidoMds {
             fido2,
             fido2_description,
             uaf,
-            u2f
+            u2f,
         }
     }
 }

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -297,14 +297,25 @@ pub enum AuthenticationAlgorithm {
 impl fmt::Display for AuthenticationAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AuthenticationAlgorithm::Secp256r1EcdsaSha256Raw => write!(f, "secp256r1_ecdsa_sha256_raw"),
-            AuthenticationAlgorithm::Secp256r1EcdsaSha256Der => write!(f, "secp256r1_ecdsa_sha256_der"),
-            AuthenticationAlgorithm::Secp256K1EcdsaSha256Raw => write!(f, "secp256k1_ecdsa_sha256_raw"),
-            AuthenticationAlgorithm::RsaEmsaPkcs1Sha256Raw => write!(f, "rsa_emsa_pkcs1_sha256_raw"),
+            AuthenticationAlgorithm::Secp256r1EcdsaSha256Raw => {
+                write!(f, "secp256r1_ecdsa_sha256_raw")
+            }
+            AuthenticationAlgorithm::Secp256r1EcdsaSha256Der => {
+                write!(f, "secp256r1_ecdsa_sha256_der")
+            }
+            AuthenticationAlgorithm::Secp256K1EcdsaSha256Raw => {
+                write!(f, "secp256k1_ecdsa_sha256_raw")
+            }
+            AuthenticationAlgorithm::RsaEmsaPkcs1Sha256Raw => {
+                write!(f, "rsa_emsa_pkcs1_sha256_raw")
+            }
             AuthenticationAlgorithm::Ed25519EddsaSha512Raw => write!(f, "ed25519_eddsa_sha512_raw"),
-            AuthenticationAlgorithm::Secp384r1EcdsaSha384Raw => write!(f, "secp384r1_ecdsa_sha384_raw"),
-            AuthenticationAlgorithm::RsassaPkcsv15Sha256Raw => write!(f, "rsassa_pkcsv15_sha256_raw"),
-
+            AuthenticationAlgorithm::Secp384r1EcdsaSha384Raw => {
+                write!(f, "secp384r1_ecdsa_sha384_raw")
+            }
+            AuthenticationAlgorithm::RsassaPkcsv15Sha256Raw => {
+                write!(f, "rsassa_pkcsv15_sha256_raw")
+            }
         }
     }
 }

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,4 @@
 Fixes #
 
-- [ ] cargo fmt has been run
 - [ ] cargo test has been run and passes
 - [ ] documentation has been updated with relevant examples (if relevant)

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -429,17 +429,6 @@ impl Webauthn {
     ///         None, // No other credentials are registered yet.
     ///     )
     ///     .expect("Failed to start registration.");
-    ///
-    /// // Only allow credentials from manufacturers that are trusted and part of the webauthn-rs
-    /// // strict "high quality" list.
-    /// let (ccr, skr) = webauthn
-    ///     .start_passkey_registration(
-    ///         Uuid::new_v4(),
-    ///         "claire",
-    ///         "Claire",
-    ///         None, // No other credentials are registered yet.
-    ///     )
-    ///     .expect("Failed to start registration.");
     /// ```
     pub fn start_passkey_registration(
         &self,

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -470,7 +470,7 @@ impl Webauthn {
     }
 
     /// Complete the registration of the credential. The user agent (e.g. a browser) will return the data of `RegisterPublicKeyCredential`,
-    /// and the server provides it's paired [PasskeyRegistration]. The details of the Authenticator
+    /// and the server provides its paired [PasskeyRegistration]. The details of the Authenticator
     /// based on the registration parameters are asserted.
     ///
     /// # Errors


### PR DESCRIPTION
## Contents
- Fixes #240 
- Bumps github checkout action to `v3` to solve deprecation warnings
- Introduces `cargo fmt --check` at CI time and remove the related checks from the PR template

## Checks

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
