### PR TITLE
Common API changes needed to (later) add caBLE support.

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/kanidm/webauthn-rs"
 [features]
 nfc_raw_transmit = ["nfc"]
 u2fhid = ["authenticator"]
+
 nfc = ["pcsc"]
 usb = ["hidapi"]
 win10 = ["windows"]
@@ -50,7 +51,10 @@ num-derive = "0.3"
 async-trait = "0.1.58"
 futures = "0.3.25"
 
+qrcode = { version = "^0.12.0", optional = true }
+
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
-base64 = "0.13"
 clap = { version = "^3.2", features = ["derive", "env"] }
+tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"] }
+tempfile = { version = "3.3.0" }

--- a/webauthn-authenticator-rs/examples/conformance/core.rs
+++ b/webauthn-authenticator-rs/examples/conformance/core.rs
@@ -1,5 +1,5 @@
 use pcsc::Scope;
-use webauthn_authenticator_rs::ctap2::{commands::*, *};
+use webauthn_authenticator_rs::ctap2::commands::*;
 use webauthn_authenticator_rs::nfc::*;
 use webauthn_authenticator_rs::transport::iso7816::*;
 
@@ -62,7 +62,7 @@ fn test_extended_lc_info(card: &NFCCard) -> TestResult {
         return TestResult::Fail("Unsupported CTAP applet");
     }
 
-    let mut get_info = (GetInfoRequest {}).to_extended_apdu().unwrap();
+    let mut get_info = to_extended_apdu((GetInfoRequest {}).cbor().unwrap());
     get_info.ne = 65536;
     resp = card
         .transmit(&get_info, &ISO7816LengthForm::Extended)

