### PR TITLE
require at least openssl 0.10.41 for set_affine_coordinates_gfp

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -32,7 +32,7 @@ uuid = "1"
 serde_json = "1.0"
 nom = "7.1"
 serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
-openssl = "0.10"
+openssl = "0.10.41"
 rpassword = "5.0"
 
 # authenticator = { path = "../../../authenticator-rs", optional = true, default-features = false, features = ["crypto_openssl"], package = "authenticator-ctap2-2021" }

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -23,7 +23,7 @@ nom = "7.1"
 base64 = "0.13"
 thiserror = "1.0"
 tracing = "0.1"
-openssl = { version = "0.10" }
+openssl = "0.10.41"
 # We could consider replacing this with openssl rand.
 rand = { version = "0.8" }
 url = { version = "2", features = ["serde"] }


### PR DESCRIPTION
Issue reported by @devsnek on chat: https://gc.gy/140956042.png

Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
