### PR TITLE
Add improved query support

### DIFF
--- a/fido-mds/Cargo.toml
+++ b/fido-mds/Cargo.toml
@@ -13,11 +13,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
 base64 = "0.13"
-# base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }
 compact_jwt = "^0.2.3"
-
+peg = "0.8.1"
 openssl = { version = "0.10" }
 serde = { version = "^1.0.141", features = ["derive"] }
 serde_json = "^1.0.79"

--- a/fido-mds/src/query.rs
+++ b/fido-mds/src/query.rs
@@ -1,0 +1,169 @@
+//! This implements a query language for the FIDO Metadata Service. This is loosely
+//! based on the SCIM query language.
+//!
+//! `aaguid eq abcd and userverification eq passcodeexternal`
+
+use std::str::FromStr;
+use uuid::Uuid;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CompareOp {
+    Equal,
+    NotEqual,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AttrValueAssertion {
+    Aaguid(Uuid),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Query {
+    Op(AttrValueAssertion, CompareOp),
+    And(Box<Query>, Box<Query>),
+    Or(Box<Query>, Box<Query>),
+    Not(Box<Query>),
+}
+
+impl FromStr for Query {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+
+    fn from_str(q: &str) -> Result<Self, Self::Err> {
+        query::parse(q)
+    }
+}
+
+peg::parser! {
+    grammar query() for str {
+        pub rule parse() -> Query = precedence!{
+                 a:(@) separator()+ "or" separator()+ b:@ {
+                Query::Or(
+                    Box::new(a),
+                    Box::new(b)
+                )
+            }
+            --
+            a:(@) separator()+ "and" separator()+ b:@ {
+                Query::And(
+                    Box::new(a),
+                    Box::new(b)
+                )
+            }
+            --
+            "not" separator()+ "(" e:parse() ")" {
+                Query::Not(Box::new(e))
+            }
+            --
+            "(" e:parse() ")" { e }
+            a:expr() { a }
+        }
+
+        rule separator() =
+            ['\n' | ' ' | '\t' ]
+
+        rule operator() =
+            ['\n' | ' ' | '\t' | '(' | ')' ]
+
+        pub(crate) rule expr() -> Query =
+            uuid_expr()
+
+        rule uuid_expr() -> Query =
+            "aaguid" separator()+ c:compareop() separator() + v:uuid() { Query::Op(AttrValueAssertion::Aaguid(v), c) }
+
+        pub(crate) rule compareop() -> CompareOp =
+            "eq" { CompareOp::Equal } /
+            "ne" { CompareOp::NotEqual }
+
+        pub(crate) rule uuid() -> Uuid =
+            s:$((!operator()[_])*) {? Uuid::from_str(s).map_err(|_| "invalid UUID" ) }
+
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_attr_uuid() {
+        assert_eq!(
+            query::uuid("c370f859-622e-4388-9ad2-a7fe7551fdba"),
+            Ok(uuid::uuid!("c370f859-622e-4388-9ad2-a7fe7551fdba"))
+        );
+        assert!(query::uuid("oueuntonaeunaun").is_err());
+    }
+
+    #[test]
+    fn test_compareop() {
+        assert_eq!(query::compareop("eq"), Ok(CompareOp::Equal));
+        assert_eq!(query::compareop("ne"), Ok(CompareOp::NotEqual));
+    }
+
+    #[test]
+    fn test_query_attr_uuid() {
+        assert_eq!(
+            query::expr("aaguid eq c370f859-622e-4388-9ad2-a7fe7551fdba"),
+            Ok(Query::Op(
+                AttrValueAssertion::Aaguid(uuid::uuid!("c370f859-622e-4388-9ad2-a7fe7551fdba")),
+                CompareOp::Equal
+            ))
+        );
+    }
+
+    #[test]
+    fn test_query_not() {
+        assert_eq!(
+            query::parse("not (aaguid eq c370f859-622e-4388-9ad2-a7fe7551fdba)"),
+            Ok(Query::Not(Box::new(Query::Op(
+                AttrValueAssertion::Aaguid(uuid::uuid!("c370f859-622e-4388-9ad2-a7fe7551fdba")),
+                CompareOp::Equal
+            ))))
+        );
+    }
+
+    #[test]
+    fn test_query_and() {
+        assert_eq!(
+            query::parse("aaguid eq c370f859-622e-4388-9ad2-a7fe7551fdba and aaguid eq 70f11dce-befb-4619-a091-110633d923f6"),
+            Ok(
+                Query::And(
+                    Box::new(
+                        Query::Op(
+                            AttrValueAssertion::Aaguid(uuid::uuid!("c370f859-622e-4388-9ad2-a7fe7551fdba")),
+                            CompareOp::Equal
+                        )
+                    ),
+                    Box::new(
+                        Query::Op(
+                            AttrValueAssertion::Aaguid(uuid::uuid!("70f11dce-befb-4619-a091-110633d923f6")),
+                            CompareOp::Equal
+                        )
+                    ),
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn test_query_or() {
+        assert_eq!(
+            query::parse("aaguid eq c370f859-622e-4388-9ad2-a7fe7551fdba or aaguid eq 70f11dce-befb-4619-a091-110633d923f6"),
+            Ok(
+                Query::Or(
+                    Box::new(
+                        Query::Op(
+                            AttrValueAssertion::Aaguid(uuid::uuid!("c370f859-622e-4388-9ad2-a7fe7551fdba")),
+                            CompareOp::Equal
+                        )
+                    ),
+                    Box::new(
+                        Query::Op(
+                            AttrValueAssertion::Aaguid(uuid::uuid!("70f11dce-befb-4619-a091-110633d923f6")),
+                            CompareOp::Equal
+                        )
+                    ),
+                )
+            )
+        );
+    }
+}

--- a/webauthn-authenticator-rs/examples/key_manager/main.rs
+++ b/webauthn-authenticator-rs/examples/key_manager/main.rs
@@ -151,7 +151,7 @@ fn main() {
 
         Opt::Info => {
             for token in &tokens {
-                println!("{:?}", token.get_info());
+                println!("{}", token.get_info());
             }
         }
 

--- a/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
@@ -2,6 +2,8 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use serde_cbor::Value;
+use std::fmt;
+use uuid::Uuid;
 use webauthn_rs_proto::AuthenticatorTransport;
 
 use self::CBORCommand;
@@ -53,6 +55,73 @@ pub struct GetInfoResponse {
     /// Use [get_min_pin_length][Self::get_min_pin_length] to get a default
     /// value for when this is not present.
     pub min_pin_length: Option<usize>,
+}
+
+impl fmt::Display for GetInfoResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "versions: ")?;
+        for v in self.versions.iter() {
+            write!(f, "{} ", v)?;
+        }
+        writeln!(f)?;
+
+        write!(f, "extensions: ")?;
+        for e in self.extensions.iter().flatten() {
+            write!(f, "{} ", e)?;
+        }
+        writeln!(f)?;
+
+        if let Ok(aaguid) = Uuid::from_slice(self.aaguid.as_slice()) {
+            writeln!(f, "aaguid: {}", aaguid)?;
+        } else {
+            writeln!(f, "aaguid: INVALID - {:?}", self.aaguid)?;
+        }
+
+        write!(f, "options: ")?;
+        for (o, b) in self.options.iter().flatten() {
+            write!(f, "{}:{} ", o, b)?;
+        }
+        writeln!(f)?;
+
+        if let Some(mms) = self.max_msg_size {
+            writeln!(f, "max message size: {}", mms)?;
+        } else {
+            writeln!(f, "max message size: N/A")?;
+        }
+
+        write!(f, "pin_protocols: ")?;
+        for e in self.pin_protocols.iter().flatten() {
+            write!(f, "{} ", e)?;
+        }
+        writeln!(f)?;
+
+        if let Some(mms) = self.max_cred_count_in_list {
+            writeln!(f, "max cred count in list: {}", mms)?;
+        } else {
+            writeln!(f, "max cred count in list: N/A")?;
+        }
+
+        if let Some(mms) = self.max_cred_id_len {
+            writeln!(f, "max cred id len: {}", mms)?;
+        } else {
+            writeln!(f, "max cred id len: N/A")?;
+        }
+
+        write!(f, "transports: ")?;
+        for e in self.transports.iter().flatten() {
+            write!(f, "{} ", e)?;
+        }
+        writeln!(f)?;
+
+        // ???
+        writeln!(f, "algorithms: {:?}", self.algorithms)?;
+
+        if let Some(mms) = self.min_pin_length {
+            writeln!(f, "min pin len: {}", mms)
+        } else {
+            writeln!(f, "min pin len: N/A")
+        }
+    }
 }
 
 impl GetInfoResponse {


### PR DESCRIPTION
This adds support for improved querying of the MDS. Currently it only supports aaguid queries but we can expand this to also support other items that may be used by people making decisions. 

- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