--- a/webauthn-authenticator-rs/examples/softtoken/main.rs
+++ b/webauthn-authenticator-rs/examples/softtoken/main.rs
@@ -1,0 +1,43 @@
+extern crate tracing;
+
+use std::fs::OpenOptions;
+
+use clap::{Args, Parser, Subcommand};
+use webauthn_authenticator_rs::softtoken::{SoftToken, SoftTokenFile};
+
+#[derive(Debug, clap::Parser)]
+#[clap(about = "SoftToken management tool")]
+pub struct CliParser {
+    #[clap(subcommand)]
+    pub commands: Opt,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Opt {
+    Create(CreateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct CreateArgs {
+    #[clap()]
+    pub filename: String,
+}
+
+fn main() {
+    use Opt::*;
+
+    let opt = CliParser::parse();
+    tracing_subscriber::fmt::init();
+    match opt.commands {
+        Create(args) => {
+            let (token, _) = SoftToken::new().unwrap();
+            let f = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(args.filename)
+                .unwrap();
+            let authenticator = SoftTokenFile::new(token, f);
+            drop(authenticator);
+        }
+    }
+}

--- a/webauthn-authenticator-rs/src/authenticator_hashed.rs
+++ b/webauthn-authenticator-rs/src/authenticator_hashed.rs
@@ -1,0 +1,360 @@
+//! Specialized alternative traits for authenticator backends.
+use std::collections::BTreeMap;
+
+use base64urlsafedata::Base64UrlSafeData;
+use serde_cbor::{ser::to_vec_packed, Value};
+use url::Url;
+use webauthn_rs_proto::{
+    PublicKeyCredential, PublicKeyCredentialCreationOptions, PublicKeyCredentialDescriptor,
+    PublicKeyCredentialRequestOptions, RegisterPublicKeyCredential,
+};
+
+use crate::{
+    ctap2::commands::{
+        GetAssertionRequest, GetAssertionResponse, MakeCredentialRequest, MakeCredentialResponse,
+    },
+    error::WebauthnCError,
+    util::{compute_sha256, creation_to_clientdata, get_to_clientdata},
+    AuthenticatorBackend,
+};
+
+/// [AuthenticatorBackend] with a `client_data_hash` parameter, for proxying
+/// requests.
+///
+/// **Note:** unless you're proxying autentication requests, use the
+/// [AuthenticatorBackend] trait instead. There is an implementation of
+/// [AuthenticatorBackend] for `T: AuthenticatorBackendHashedClientData`.
+///
+/// Normally, [AuthenticatorBackend] takes the `origin` and `options.challenge`
+/// parameters, serialises it to JSON, and then hashes it to produce
+/// `client_data_hash`, which the authenticator signs. That JSON and the
+/// signature are returned to the relying party, which it can check contain
+/// expected values and are signed correctly.
+///
+/// This doesn't work when proxying an authenticator, where an initiator (web
+/// browser) has *already* produced a `client_data_hash` for the authenticator
+/// to sign, and changing it will cause the authenticator to sign something else
+/// (and fail verification).
+///
+/// This trait instead takes a `client_data_hash` directly, and ignores the
+/// `options.challenge` parameter. The downside is that this *can't* return a
+/// `client_data_json` (the value is unknown), because the authenticator
+/// wouldn't normally get a `client_data_json`.
+///
+/// This is similar to
+/// [`BrowserPublicKeyCredentialCreationOptions.Builder.setClientDataHash()`][0]
+/// on Android (Google Play Services FIDO API), which Chromium uses to proxy
+/// caBLE requests (which only contain `client_data_json`) to an authenticator
+/// stored in the device's secure element.
+///
+/// [AuthenticatorBackendHashedClientData] provides a [AuthenticatorBackend]
+/// implementation – so backends should only implement **one** of those APIs,
+/// preferring to implement [AuthenticatorBackendHashedClientData] if possible.
+///
+/// This interface won't be feasiable to implement on all platforms. For
+/// example, Windows' Webauthn API takes a `client_data_json` and always hashes
+/// it, and Apple's Passkey API takes `relyingPartyIdentifier` (origin) and
+/// `challenge` parameters and generates the `client_data_json` for you.
+///
+/// Most clients should prefer to use the [AuthenticatorBackend] trait.
+///
+/// **See also:** [perform_register_with_request], [perform_auth_with_request]
+///
+/// [0]: https://developers.google.com/android/reference/com/google/android/gms/fido/fido2/api/common/BrowserPublicKeyCredentialCreationOptions.Builder#public-browserpublickeycredentialcreationoptions.builder-setclientdatahash-byte[]-clientdatahash
+pub trait AuthenticatorBackendHashedClientData {
+    fn perform_register(
+        &mut self,
+        client_data_hash: Vec<u8>,
+        options: PublicKeyCredentialCreationOptions,
+        timeout_ms: u32,
+    ) -> Result<RegisterPublicKeyCredential, WebauthnCError>;
+
+    fn perform_auth(
+        &mut self,
+        client_data_hash: Vec<u8>,
+        options: PublicKeyCredentialRequestOptions,
+        timeout_ms: u32,
+    ) -> Result<PublicKeyCredential, WebauthnCError>;
+}
+
+/// This provides a [AuthenticatorBackend] implementation for
+/// [AuthenticatorBackendHashedClientData] implementations.
+///
+/// This implementation creates and hashes the `client_data_json`, and inserts
+/// it back into the response type as normal.
+impl<T: AuthenticatorBackendHashedClientData> AuthenticatorBackend for T {
+    fn perform_register(
+        &mut self,
+        origin: Url,
+        options: PublicKeyCredentialCreationOptions,
+        timeout_ms: u32,
+    ) -> Result<RegisterPublicKeyCredential, WebauthnCError> {
+        let client_data = creation_to_clientdata(origin, options.challenge.clone());
+        let client_data: Vec<u8> = serde_json::to_string(&client_data)
+            .map_err(|_| WebauthnCError::Json)?
+            .into();
+        let client_data_hash = compute_sha256(&client_data).to_vec();
+        let mut cred = self.perform_register(client_data_hash, options, timeout_ms)?;
+        cred.response.client_data_json = Base64UrlSafeData(client_data);
+
+        Ok(cred)
+    }
+
+    fn perform_auth(
+        &mut self,
+        origin: Url,
+        options: PublicKeyCredentialRequestOptions,
+        timeout_ms: u32,
+    ) -> Result<PublicKeyCredential, WebauthnCError> {
+        let client_data = get_to_clientdata(origin, options.challenge.clone());
+        let client_data: Vec<u8> = serde_json::to_string(&client_data)
+            .map_err(|_| WebauthnCError::Json)?
+            .into();
+        let client_data_hash = compute_sha256(&client_data).to_vec();
+        let mut cred = self.perform_auth(client_data_hash, options, timeout_ms)?;
+        cred.response.client_data_json = Base64UrlSafeData(client_data);
+        Ok(cred)
+    }
+}
+
+/// Performs a registration request, using a [MakeCredentialRequest].
+///
+/// All PIN/UV auth parameters will be ignored, and are processed by
+/// [AuthenticatorBackendHashedClientData] in the usual way.
+///
+/// Returns a [MakeCredentialResponse] as `Vec<u8>` on success. The message may
+/// not be identical to what the authenticator actually returned, as it is
+/// subject to deserialisation and conversion to and from another structure used
+/// by [AuthenticatorBackend].
+pub fn perform_register_with_request(
+    backend: &mut impl AuthenticatorBackendHashedClientData,
+    request: MakeCredentialRequest,
+    timeout_ms: u32,
+) -> Result<Vec<u8>, WebauthnCError> {
+    let options = PublicKeyCredentialCreationOptions {
+        rp: request.rp,
+        user: request.user,
+        challenge: Base64UrlSafeData(vec![]),
+        pub_key_cred_params: request.pub_key_cred_params,
+        timeout: Some(timeout_ms),
+        exclude_credentials: Some(request.exclude_list),
+        // TODO
+        attestation: None,
+        authenticator_selection: None,
+        extensions: None,
+    };
+    let client_data_hash = request.client_data_hash;
+
+    let cred: RegisterPublicKeyCredential =
+        backend.perform_register(client_data_hash, options, timeout_ms)?;
+
+    // attestation_object is a MakeCredentialResponse, with string keys
+    // rather than u32, we need to convert it.
+    let resp: MakeCredentialResponse =
+        serde_cbor::de::from_slice(cred.response.attestation_object.0.as_slice())
+            .map_err(|_| WebauthnCError::Cbor)?;
+
+    // Write value with u32 keys
+    let resp: BTreeMap<u32, Value> = resp.into();
+    to_vec_packed(&resp).map_err(|_| WebauthnCError::Cbor)
+}
+
+/// Performs an authentication request, using a [GetAssertionRequest].
+///
+/// All PIN/UV auth parameters will be ignored, and are processed by
+/// [AuthenticatorBackendHashedClientData] in the usual way.
+///
+/// Returns a [GetAssertionResponse] as `Vec<u8>` on success. The message may
+/// not be identical to what the authenticator actually returned, as it is
+/// subject to deserialisation and conversion to and from another structure used
+/// by [AuthenticatorBackend].
+pub fn perform_auth_with_request(
+    backend: &mut impl AuthenticatorBackendHashedClientData,
+    request: GetAssertionRequest,
+    timeout_ms: u32,
+) -> Result<Vec<u8>, WebauthnCError> {
+    let options = PublicKeyCredentialRequestOptions {
+        challenge: Base64UrlSafeData(vec![]),
+        timeout: Some(timeout_ms),
+        rp_id: request.rp_id,
+        allow_credentials: request.allow_list,
+        // TODO
+        user_verification: webauthn_rs_proto::UserVerificationPolicy::Preferred,
+        extensions: None,
+    };
+
+    let cred = backend.perform_auth(request.client_data_hash, options, timeout_ms)?;
+    let resp = GetAssertionResponse {
+        credential: Some(PublicKeyCredentialDescriptor {
+            type_: cred.type_,
+            id: cred.raw_id,
+            transports: None,
+        }),
+        auth_data: Some(cred.response.authenticator_data.0),
+        signature: Some(cred.response.signature.0),
+        number_of_credentials: None,
+        user_selected: None,
+        large_blob_key: None,
+    };
+
+    // Write value with u32 keys
+    let resp: BTreeMap<u32, Value> = resp.into();
+    to_vec_packed(&resp).map_err(|_| WebauthnCError::Cbor)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod test {
+    use openssl::{hash::MessageDigest, rand::rand_bytes, sign::Verifier, x509::X509};
+    use webauthn_rs_core::proto::COSEKey;
+    use webauthn_rs_proto::{AllowCredentials, PubKeyCredParams, RelyingParty, User};
+
+    use crate::{
+        ctap2::{commands::value_to_vec_u8, CBORResponse},
+        softtoken::SoftToken,
+    };
+
+    use super::*;
+
+    #[test]
+    fn perform_register_auth_with_command() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let (mut soft_token, _) = SoftToken::new().unwrap();
+        let mut client_data_hash = vec![0; 32];
+        let mut user_id = vec![0; 16];
+        rand_bytes(&mut client_data_hash).unwrap();
+        rand_bytes(&mut user_id).unwrap();
+
+        let request = MakeCredentialRequest {
+            client_data_hash: client_data_hash.clone(),
+            rp: RelyingParty {
+                name: "example.com".to_string(),
+                id: "example.com".to_string(),
+            },
+            user: User {
+                id: Base64UrlSafeData(user_id),
+                name: "sampleuser".to_string(),
+                display_name: "Sample User".to_string(),
+            },
+            pub_key_cred_params: vec![
+                PubKeyCredParams {
+                    type_: "public-key".to_string(),
+                    alg: -7,
+                },
+                PubKeyCredParams {
+                    type_: "public-key".to_string(),
+                    alg: -257,
+                },
+            ],
+            exclude_list: vec![],
+            options: None,
+            pin_uv_auth_param: None,
+            pin_uv_auth_proto: None,
+            enterprise_attest: None,
+        };
+
+        let response = perform_register_with_request(&mut soft_token, request, 10000).unwrap();
+
+        // All keys should be ints
+        let m: Value = serde_cbor::from_slice(response.as_slice()).unwrap();
+        let m = if let Value::Map(m) = m {
+            m
+        } else {
+            panic!("unexpected type")
+        };
+        assert!(m.keys().all(|k| matches!(k, Value::Integer(_))));
+
+        // Try to deserialise the MakeCredentialResponse again
+        let response =
+            <MakeCredentialResponse as CBORResponse>::try_from(response.as_slice()).unwrap();
+        trace!(?response);
+
+        // Run packed attestation verification
+        // https://www.w3.org/TR/webauthn-2/#sctn-packed-attestation
+        let mut att_stmt = if let Value::Map(m) = response.att_stmt.unwrap() {
+            m
+        } else {
+            panic!("unexpected type");
+        };
+        trace!(?att_stmt);
+        let signature = value_to_vec_u8(
+            att_stmt.remove(&Value::Text("sig".to_string())).unwrap(),
+            "att_stmt.sig",
+        )
+        .unwrap();
+
+        // Extract attestation certificate
+        let x5c = if let Value::Array(v) = att_stmt.remove(&Value::Text("x5c".to_string())).unwrap()
+        {
+            v
+        } else {
+            panic!("Unexpected type");
+        };
+        let x5c = value_to_vec_u8(x5c[0].to_owned(), "x5c[0]").unwrap();
+        let verification_cert = X509::from_der(&x5c).unwrap();
+        let pubkey = verification_cert.public_key().unwrap();
+
+        // Reconstruct verification data (auth_data + client_data_hash)
+        let mut verification_data =
+            value_to_vec_u8(response.auth_data.unwrap(), "verification_data").unwrap();
+        let auth_data_len = verification_data.len();
+        verification_data.reserve(client_data_hash.len());
+        verification_data.extend_from_slice(&client_data_hash);
+
+        let mut verifier = Verifier::new(MessageDigest::sha256(), &pubkey).unwrap();
+        assert!(verifier
+            .verify_oneshot(&signature, &verification_data)
+            .unwrap());
+
+        // https://www.w3.org/TR/webauthn-2/#attestation-object
+        let cred_id_off = /* rp_id_hash */ 32 + /* flags */ 1 + /* counter */ 4 + /* aaguid */ 16;
+        let cred_id_len = u16::from_be_bytes(
+            (&verification_data[cred_id_off..cred_id_off + 2])
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let cred_id = Base64UrlSafeData(
+            (verification_data[cred_id_off + 2..cred_id_off + 2 + cred_id_len]).to_vec(),
+        );
+
+        // Future assertions are signed with this COSEKey
+        let cose_key: Value = serde_cbor::from_slice(
+            &verification_data[cred_id_off + 2 + cred_id_len..auth_data_len],
+        )
+        .unwrap();
+        let cose_key = COSEKey::try_from(&cose_key).unwrap();
+
+        rand_bytes(&mut client_data_hash).unwrap();
+        let request = GetAssertionRequest {
+            client_data_hash: client_data_hash.clone(),
+            rp_id: "example.com".to_string(),
+            allow_list: vec![AllowCredentials {
+                type_: "public-key".to_string(),
+                id: cred_id.to_owned(),
+                transports: None,
+            }],
+            options: None,
+            pin_uv_auth_param: None,
+            pin_uv_auth_proto: None,
+        };
+        trace!(?request);
+
+        let response = perform_auth_with_request(&mut soft_token, request, 10000).unwrap();
+        let response =
+            <GetAssertionResponse as CBORResponse>::try_from(response.as_slice()).unwrap();
+        trace!(?response);
+
+        // Check correct matching credential
+        assert_eq!(response.credential.unwrap().id, cred_id);
+
+        // Check the signature
+        let signature = response.signature.unwrap();
+        let mut verification_data = response.auth_data.unwrap();
+        verification_data.reserve(client_data_hash.len());
+        verification_data.extend_from_slice(&client_data_hash);
+
+        assert!(cose_key
+            .verify_signature(&signature, &verification_data)
+            .unwrap());
+    }
+}

--- a/webauthn-authenticator-rs/src/crypto.rs
+++ b/webauthn-authenticator-rs/src/crypto.rs
@@ -1,0 +1,141 @@
+//! Common cryptographic routines for FIDO2.
+
+use openssl::{
+    ec::{EcGroup, EcKey},
+    md::Md,
+    nid::Nid,
+    pkey::{Id, PKey, Private, Public},
+    pkey_ctx::PkeyCtx,
+    symm::{Cipher, Crypter, Mode},
+};
+
+use crate::error::WebauthnCError;
+
+/// Gets an [EcGroup] for P-256
+pub fn get_group() -> Result<EcGroup, WebauthnCError> {
+    Ok(EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?)
+}
+
+/// Encrypts some data using AES-256-CBC, with no padding.
+///
+/// `plaintext.len()` must be a multiple of the cipher's blocksize.
+pub fn encrypt(key: &[u8], iv: Option<&[u8]>, plaintext: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
+    let cipher = Cipher::aes_256_cbc();
+    let mut ct = vec![0; plaintext.len() + cipher.block_size()];
+    let mut c = Crypter::new(cipher, Mode::Encrypt, key, iv)?;
+    c.pad(false);
+    let l = c.update(plaintext, &mut ct)?;
+    let l = l + c.finalize(&mut ct[l..])?;
+    ct.truncate(l);
+    Ok(ct)
+}
+
+/// Decrypts some data using AES-256-CBC, with no padding.
+pub fn decrypt(
+    key: &[u8],
+    iv: Option<&[u8]>,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, WebauthnCError> {
+    let cipher = Cipher::aes_256_cbc();
+    if ciphertext.len() % cipher.block_size() != 0 {
+        error!(
+            "ciphertext length {} is not a multiple of {} bytes",
+            ciphertext.len(),
+            cipher.block_size()
+        );
+        return Err(WebauthnCError::Internal);
+    }
+
+    let mut pt = vec![0; ciphertext.len() + cipher.block_size()];
+    let mut c = Crypter::new(cipher, Mode::Decrypt, key, iv)?;
+    c.pad(false);
+    let l = c.update(ciphertext, &mut pt)?;
+    let l = l + c.finalize(&mut pt[l..])?;
+    pt.truncate(l);
+    Ok(pt)
+}
+
+pub fn hkdf_sha_256(
+    salt: &[u8],
+    ikm: &[u8],
+    info: Option<&[u8]>,
+    output: &mut [u8],
+) -> Result<(), WebauthnCError> {
+    let mut ctx = PkeyCtx::new_id(Id::HKDF)?;
+    ctx.derive_init()?;
+    ctx.set_hkdf_md(Md::sha256())?;
+    ctx.set_hkdf_salt(salt)?;
+    ctx.set_hkdf_key(ikm)?;
+    if let Some(info) = info {
+        ctx.add_hkdf_info(info)?;
+    }
+    ctx.derive(Some(output))?;
+    Ok(())
+}
+
+/// Generate a fresh, random P-256 private key
+pub fn regenerate() -> Result<EcKey<Private>, WebauthnCError> {
+    let ecgroup = get_group()?;
+    let eckey = EcKey::generate(&ecgroup)?;
+    Ok(eckey)
+}
+
+pub fn ecdh(
+    private_key: EcKey<Private>,
+    peer_key: EcKey<Public>,
+    output: &mut [u8],
+) -> Result<(), WebauthnCError> {
+    let peer_key = PKey::from_ec_key(peer_key)?;
+    let pkey = PKey::from_ec_key(private_key)?;
+    let mut ctx = PkeyCtx::new(&pkey)?;
+    ctx.derive_init()?;
+    ctx.derive_set_peer(&peer_key)?;
+    ctx.derive(Some(output))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn hkdf() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let salt: Vec<u8> = (0..0x0d).collect();
+        let ikm: [u8; 22] = [0x0b; 22];
+        let info: Vec<u8> = (0xf0..0xfa).collect();
+        let expected: [u8; 42] = [
+            0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a, 0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36,
+            0x2f, 0x2a, 0x2d, 0x2d, 0xa, 0x90, 0xcf, 0x1a, 0x5a, 0x4c, 0x5d, 0xb0, 0x2d, 0x56,
+            0xec, 0xc4, 0xc5, 0xbf, 0x34, 0x0, 0x72, 0x8, 0xd5, 0xb8, 0x87, 0x18, 0x58, 0x65,
+        ];
+
+        let mut output: [u8; 42] = [0; 42];
+
+        hkdf_sha_256(salt.as_slice(), &ikm, Some(info.as_slice()), &mut output)
+            .expect("hkdf_sha_256 fail");
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn hkdf_chromium() {
+        // Compare hkdf using values debug-logged from Chromium
+        let _ = tracing_subscriber::fmt::try_init();
+        let ck = [
+            0x30, 0x7a, 0x70, 0x6e, 0x63, 0x38, 0x2e, 0x8e, 0x9d, 0x46, 0xcc, 0xdb, 0xc, 0xeb,
+            0xed, 0x5c, 0x2b, 0x19, 0x28, 0xc5, 0xae, 0x2d, 0xee, 0x63, 0x52, 0xe1, 0x30, 0xac,
+            0xe1, 0xf7, 0x4f, 0x44,
+        ];
+        let expected = [
+            0x1f, 0xba, 0x3c, 0xce, 0x17, 0x62, 0x2c, 0x68, 0x26, 0x8d, 0x9f, 0x75, 0xb5, 0xa8,
+            0xa3, 0x35, 0x1b, 0x51, 0x7f, 0x9, 0x6f, 0xb5, 0xe2, 0x94, 0x94, 0x1a, 0xf7, 0xe3,
+            0xa6, 0xa8, 0xd6, 0xe1, 0xe3, 0x4f, 0x1a, 0xa3, 0x74, 0x72, 0x38, 0xc0, 0x4d, 0x3b,
+            0xd2, 0x5e, 0x7, 0xef, 0x1b, 0x35, 0xfe, 0xf3, 0x59, 0x0, 0xd, 0x75, 0x56, 0x15, 0xcd,
+            0x85, 0xbe, 0x27, 0xcf, 0xc8, 0x7, 0xd1,
+        ];
+        let mut actual = [0; 64];
+
+        hkdf_sha_256(&ck, &[], None, &mut actual).unwrap();
+        assert_eq!(expected, actual);
+    }
+}

--- a/webauthn-authenticator-rs/src/ctap2/commands/bio_enrollment.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/bio_enrollment.rs
@@ -220,8 +220,8 @@ pub enum BioSubCommand {
     /// Captures another sample of a fingerprint while enrollment is in
     /// progress:
     ///
-    /// * [Vec<u8>]: `template_id` of the partially-enrolled fingerprint.
-    /// * [Duration]: time-out for the operation.
+    /// * [`Vec<u8>`]: `template_id` of the partially-enrolled fingerprint.
+    /// * [`Duration`]: time-out for the operation.
     ///
     /// <https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#enrollingFingerprint>
     FingerprintEnrollCaptureNextSample(/* id */ Vec<u8>, /* timeout */ Duration),

--- a/webauthn-authenticator-rs/src/ctap2/commands/get_assertion.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/get_assertion.rs
@@ -4,6 +4,8 @@ use serde_cbor::Value;
 use std::{collections::BTreeMap, str::FromStr};
 use webauthn_rs_proto::{AllowCredentials, AuthenticatorTransport, PublicKeyCredentialDescriptor};
 
+use crate::ctap2::commands::{value_to_map, value_to_vec, value_to_vec_string};
+
 use super::{
     value_to_bool, value_to_set_string, value_to_string, value_to_u32, value_to_vec_u8, CBORCommand,
 };
@@ -12,7 +14,7 @@ use super::{
 ///
 /// Reference: <https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorGetAssertion>
 #[derive(Serialize, Debug, Clone)]
-#[serde(into = "BTreeMap<u32, Value>")]
+#[serde(into = "BTreeMap<u32, Value>", try_from = "BTreeMap<u32, Value>")]
 pub struct GetAssertionRequest {
     pub rp_id: String,
     pub client_data_hash: Vec<u8>,
@@ -33,7 +35,7 @@ impl CBORCommand for GetAssertionRequest {
 /// Reference: <https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorgetassertion-response-structure>
 // Note: this needs to have the same names as AttestationObjectInner
 #[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase", try_from = "BTreeMap<u32, Value>")]
+#[serde(rename_all = "camelCase")]
 pub struct GetAssertionResponse {
     pub credential: Option<PublicKeyCredentialDescriptor>,
     pub auth_data: Option<Vec<u8>>,
@@ -120,6 +122,111 @@ impl From<GetAssertionRequest> for BTreeMap<u32, Value> {
     }
 }
 
+impl TryFrom<BTreeMap<u32, Value>> for GetAssertionRequest {
+    type Error = &'static str;
+    fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
+        trace!("raw: {:?}", raw);
+        Ok(Self {
+            rp_id: raw
+                .remove(&0x01)
+                .and_then(|v| value_to_string(v, "0x01"))
+                .ok_or("parsing rpId")?,
+            client_data_hash: raw
+                .remove(&0x02)
+                .and_then(|v| value_to_vec_u8(v, "0x02"))
+                .ok_or("parsing clientDataHash")?,
+            allow_list: raw
+                .remove(&0x03)
+                .and_then(|v| value_to_vec(v, "0x03"))
+                .map(|v| {
+                    v.into_iter()
+                        .filter_map(|a| {
+                            let mut a = value_to_map(a, "0x03")?;
+                            let type_ = value_to_string(
+                                a.remove(&Value::Text("type".to_string()))?,
+                                "type",
+                            )?;
+                            let id = Base64UrlSafeData(value_to_vec_u8(
+                                a.remove(&Value::Text("id".to_string()))?,
+                                "id",
+                            )?);
+                            let transports = a
+                                .remove(&Value::Text("transports".to_string()))
+                                .and_then(|v| value_to_vec_string(v, "transports"))
+                                .map(|v| {
+                                    v.into_iter()
+                                        .filter_map(|t| AuthenticatorTransport::from_str(&t).ok())
+                                        .collect()
+                                });
+                            Some(AllowCredentials {
+                                id,
+                                type_,
+                                transports,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            // TODO
+            options: None,
+            pin_uv_auth_param: None,
+            pin_uv_auth_proto: None,
+        })
+    }
+}
+
+impl From<GetAssertionResponse> for BTreeMap<u32, Value> {
+    fn from(r: GetAssertionResponse) -> Self {
+        let GetAssertionResponse {
+            credential,
+            auth_data,
+            signature,
+            number_of_credentials,
+            user_selected,
+            large_blob_key,
+        } = r;
+
+        let mut keys = BTreeMap::new();
+        if let Some(credential) = credential {
+            let mut m = BTreeMap::from([
+                (Value::Text("id".to_string()), Value::Bytes(credential.id.0)),
+                (
+                    Value::Text("type".to_string()),
+                    Value::Text(credential.type_),
+                ),
+            ]);
+            if let Some(transports) = credential.transports {
+                let transports = transports
+                    .into_iter()
+                    .map(|t| Value::Text(t.to_string()))
+                    .collect();
+                m.insert(
+                    Value::Text("transports".to_string()),
+                    Value::Array(transports),
+                );
+            };
+            keys.insert(0x01, Value::Map(m));
+        }
+        if let Some(auth_data) = auth_data {
+            keys.insert(0x02, Value::Bytes(auth_data));
+        }
+        if let Some(signature) = signature {
+            keys.insert(0x03, Value::Bytes(signature));
+        }
+        if let Some(number_of_credentials) = number_of_credentials {
+            keys.insert(0x05, Value::Integer(number_of_credentials.into()));
+        }
+        if let Some(user_selected) = user_selected {
+            keys.insert(0x06, Value::Bool(user_selected));
+        }
+        if let Some(large_blob_key) = large_blob_key {
+            keys.insert(0x07, Value::Bytes(large_blob_key));
+        }
+
+        keys
+    }
+}
+
 impl TryFrom<BTreeMap<u32, Value>> for GetAssertionResponse {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
@@ -164,6 +271,7 @@ impl TryFrom<BTreeMap<u32, Value>> for GetAssertionResponse {
     }
 }
 
+crate::deserialize_cbor!(GetAssertionRequest);
 crate::deserialize_cbor!(GetAssertionResponse);
 
 #[cfg(test)]

--- a/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
@@ -51,63 +51,61 @@ pub trait CBORCommand: Serialize + Sized + std::fmt::Debug + Send {
     /// Converts a CTAP v2 command into a binary form.
     fn cbor(&self) -> Result<Vec<u8>, serde_cbor::Error> {
         // CTAP v2.1, s8.2.9.1.2 (USB CTAPHID_CBOR), s8.3.5 (NFC framing).
+        // Similar form used for caBLE.
         // TODO: BLE is different, it includes a u16 length after the command?
         if !Self::HAS_PAYLOAD {
             return Ok(vec![Self::CMD]);
         }
 
-        // Canonical example returns 0x33 (PIN error)
         trace!("Sending: {:?}", self);
-        let b = /* if Self::CMD == 1 {
-            vec![168, 1, 88, 32, 104, 113, 52, 150, 130, 34, 236, 23, 32, 46, 66, 80, 95, 142, 210, 177, 106, 226, 47, 22, 187, 5, 184, 140, 37, 219, 158, 96, 38, 69, 241, 65, 2, 162, 98, 105, 100, 105, 116, 101, 115, 116, 46, 99, 116, 97, 112, 100, 110, 97, 109, 101, 105, 116, 101, 115, 116, 46, 99, 116, 97, 112, 3, 163, 98, 105, 100, 88, 32, 43, 102, 137, 187, 24, 244, 22, 159, 6, 159, 188, 223, 80, 203, 110, 163, 198, 10, 134, 27, 154, 123, 99, 148, 105, 131, 224, 181, 119, 183, 140, 112, 100, 110, 97, 109, 101, 113, 116, 101, 115, 116, 99, 116, 97, 112, 64, 99, 116, 97, 112, 46, 99, 111, 109, 107, 100, 105, 115, 112, 108, 97, 121, 78, 97, 109, 101, 105, 84, 101, 115, 116, 32, 67, 116, 97, 112, 4, 131, 162, 99, 97, 108, 103, 38, 100, 116, 121, 112, 101, 106, 112, 117, 98, 108, 105, 99, 45, 107, 101, 121, 162, 99, 97, 108, 103, 57, 1, 0, 100, 116, 121, 112, 101, 106, 112, 117, 98, 108, 105, 99, 45, 107, 101, 121, 162, 99, 97, 108, 103, 56, 36, 100, 116, 121, 112, 101, 106, 112, 117, 98, 108, 105, 99, 45, 107, 101, 121, 6, 161, 107, 104, 109, 97, 99, 45, 115, 101, 99, 114, 101, 116, 245, 7, 161, 98, 114, 107, 245, 8, 80, 252, 67, 170, 164, 17, 217, 72, 204, 108, 55, 6, 139, 141, 161, 213, 8, 9, 1]
-        } else */ { to_vec_packed(self)? };
+        let mut b = to_vec_packed(self)?;
         trace!(
-            "CBOR payload: {:?}",
+            "CBOR: cmd={}, cbor={:?}",
+            Self::CMD,
             serde_cbor::from_slice::<'_, serde_cbor::Value>(&b[..])
         );
-        let mut x = Vec::with_capacity(b.len() + 1);
-        x.push(Self::CMD);
-        x.extend_from_slice(&b);
-        Ok(x)
+
+        b.reserve(1);
+        b.insert(0, Self::CMD);
+        Ok(b)
+    }
+}
+
+/// Converts a CTAP v2 command into a form suitable for transmission with
+/// short ISO/IEC 7816-4 APDUs (over NFC).
+pub fn to_short_apdus(cbor: &[u8]) -> Vec<ISO7816RequestAPDU> {
+    let chunks = cbor.chunks(FRAG_MAX).rev();
+    let mut o = Vec::with_capacity(chunks.len());
+    let mut last = true;
+
+    for chunk in chunks {
+        o.insert(
+            0,
+            ISO7816RequestAPDU {
+                cla: if last { 0x80 } else { 0x90 },
+                ins: 0x10,
+                p1: 0x00,
+                p2: 0x00,
+                data: chunk.to_vec(),
+                ne: if last { 256 } else { 0 },
+            },
+        );
+        last = false;
     }
 
-    /// Converts a CTAP v2 command into a form suitable for transmission with
-    /// short ISO/IEC 7816-4 APDUs (over NFC).
-    fn to_short_apdus(&self) -> Result<Vec<ISO7816RequestAPDU>, serde_cbor::Error> {
-        let cbor = self.cbor()?;
-        let chunks = cbor.chunks(FRAG_MAX).rev();
-        let mut o = Vec::with_capacity(chunks.len());
-        let mut last = true;
+    o
+}
 
-        for chunk in chunks {
-            o.insert(
-                0,
-                ISO7816RequestAPDU {
-                    cla: if last { 0x80 } else { 0x90 },
-                    ins: 0x10,
-                    p1: 0x00,
-                    p2: 0x00,
-                    data: chunk.to_vec(),
-                    ne: if last { 256 } else { 0 },
-                },
-            );
-            last = false;
-        }
-
-        Ok(o)
-    }
-
-    /// Converts a CTAP v2 command into a form suitable for transmission with
-    /// extended ISO/IEC 7816-4 APDUs (over NFC).
-    fn to_extended_apdu(&self) -> Result<ISO7816RequestAPDU, serde_cbor::Error> {
-        Ok(ISO7816RequestAPDU {
-            cla: 0x80,
-            ins: 0x10,
-            p1: 0, // 0x80,  // client supports NFCCTAP_GETRESPONSE
-            p2: 0x00,
-            data: self.cbor()?,
-            ne: 65536,
-        })
+/// Converts a CTAP v2 command into a form suitable for transmission with
+/// extended ISO/IEC 7816-4 APDUs (over NFC).
+pub fn to_extended_apdu(cbor: Vec<u8>) -> ISO7816RequestAPDU {
+    ISO7816RequestAPDU {
+        cla: 0x80,
+        ins: 0x10,
+        p1: 0, // 0x80,  // client supports NFCCTAP_GETRESPONSE
+        p2: 0x00,
+        data: cbor,
+        ne: 65536,
     }
 }
 
@@ -145,29 +143,33 @@ fn value_to_set_string(v: Value, loc: &str) -> Option<BTreeSet<String>> {
     }
 }
 
-fn value_to_vec_u32(v: Value, loc: &str) -> Option<Vec<u32>> {
+fn value_to_vec(v: Value, loc: &str) -> Option<Vec<Value>> {
     if let Value::Array(v) = v {
-        let x = v
-            .into_iter()
-            .filter_map(|i| {
-                if let Value::Integer(i) = i {
-                    u32::try_from(i)
-                        .map_err(|_| error!("Invalid value inside {}: {:?}", loc, i))
-                        .ok()
-                } else {
-                    error!("Invalid type for {}: {:?}", loc, i);
-                    None
-                }
-            })
-            .collect();
-        Some(x)
+        Some(v)
     } else {
         error!("Invalid type for {}: {:?}", loc, v);
         None
     }
 }
 
-fn value_to_u32(v: &Value, loc: &str) -> Option<u32> {
+fn value_to_map(v: Value, loc: &str) -> Option<BTreeMap<Value, Value>> {
+    if let Value::Map(v) = v {
+        Some(v)
+    } else {
+        error!("Invalid type for {}: {:?}", loc, v);
+        None
+    }
+}
+
+fn value_to_vec_u32(v: Value, loc: &str) -> Option<Vec<u32>> {
+    value_to_vec(v, loc).map(|v| {
+        v.into_iter()
+            .filter_map(|i| value_to_u32(&i, loc))
+            .collect()
+    })
+}
+
+pub(crate) fn value_to_u32(v: &Value, loc: &str) -> Option<u32> {
     if let Value::Integer(i) = v {
         u32::try_from(*i)
             .map_err(|_| error!("Invalid value inside {}: {:?}", loc, i))
@@ -178,8 +180,8 @@ fn value_to_u32(v: &Value, loc: &str) -> Option<u32> {
     }
 }
 
-/// Converts a [Value::Bool] into [Option<bool>]. Returns `None` for other [Value] types.
-fn value_to_bool(v: &Value, loc: &str) -> Option<bool> {
+/// Converts a [`Value::Bool`] into [`Option<bool>`]. Returns [`Option::None`] for other [`Value`] types.
+pub(crate) fn value_to_bool(v: &Value, loc: &str) -> Option<bool> {
     if let Value::Bool(b) = v {
         Some(*b)
     } else {
@@ -188,8 +190,8 @@ fn value_to_bool(v: &Value, loc: &str) -> Option<bool> {
     }
 }
 
-/// Converts a [Value::Bytes] into [Option<Vec<u8>>]. Returns `None` for other [Value] types.
-fn value_to_vec_u8(v: Value, loc: &str) -> Option<Vec<u8>> {
+/// Converts a [`Value::Bytes`] into [`Option<Vec<u8>>`]. Returns [`Option::None`] for other [`Value`] types.
+pub(crate) fn value_to_vec_u8(v: Value, loc: &str) -> Option<Vec<u8>> {
     if let Value::Bytes(b) = v {
         Some(b)
     } else {
@@ -198,7 +200,7 @@ fn value_to_vec_u8(v: Value, loc: &str) -> Option<Vec<u8>> {
     }
 }
 
-fn value_to_string(v: Value, loc: &str) -> Option<String> {
+pub(crate) fn value_to_string(v: Value, loc: &str) -> Option<String> {
     if let Value::Text(s) = v {
         Some(s)
     } else {
@@ -217,6 +219,16 @@ impl CBORResponse for NoResponse {
     }
 }
 
+fn map_int_keys(m: BTreeMap<Value, Value>) -> Result<BTreeMap<u32, Value>, WebauthnCError> {
+    m.into_iter()
+        .map(|(k, v)| {
+            let k = value_to_u32(&k, "map_int_keys").ok_or(WebauthnCError::Internal)?;
+
+            Ok((k, v))
+        })
+        .collect()
+}
+
 // TODO: switch to #derive
 #[macro_export]
 macro_rules! deserialize_cbor {
@@ -224,13 +236,30 @@ macro_rules! deserialize_cbor {
         impl $crate::ctap2::commands::CBORResponse for $name {
             fn try_from(i: &[u8]) -> Result<Self, $crate::error::WebauthnCError> {
                 if i.is_empty() {
-                    TryFrom::try_from(BTreeMap::new()).map_err(|e| {
+                    TryFrom::try_from(std::collections::BTreeMap::new()).map_err(|e| {
                         error!("Tried to deserialise empty input, got error: {:?}", e);
                         $crate::error::WebauthnCError::Cbor
                     })
                 } else {
-                    serde_cbor::from_slice(&i).map_err(|e| {
+                    // Convert to Value (Value::Map)
+                    let v = serde_cbor::from_slice::<'_, serde_cbor::Value>(&i).map_err(|e| {
                         error!("deserialise: {:?}", e);
+                        $crate::error::WebauthnCError::Cbor
+                    })?;
+
+                    // Extract the BTreeMap
+                    let v = if let serde_cbor::Value::Map(v) = v {
+                        Ok(v)
+                    } else {
+                        error!("deserialise: unexpected CBOR type {:?}", v);
+                        Err($crate::error::WebauthnCError::Cbor)
+                    }?;
+
+                    // Convert BTreeMap<Value, Value> into BTreeMap<u32, Value>
+                    let v = $crate::ctap2::commands::map_int_keys(v)?;
+
+                    TryFrom::try_from(v).map_err(|_| {
+                        error!("deserialising structure");
                         $crate::error::WebauthnCError::Cbor
                     })
                 }

--- a/webauthn-authenticator-rs/src/ctap2/commands/reset.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/reset.rs
@@ -30,28 +30,24 @@ mod tests {
         let short = vec![0x80, 0x10, 0, 0, 1, 0x7, 0];
         let ext = vec![0x80, 0x10, 0, 0, 0, 0, 1, 0x7, 0, 0];
 
-        let a = req.to_short_apdus().unwrap();
+        let a = to_short_apdus(&req.cbor().unwrap());
         assert_eq!(1, a.len());
         assert_eq!(short, a[0].to_bytes(&ISO7816LengthForm::ShortOnly).unwrap());
         assert_eq!(short, a[0].to_bytes(&ISO7816LengthForm::Extended).unwrap());
 
         assert_eq!(
             ext,
-            req.to_extended_apdu()
-                .unwrap()
+            to_extended_apdu(req.cbor().unwrap())
                 .to_bytes(&ISO7816LengthForm::Extended)
                 .unwrap()
         );
         assert_eq!(
             ext,
-            req.to_extended_apdu()
-                .unwrap()
+            to_extended_apdu(req.cbor().unwrap())
                 .to_bytes(&ISO7816LengthForm::ExtendedOnly)
                 .unwrap()
         );
-        assert!(req
-            .to_extended_apdu()
-            .unwrap()
+        assert!(to_extended_apdu(req.cbor().unwrap())
             .to_bytes(&ISO7816LengthForm::ShortOnly)
             .is_err());
     }

--- a/webauthn-authenticator-rs/src/ctap2/commands/selection.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/selection.rs
@@ -30,28 +30,24 @@ mod tests {
         let short = vec![0x80, 0x10, 0, 0, 1, 0xb, 0];
         let ext = vec![0x80, 0x10, 0, 0, 0, 0, 1, 0xb, 0, 0];
 
-        let a = req.to_short_apdus().unwrap();
+        let a = to_short_apdus(&req.cbor().unwrap());
         assert_eq!(1, a.len());
         assert_eq!(short, a[0].to_bytes(&ISO7816LengthForm::ShortOnly).unwrap());
         assert_eq!(short, a[0].to_bytes(&ISO7816LengthForm::Extended).unwrap());
 
         assert_eq!(
             ext,
-            req.to_extended_apdu()
-                .unwrap()
+            to_extended_apdu(req.cbor().unwrap())
                 .to_bytes(&ISO7816LengthForm::Extended)
                 .unwrap()
         );
         assert_eq!(
             ext,
-            req.to_extended_apdu()
-                .unwrap()
+            to_extended_apdu(req.cbor().unwrap())
                 .to_bytes(&ISO7816LengthForm::ExtendedOnly)
                 .unwrap()
         );
-        assert!(req
-            .to_extended_apdu()
-            .unwrap()
+        assert!(to_extended_apdu(req.cbor().unwrap())
             .to_bytes(&ISO7816LengthForm::ShortOnly)
             .is_err());
     }

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -19,6 +19,8 @@ pub enum WebauthnCError {
     InvalidAssertion,
     MessageTooLarge,
     MessageTooShort,
+    /// Message was an unexpected length
+    InvalidMessageLength,
     Cancelled,
     Ctap(CtapError),
     /// The PIN was too short.
@@ -53,6 +55,7 @@ pub enum WebauthnCError {
     Checksum,
     /// The card reported as a PC/SC storage card, rather than a smart card.
     StorageCard,
+    IoError(String),
 }
 
 #[cfg(feature = "nfc")]
@@ -88,6 +91,12 @@ impl From<Error> for WebauthnCError {
 impl From<openssl::error::ErrorStack> for WebauthnCError {
     fn from(v: openssl::error::ErrorStack) -> Self {
         Self::OpenSSL(v.to_string())
+    }
+}
+
+impl From<std::io::Error> for WebauthnCError {
+    fn from(v: std::io::Error) -> Self {
+        Self::IoError(v.to_string())
     }
 }
 
@@ -213,6 +222,62 @@ impl From<u8> for CtapError {
             0x7f => Ctap1Unspecified,
             0xdf => Ctap2LastError,
             e => Unknown(e),
+        }
+    }
+}
+
+impl From<CtapError> for u8 {
+    fn from(e: CtapError) -> Self {
+        use CtapError::*;
+        match e {
+            Ok => 0x00,
+            Ctap1InvalidCommand => 0x01,
+            Ctap1InvalidParameter => 0x02,
+            Ctap1InvalidLength => 0x03,
+            Ctap1InvalidSeq => 0x04,
+            Ctap1Timeout => 0x05,
+            Ctap1ChannelBusy => 0x06,
+            Ctap1LockRequired => 0x0a,
+            Ctap1InvalidChannel => 0x0b,
+            Ctap2CborUnexpectedType => 0x11,
+            Ctap2InvalidCBOR => 0x12,
+            Ctap2MissingParameter => 0x14,
+            Ctap2LimitExceeded => 0x15,
+            Ctap2FingerprintDatabaseFull => 0x17,
+            Ctap2LargeBlobStorageFull => 0x18,
+            Ctap2CredentialExcluded => 0x19,
+            Ctap2Processing => 0x21,
+            Ctap2InvalidCredential => 0x22,
+            Ctap2UserActionPending => 0x23,
+            Ctap2OperationPending => 0x24,
+            Ctap2NoOperations => 0x25,
+            Ctap2UnsupportedAlgorithm => 0x26,
+            Ctap2OperationDenied => 0x27,
+            Ctap2KeyStoreFull => 0x28,
+            Ctap2UnsupportedOption => 0x2b,
+            Ctap2InvalidOption => 0x2c,
+            Ctap2KeepAliveCancel => 0x2d,
+            Ctap2NoCredentials => 0x2e,
+            Ctap2UserActionTimeout => 0x2f,
+            Ctap2NotAllowed => 0x30,
+            Ctap2PinInvalid => 0x31,
+            Ctap2PinBlocked => 0x32,
+            Ctap2PinAuthInvalid => 0x33,
+            Ctap2PinAuthBlocked => 0x34,
+            Ctap2PinNotSet => 0x35,
+            Ctap2PUATRequired => 0x36,
+            Ctap2PinPolicyViolation => 0x37,
+            Ctap2RequestTooLarge => 0x39,
+            Ctap2ActionTimeout => 0x3a,
+            Ctap2UserPresenceRequired => 0x3b,
+            Ctap2UserVerificationBlocked => 0x3c,
+            Ctap2IntegrityFailure => 0x3d,
+            Ctap2InvalidSubcommand => 0x3e,
+            Ctap2UserVerificationInvalid => 0x3f,
+            Ctap2UnauthorizedPermission => 0x40,
+            Ctap1Unspecified => 0x7f,
+            Ctap2LastError => 0xdf,
+            Unknown(e) => e,
         }
     }
 }

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -35,11 +35,14 @@ pub mod prelude {
     };
 }
 
+mod authenticator_hashed;
+mod crypto;
 pub mod ctap2;
 pub mod error;
 pub mod softpasskey;
 pub mod softtoken;
 pub mod transport;
+pub mod types;
 pub mod ui;
 mod util;
 
@@ -54,6 +57,10 @@ pub mod u2fhid;
 
 #[cfg(feature = "win10")]
 pub mod win10;
+
+pub use crate::authenticator_hashed::{
+    perform_auth_with_request, perform_register_with_request, AuthenticatorBackendHashedClientData,
+};
 
 pub struct WebauthnAuthenticator<T>
 where

--- a/webauthn-authenticator-rs/src/softpasskey.rs
+++ b/webauthn-authenticator-rs/src/softpasskey.rs
@@ -1,8 +1,8 @@
+use crate::authenticator_hashed::AuthenticatorBackendHashedClientData;
+use crate::crypto::get_group;
 use crate::error::WebauthnCError;
 use crate::util::compute_sha256;
-use crate::AuthenticatorBackend;
-use crate::Url;
-use openssl::{bn, ec, hash, nid, pkey, rand, sign};
+use openssl::{bn, ec, hash, pkey, rand, sign};
 use serde_cbor::value::Value;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -12,8 +12,8 @@ use base64urlsafedata::Base64UrlSafeData;
 
 use webauthn_rs_proto::{
     AllowCredentials, AuthenticationExtensionsClientOutputs, AuthenticatorAssertionResponseRaw,
-    AuthenticatorAttachment, AuthenticatorAttestationResponseRaw, CollectedClientData,
-    PublicKeyCredential, PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
+    AuthenticatorAttachment, AuthenticatorAttestationResponseRaw, PublicKeyCredential,
+    PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
     RegisterPublicKeyCredential, RegistrationExtensionsClientOutputs, UserVerificationPolicy,
 };
 
@@ -45,10 +45,10 @@ pub struct U2FSignData {
     user_present: u8,
 }
 
-impl AuthenticatorBackend for SoftPasskey {
+impl AuthenticatorBackendHashedClientData for SoftPasskey {
     fn perform_register(
         &mut self,
-        origin: Url,
+        client_data_json_hash: Vec<u8>,
         options: PublicKeyCredentialCreationOptions,
         _timeout_ms: u32,
     ) -> Result<RegisterPublicKeyCredential, WebauthnCError> {
@@ -89,36 +89,6 @@ impl AuthenticatorBackend for SoftPasskey {
             //     Let authenticatorExtensionInput be the (CBOR) result of running extensionId’s client extension processing algorithm on clientExtensionInput. If the algorithm returned an error, continue.
             //     Set authenticatorExtensions[extensionId] to the base64url encoding of authenticatorExtensionInput.
         */
-
-        // Let collectedClientData be a new CollectedClientData instance whose fields are:
-        //    type
-        //        The string "webauthn.create".
-        //    challenge
-        //        The base64url encoding of options.challenge.
-        //    origin
-        //        The serialization of callerOrigin.
-
-        //    Not Supported Yet.
-        //    tokenBinding
-        //        The status of Token Binding between the client and the callerOrigin, as well as the Token Binding ID associated with callerOrigin, if one is available.
-        let collected_client_data = CollectedClientData {
-            type_: "webauthn.create".to_string(),
-            challenge: options.challenge.clone(),
-            origin,
-            token_binding: None,
-            cross_origin: None,
-            unknown_keys: BTreeMap::new(),
-        };
-
-        //  Let clientDataJSON be the JSON-serialized client data constructed from collectedClientData.
-        let client_data_json =
-            serde_json::to_string(&collected_client_data).map_err(|_| WebauthnCError::Json)?;
-
-        // Let clientDataHash be the hash of the serialized client data represented by clientDataJSON.
-        let client_data_json_hash = compute_sha256(client_data_json.as_bytes()).to_vec();
-
-        trace!("client_data_json -> {:x?}", client_data_json);
-        trace!("client_data_json_hash -> {:x?}", client_data_json_hash);
 
         // Not required.
         // If the options.signal is present and its aborted flag is set to true, return a DOMException whose name is "AbortError" and terminate this algorithm.
@@ -232,7 +202,7 @@ impl AuthenticatorBackend for SoftPasskey {
         rand::rand_bytes(key_handle.as_mut_slice())?;
 
         // Create a new key.
-        let ecgroup = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1)?;
+        let ecgroup = get_group()?;
 
         let eckey = ec::EcKey::generate(&ecgroup)?;
 
@@ -384,7 +354,7 @@ impl AuthenticatorBackend for SoftPasskey {
             raw_id: Base64UrlSafeData(key_handle),
             response: AuthenticatorAttestationResponseRaw {
                 attestation_object: Base64UrlSafeData(ao_bytes),
-                client_data_json: Base64UrlSafeData(client_data_json.as_bytes().to_vec()),
+                client_data_json: Base64UrlSafeData(vec![]),
                 transports: None,
             },
             type_: "public-key".to_string(),
@@ -397,7 +367,7 @@ impl AuthenticatorBackend for SoftPasskey {
 
     fn perform_auth(
         &mut self,
-        origin: Url,
+        client_data_json_hash: Vec<u8>,
         options: PublicKeyCredentialRequestOptions,
         timeout_ms: u32,
     ) -> Result<PublicKeyCredential, WebauthnCError> {
@@ -405,26 +375,6 @@ impl AuthenticatorBackend for SoftPasskey {
 
         // If the extensions member of options is present, then for each extensionId → clientExtensionInput of options.extensions:
         // ...
-
-        // Let collectedClientData be a new CollectedClientData instance whose fields are:
-        let collected_client_data = CollectedClientData {
-            type_: "webauthn.get".to_string(),
-            challenge: options.challenge.clone(),
-            origin,
-            token_binding: None,
-            cross_origin: None,
-            unknown_keys: BTreeMap::new(),
-        };
-
-        // Let clientDataJSON be the JSON-serialized client data constructed from collectedClientData.
-        let client_data_json =
-            serde_json::to_string(&collected_client_data).map_err(|_| WebauthnCError::Json)?;
-
-        // Let clientDataHash be the hash of the serialized client data represented by clientDataJSON.
-        let client_data_json_hash = compute_sha256(client_data_json.as_bytes()).to_vec();
-
-        trace!("client_data_json -> {:x?}", client_data_json);
-        trace!("client_data_json_hash -> {:x?}", client_data_json_hash);
 
         // This is where we deviate from the spec, since we aren't a browser.
 
@@ -462,7 +412,7 @@ impl AuthenticatorBackend for SoftPasskey {
             raw_id: Base64UrlSafeData(u2sd.key_handle.clone()),
             response: AuthenticatorAssertionResponseRaw {
                 authenticator_data: Base64UrlSafeData(authdata),
-                client_data_json: Base64UrlSafeData(client_data_json.as_bytes().to_vec()),
+                client_data_json: Base64UrlSafeData(vec![]),
                 signature: Base64UrlSafeData(u2sd.signature),
                 user_handle: None,
             },

--- a/webauthn-authenticator-rs/src/transport/any.rs
+++ b/webauthn-authenticator-rs/src/transport/any.rs
@@ -68,9 +68,8 @@ impl<'b> Transport<'b> for AnyTransport {
 #[allow(clippy::unimplemented)]
 impl Token for AnyToken {
     #[allow(unused_variables)]
-    async fn transmit_raw<C, U>(&self, cmd: C, ui: &U) -> Result<Vec<u8>, WebauthnCError>
+    async fn transmit_raw<U>(&mut self, cmd: &[u8], ui: &U) -> Result<Vec<u8>, WebauthnCError>
     where
-        C: CBORCommand,
         U: UiCallback,
     {
         match self {
@@ -92,13 +91,13 @@ impl Token for AnyToken {
         }
     }
 
-    fn close(&self) -> Result<(), WebauthnCError> {
+    async fn close(&mut self) -> Result<(), WebauthnCError> {
         match self {
             AnyToken::Stub => unimplemented!(),
             #[cfg(feature = "nfc")]
-            AnyToken::Nfc(n) => n.close(),
+            AnyToken::Nfc(n) => n.close().await,
             #[cfg(feature = "usb")]
-            AnyToken::Usb(u) => u.close(),
+            AnyToken::Usb(u) => u.close().await,
         }
     }
 

--- a/webauthn-authenticator-rs/src/types.rs
+++ b/webauthn-authenticator-rs/src/types.rs
@@ -1,0 +1,49 @@
+//! Types used in a public API.
+//!
+//! These types need to be present regardless of which features were selected
+//! at build time, because they are part of some other API which doesn't change.
+
+/// caBLE request type.
+#[derive(Debug, PartialEq, Eq, Clone, Default, Copy)]
+pub enum CableRequestType {
+    /// Logging in with an existing credential.
+    #[default]
+    GetAssertion,
+
+    /// Creating a new, non-discoverable credential.
+    MakeCredential,
+
+    /// Creating a new, discoverable credential.
+    DiscoverableMakeCredential,
+}
+
+/// States that a caBLE connection can be in for
+/// [crate::ui::UiCallback::cable_status_update].
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CableState {
+    /// The initiator or authenticator is connecting to the tunnel server.
+    ConnectingToTunnelServer,
+
+    /// The authenticator is waiting for the initiator to connect to the tunnel
+    /// server, and send a challenge.
+    WaitingForInitiatorConnection,
+
+    /// The initiator or authenticator is establishing an encrypted channel.
+    Handshaking,
+
+    /// The authenticator is waiting for the initiator to respond.
+    WaitingForInitiatorResponse,
+
+    /// The authenticator is waiting for a command from the initiator.
+    WaitingForInitiatorCommand,
+
+    /// The initiator or authenticator is processing what it received from the
+    /// other side.
+    Processing,
+
+    /// The initiator has sent a message to the authenticator, and waiting for
+    /// a response. This may be that the device is waiting for some sort of
+    /// user verification action (like entering PIN or biometrics) to complete
+    /// the operation.
+    WaitingForAuthenticatorResponse,
+}

--- a/webauthn-authenticator-rs/src/usb/responses.rs
+++ b/webauthn-authenticator-rs/src/usb/responses.rs
@@ -197,6 +197,7 @@ impl TryFrom<&U2FHIDFrame> for Response {
 mod tests {
     use super::*;
     use crate::ctap2::commands::GetInfoResponse;
+    use crate::ctap2::CBORResponse;
 
     #[test]
     fn init() {

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -15,6 +15,17 @@ pub fn compute_sha256(data: &[u8]) -> [u8; 32] {
 }
 
 pub fn creation_to_clientdata(origin: Url, challenge: Base64UrlSafeData) -> CollectedClientData {
+    // Let collectedClientData be a new CollectedClientData instance whose fields are:
+    //    type
+    //        The string "webauthn.create".
+    //    challenge
+    //        The base64url encoding of options.challenge.
+    //    origin
+    //        The serialization of callerOrigin.
+
+    //    Not Supported Yet.
+    //    tokenBinding
+    //        The status of Token Binding between the client and the callerOrigin, as well as the Token Binding ID associated with callerOrigin, if one is available.
     CollectedClientData {
         type_: "webauthn.create".to_string(),
         challenge,

--- a/webauthn-rs-core/src/crypto.rs
+++ b/webauthn-rs-core/src/crypto.rs
@@ -767,7 +767,8 @@ impl COSEKey {
         }
     }
 
-    pub(crate) fn verify_signature(
+    /// Verifies data was signed with this [COSEKey].
+    pub fn verify_signature(
         &self,
         signature: &[u8],
         verification_data: &[u8],


### PR DESCRIPTION
This adds functionality, changes APIs and refactors `webauthn-authenticator-rs` in ways that's necessary (or useful) for caBLE support (#232), without _actually adding_ support for caBLE itself.

* `AuthenticatorBackendHashedClientData`: new trait for `AuthenticatorBackends` which accepts `client_data_hash` directly. This de-duplicates the `client_data_json` handling, and allows the library to proxy requests from a caBLE initiator.
* `perform_register_with_request`, `perform_auth_with_request`: Accepts `MakeCredentialRequest` and `GetAssertionRequest` commands directly, mapping them onto `AuthenticatorBackendHashedClientData`.  This allows it to act as a caBLE authenticator, while _also_ handling PIN/UV auth internally when proxying to physical authenticators (as browsers don't attempt it!)
* crypto: new module for common cryptographic operations, shared between caBLE and CTAP2 implementation.
* CTAP2:
  * implement `AuthenticatorBackendHashedClientData` instead of `AuthenticatorBackend`
  * adds serialisation for `Map<u32, String>` to `GetAssertionResponse` and `MakeCredentialResponse` and from `GetAssertionRequest` and `MakeCredentialRequest` for `perform_*_with_request`.
  * allow for both `Map<String, String>` and `Map<u32, String>` representations of `CBORRequest` and `CBORResponse` for `perform_*_with_request`.
  * add `GetInfoResponse` serialisation
  * make `to_short_apdus` and `to_long_apdu` stand-alone methods
  * `Token` is now mutable, and `Token::close` is now async
  * use short APDUs for selecting FIDO2 applet over NFC, because Feitian tokens don't support extended APDUs (in violation of the FIDO specification!)
* SoftPasskey:
  * implement `AuthenticatorBackendHashedClientData` instead of `AuthenticatorBackend`
* SoftToken: 
  * implement `AuthenticatorBackendHashedClientData` instead of `AuthenticatorBackend`
  * add support for persisting the SoftToken (as `SoftTokenFile`)
  * add `examples/softtoken` for creating a persisted `SoftToken`
* ui: Add methods for caBLE (displaying QR codes and reporting status)
* `examples/authenticate`:
  * refactor to use command line arguments, rather than interactive text UI
  * re-open the connection to the key after every operation (needed for Feitian NFC keys, and also caBLE)
* clean up some dead/commented code that was from testing earlier features
* fix some documentation formatting errors

Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
