### PR TITLE
Document feature flags

### DIFF
--- a/.github/check_built_docs.sh
+++ b/.github/check_built_docs.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Checks that documentation artefacts are present.
+#
+# This ensures that the library's documentation was buildable and included all
+# features, regardless of which features were actually enabled.
+
+set -e
+readonly MANIFEST="$(dirname $0)/doc_manifest"
+readonly TARGET_DIR="$(dirname $0)/../target/doc/"
+c=0
+m=0
+
+if [[ ! -d "${TARGET_DIR}" ]]
+then
+    echo "Target directory ${TARGET_DIR} does not exist!"
+    exit 1
+fi
+
+echo "Checking for missing files:"
+while read -r f
+do
+    # Ignore empty lines and comments
+    if [[ -z "$f" || "${f:0:1}" == "#" ]]
+    then
+        continue
+    fi
+
+    c=$((c+1))
+    # File must exist and be > 0 bytes
+    if [[ ! -s "${TARGET_DIR}/${f}" ]]
+    then
+        # Missing file
+        echo "$f"
+        m=$((m+1))
+    fi
+done < "${MANIFEST}"
+
+if [[ "$c" == "0" ]]
+then
+    echo "No files listed in ${MANIFEST} to check!"
+    exit 1
+fi
+
+if [[ "$m" == "0" ]]
+then
+    echo "All ${c} files present."
+else
+    echo "${m} of ${c} files missing!"
+    exit 1
+fi

--- a/.github/doc_manifest
+++ b/.github/doc_manifest
@@ -1,0 +1,21 @@
+# Manifest for check_built_docs.sh
+# Paths are relative to target/doc/
+
+authenticator_cli/index.html
+base64urlsafedata/index.html
+fido_mds/index.html
+fido_mds_tool/index.html
+
+webauthn_authenticator_rs/index.html
+webauthn_authenticator_rs/cable/index.html
+webauthn_authenticator_rs/nfc/index.html
+webauthn_authenticator_rs/usb/index.html
+webauthn_authenticator_rs/u2fhid/index.html
+webauthn_authenticator_rs/win10/index.html
+
+webauthn_rs/index.html
+webauthn_rs/interface/index.html
+
+webauthn_rs_core/index.html
+webauthn_rs_demo/index.html
+webauthn_rs_proto/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,51 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets ${{ matrix.features }}
       - run: cargo test --all ${{ matrix.features }}
+
+  docs:
+    name: Documentation
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_version: [stable, nightly]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_version }}
+      - run: |
+          sudo apt-get update && \
+          sudo apt-get -y install libudev-dev
+
+      # Build documentation with zero dependencies / features
+      #
+      # This tests that all the stubs work properly for optional dependencies
+      - run: cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs-${{ matrix.rust_version }}
+          path: |
+            target/doc/
+            !target/doc/src/
+          if-no-files-found: error
+          retention-days: 14
+      - run: ./.github/check_built_docs.sh
+
+      # Build with all features
+      - run: |
+          sudo apt-get -y install libpcsclite-dev libusb-1.0-0-dev libdbus-1-dev
+      - run: cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all --no-deps --document-private-items --all-features
+        env:
+          RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs-${{ matrix.rust_version }}-all_features
+          path: |
+            target/doc/
+            !target/doc/src/
+          if-no-files-found: error
+          retention-days: 14
+      - run: ./.github/check_built_docs.sh

--- a/compat_tester/webauthn-rs-demo-shared/src/lib.rs
+++ b/compat_tester/webauthn-rs-demo-shared/src/lib.rs
@@ -594,7 +594,7 @@ impl From<WebauthnError> for ResponseError {
             }
             WebauthnError::CredentialCrossOrigin => Self::CredentialCrossOrigin,
             #[allow(unreachable_patterns)]
-            _ => Self::UnknownError(format!("{:?}", value)),
+            _ => Self::UnknownError(format!("{value:?}")),
             // WebauthnError::OpenSSLError(_)                                                                                =>      Self::OpenSSLError,
         }
     }

--- a/fido-mds-tool/src/main.rs
+++ b/fido-mds-tool/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
         match EnvFilter::try_new("fido-mds=debug,fido-mds-tool=debug") {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("ERROR! Unable to start tracing {:?}", e);
+                eprintln!("ERROR! Unable to start tracing {e:?}");
                 return;
             }
         }
@@ -118,7 +118,7 @@ fn main() {
                 Ok(mds) => {
                     debug!("{} fido metadata avaliable", mds.u2f.len());
                     for fd in mds.u2f.values() {
-                        eprintln!("{}", fd);
+                        eprintln!("{fd}");
                     }
                 }
                 Err(e) => {
@@ -144,11 +144,11 @@ fn main() {
                 Ok(mds) => {
                     debug!("{} fido metadata avaliable", mds.fido2.len());
                     for fd in mds.fido2_description.values() {
-                        eprintln!("{}", fd);
+                        eprintln!("{fd}");
                         if extra_details {
                             println!("  authentication_algorithms:");
                             for alg in fd.authentication_algorithms.iter() {
-                                println!("    * {}", alg);
+                                println!("    * {alg}");
                             }
 
                             println!("  user_verification_details:");
@@ -160,7 +160,7 @@ fn main() {
                                         print!(" AND");
                                     }
                                     first = false;
-                                    print!(" {}", uvm_and);
+                                    print!(" {uvm_and}");
                                 }
                                 println!();
                             }
@@ -206,11 +206,11 @@ fn main() {
                                 println!("authenticator_version: {}", fd.authenticator_version);
                                 println!("authentication_algorithms:");
                                 for alg in fd.authentication_algorithms.iter() {
-                                    println!("  {:?}", alg);
+                                    println!("  {alg:?}");
                                 }
                                 println!("public_key_alg_and_encodings: ");
                                 for alg in fd.public_key_alg_and_encodings.iter() {
-                                    println!("  {:?}", alg);
+                                    println!("  {alg:?}");
                                 }
 
                                 println!("user_verification_details:");
@@ -218,12 +218,12 @@ fn main() {
                                     println!("-- OR");
                                     for uvm_and in uvm_or.iter() {
                                         println!("  AND");
-                                        println!("  {}", uvm_and);
+                                        println!("  {uvm_and}");
                                     }
                                 }
                                 println!("key_protection:");
                                 for kp in fd.key_protection.iter() {
-                                    println!("  {:?}", kp);
+                                    println!("  {kp:?}");
                                 }
                                 println!("is_key_restricted: {}", fd.is_key_restricted);
                                 println!(
@@ -244,14 +244,14 @@ fn main() {
                                 }
 
                                 if let Some(authenticator_info) = &fd.authenticator_get_info {
-                                    println!("authenticator_get_info: {:?}", authenticator_info);
+                                    println!("authenticator_get_info: {authenticator_info:?}");
                                 } else {
                                     println!("authenticator_get_info: not present")
                                 }
 
                                 println!("status_reports:");
                                 for sr in fd.status_reports.iter() {
-                                    println!("  {:?}", sr);
+                                    println!("  {sr:?}");
                                 }
 
                                 println!();

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -890,7 +890,7 @@ pub struct FidoDevice {
 impl fmt::Display for FidoDevice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = serde_json::to_string_pretty(self).map_err(|_| fmt::Error)?;
-        write!(f, "FidoDevice {}", s)
+        write!(f, "FidoDevice {s}")
     }
 }
 

--- a/tutorial/server/axum/src/main.rs
+++ b/tutorial/server/axum/src/main.rs
@@ -67,7 +67,7 @@ async fn main() {
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
-    println!("listening on {}", addr);
+    println!("listening on {addr}");
     tracing::debug!("listening on {}", addr);
     axum::Server::bind(&addr)
         .serve(app.into_make_service())

--- a/tutorial/server/axum/src/main.rs
+++ b/tutorial/server/axum/src/main.rs
@@ -20,7 +20,7 @@ extern crate tracing;
 mod auth;
 mod startup;
 
-#[cfg(all(feature = "javascript", feature = "wasm"))]
+#[cfg(all(feature = "javascript", feature = "wasm", not(doc)))]
 compile_error!("Feature \"javascript\" and feature \"wasm\" cannot be enabled at the same time");
 
 // 7. That's it! The user has now authenticated!

--- a/tutorial/wasm/src/lib.rs
+++ b/tutorial/wasm/src/lib.rs
@@ -88,7 +88,7 @@ impl App {
         opts.method("POST");
         opts.mode(RequestMode::SameOrigin);
 
-        let dest = format!("/register_start/{}", username);
+        let dest = format!("/register_start/{username}");
         let request = Request::new_with_str_and_init(&dest, &opts)?;
 
         request
@@ -151,8 +151,8 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    console::log!(format!("error -> {:?}", e).as_str());
-                    AppMsg::Error(format!("{:?}", e))
+                    console::log!(format!("error -> {e:?}").as_str());
+                    AppMsg::Error(format!("{e:?}"))
                 }
             }
         });
@@ -162,7 +162,7 @@ impl App {
     // 5. We have the public key, which we now submit to the server. When complete
     // it will issue us a 200 ok, and this will trigger the re-render of the page.
     async fn register_complete(rpkc: RegisterPublicKeyCredential) -> Result<AppMsg, FetchError> {
-        console::log!(format!("rpkc -> {:?}", rpkc).as_str());
+        console::log!(format!("rpkc -> {rpkc:?}").as_str());
 
         let req_jsvalue = serde_json::to_string(&rpkc)
             .map(|s| JsValue::from(&s))
@@ -244,7 +244,7 @@ impl App {
         opts.method("POST");
         opts.mode(RequestMode::SameOrigin);
 
-        let dest = format!("/login_start/{}", username);
+        let dest = format!("/login_start/{username}");
         let request = Request::new_with_str_and_init(&dest, &opts)?;
 
         request
@@ -300,8 +300,8 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    console::log!(format!("error -> {:?}", e).as_str());
-                    AppMsg::Error(format!("{:?}", e))
+                    console::log!(format!("error -> {e:?}").as_str());
+                    AppMsg::Error(format!("{e:?}"))
                 }
             }
         });
@@ -311,7 +311,7 @@ impl App {
     // 9. Submit the signed result to the server. If it was correct we will get
     // 200 ok.
     async fn authenticate_complete(pkc: PublicKeyCredential) -> Result<AppMsg, FetchError> {
-        console::log!(format!("pkc -> {:?}", pkc).as_str());
+        console::log!(format!("pkc -> {pkc:?}").as_str());
 
         let req_jsvalue = serde_json::to_string(&pkc)
             .map(|s| JsValue::from(&s))
@@ -443,7 +443,7 @@ impl Component for App {
                 AppState::Error(msg)
             }
             (s, m) => {
-                let msg = format!("Invalid State Transition -> {:?}, {:?}", s, m);
+                let msg = format!("Invalid State Transition -> {s:?}, {m:?}");
                 console::log!(msg.as_str());
                 AppState::Error(msg)
             }

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -25,6 +25,7 @@ default = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }

--- a/webauthn-authenticator-rs/README.md
+++ b/webauthn-authenticator-rs/README.md
@@ -1,19 +1,54 @@
 
-Webauthn-authenticator-rs
-=========================
+# webauthn-authenticator-rs
 
-Webauthn is a modern approach to hardware based authentication, consisting of
+WebAuthn is a modern approach to hardware based authentication, consisting of
 a user with an authenticator device, a browser or client that interacts with the
 device, and a server that is able to generate challenges and verify the
-authenticators validity.
+authenticator's validity.
 
 This library is the client half of the authenticator process, performing the
-steps that would normally be taken by a webbrowser. Given a challenge from
-a webauthn server, this library can contact a CTAP2 device and transform the
-response to a webauthn registration and authentication.
+steps that would normally be taken by a web browser. Given a challenge from
+a Webauthn server, this library can interface with a CTAP2 device and transform
+the response to a Webauthn registration or assertion (authentication).
 
-In addition for testing your applications this library provides a soft-token
-implementation which allows you to test your webauthn integrations inside unit
-tests, including the ability to verify attestations.
+## Development
 
+### Building docs
 
+This library contains extensive documentation in `rustdoc` format. You can build
+this with:
+
+```sh
+cargo doc --no-deps --document-private-items
+```
+
+This library includes many references to _module-private_ items to explain how
+protocols work, so we use `--document-private-items`.
+
+By default, this won't add any features, so you'll want to add them with
+`--features ...`, or use `--all-features` (which pulls in many dependencies).
+
+To build all docs in a way that
+[annotates which modules and functions are avaliable with which features][doc_cfg]:
+
+1.  Install [Rust nightly][]:
+
+    ```sh
+    rustup toolchain install nightly
+    ```
+
+2.  Build the documentation with:
+
+    ```sh
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --document-private-items
+    ```
+
+    Or with PowerShell (Windows):
+
+    ```ps1
+    $Env:RUSTDOCFLAGS = "--cfg docsrs"
+    cargo +nightly doc --no-deps --document-private-items
+    ```
+
+[Rust nightly]: https://doc.rust-lang.org/book/appendix-07-nightly-rust.html
+[doc_cfg]: https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html

--- a/webauthn-authenticator-rs/build.rs
+++ b/webauthn-authenticator-rs/build.rs
@@ -47,11 +47,11 @@ Please upgrade to OpenSSL v3.0.0 or later.
         match r {
             Ok(actual) => {
                 println!("Diagnostic: Result mismatched.");
-                println!("Expected: {:02x?}", expected);
-                println!("Actual  : {:02x?}", actual);
+                println!("Expected: {expected:02x?}");
+                println!("Actual  : {actual:02x?}");
             }
             Err(e) => {
-                println!("Diagnostic: OpenSSL error: {:?}", e);
+                println!("Diagnostic: OpenSSL error: {e:?}");
             }
         }
         println!();

--- a/webauthn-authenticator-rs/examples/authenticate/main.rs
+++ b/webauthn-authenticator-rs/examples/authenticate/main.rs
@@ -7,7 +7,9 @@ use std::io::{stdin, stdout, Write};
 use clap::{Args, Parser, Subcommand};
 use futures::executor::block_on;
 use webauthn_authenticator_rs::ctap2::CtapAuthenticator;
-use webauthn_authenticator_rs::prelude::{Url, WebauthnCError};
+use webauthn_authenticator_rs::prelude::Url;
+#[cfg(feature = "cable")]
+use webauthn_authenticator_rs::prelude::WebauthnCError;
 use webauthn_authenticator_rs::softtoken::{SoftToken, SoftTokenFile};
 use webauthn_authenticator_rs::transport::*;
 use webauthn_authenticator_rs::types::CableRequestType;
@@ -38,7 +40,7 @@ fn select_transport<'a, U: UiCallback>(ui: &'a U) -> impl AuthenticatorBackend +
                 }
             }
         }
-        Err(e) => panic!("Error: {:?}", e),
+        Err(e) => panic!("Error: {e:?}"),
     }
 
     panic!("No tokens available!");

--- a/webauthn-authenticator-rs/examples/key_manager/main.rs
+++ b/webauthn-authenticator-rs/examples/key_manager/main.rs
@@ -113,7 +113,7 @@ pub struct CliParser {
 }
 
 pub fn base16_encode<T: IntoIterator<Item = u8>>(i: T) -> String {
-    i.into_iter().map(|c| format!("{:02X}", c)).collect()
+    i.into_iter().map(|c| format!("{c:02X}")).collect()
 }
 
 pub fn base16_decode(s: &str) -> Option<Vec<u8>> {
@@ -148,7 +148,7 @@ fn main() {
     match opt.commands {
         Opt::Selection => {
             let token = block_on(select_one_token(tokens.iter_mut()));
-            println!("selected token: {:?}", token);
+            println!("selected token: {token:?}");
         }
 
         Opt::Info => {
@@ -168,7 +168,7 @@ fn main() {
             if buf == "yes" {
                 block_on(authenticator.factory_reset()).expect("Error resetting token");
             } else {
-                panic!("Unexpected response {:?}, exiting!", buf);
+                panic!("Unexpected response {buf:?}, exiting!");
             }
         }
 
@@ -187,7 +187,7 @@ fn main() {
             for token in &mut tokens {
                 if let CtapAuthenticator::Fido21(t) = token {
                     let i = block_on(t.get_fingerprint_sensor_info());
-                    println!("Fingerprint sensor info: {:?}", i);
+                    println!("Fingerprint sensor info: {i:?}");
                 } else {
                     println!("Authenticator does not support biometrics")
                 }

--- a/webauthn-authenticator-rs/examples/nfc_token_info/core.rs
+++ b/webauthn-authenticator-rs/examples/nfc_token_info/core.rs
@@ -24,6 +24,6 @@ pub(crate) fn event_loop() {
                 access_card(card);
             }
         }
-        Err(e) => panic!("Error: {:?}", e),
+        Err(e) => panic!("Error: {e:?}"),
     }
 }

--- a/webauthn-authenticator-rs/src/cable/btle.rs
+++ b/webauthn-authenticator-rs/src/cable/btle.rs
@@ -12,10 +12,18 @@
 //! data advertisements, so authenticators using this library will need to
 //! implement the [Advertiser] trait themselves. See `examples/cable_tunnel` for
 //! an example using a serial-connected BTLE HCI controller.
+#[cfg(doc)]
+use crate::stubs::*;
+
+#[cfg(feature = "bluetooth")]
 use btleplug::{
-    api::{bleuuid::uuid_from_u16, Central, CentralEvent, Manager as _, ScanFilter},
+    api::{Central, CentralEvent, Manager as _},
     platform::Manager,
 };
+
+use btleplug::api::{bleuuid::uuid_from_u16, ScanFilter};
+
+#[cfg(feature = "cable")]
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -76,6 +84,7 @@ pub trait Advertiser {
 
 /// Bluetooth Low Energy service data advertisement scanner.
 pub struct Scanner {
+    #[cfg(feature = "bluetooth")]
     manager: Manager,
 }
 

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -1,4 +1,7 @@
 //! Structures for device discovery over BTLE.
+#[cfg(doc)]
+use crate::stubs::*;
+
 use num_traits::ToPrimitive;
 use openssl::{
     ec::EcKey,

--- a/webauthn-authenticator-rs/src/cable/tunnel.rs
+++ b/webauthn-authenticator-rs/src/cable/tunnel.rs
@@ -1,4 +1,6 @@
 //! Tunnel functions
+#[cfg(doc)]
+use crate::stubs::*;
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -12,15 +14,12 @@ use openssl::{
 use serde::Serialize;
 use serde_cbor::{ser::to_vec_packed, Value};
 use tokio::net::TcpStream;
+#[cfg(feature = "cable")]
 use tokio_tungstenite::{
     connect_async,
-    tungstenite::{
-        client::IntoClientRequest,
-        http::{HeaderValue, Uri},
-        Message,
-    },
-    MaybeTlsStream, WebSocketStream,
+    tungstenite::{client::IntoClientRequest, http::HeaderValue, Message},
 };
+use tokio_tungstenite::{tungstenite::http::Uri, MaybeTlsStream, WebSocketStream};
 use webauthn_rs_proto::AuthenticatorTransport;
 
 use crate::{

--- a/webauthn-authenticator-rs/src/crypto.rs
+++ b/webauthn-authenticator-rs/src/crypto.rs
@@ -1,6 +1,6 @@
 //! Common cryptographic routines for FIDO2.
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 use openssl::{
     bn::BigNumContext,
     ec::{EcKeyRef, EcPoint, EcPointRef, PointConversionForm},
@@ -99,7 +99,7 @@ pub fn ecdh(
     Ok(())
 }
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 /// Reads `buf` as a compressed or uncompressed P-256 key.
 pub fn public_key_from_bytes(buf: &[u8]) -> Result<EcKey<Public>, WebauthnCError> {
     let group = get_group()?;
@@ -108,7 +108,7 @@ pub fn public_key_from_bytes(buf: &[u8]) -> Result<EcKey<Public>, WebauthnCError
     Ok(EcKey::from_public_key(&group, &point)?)
 }
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 /// Converts a P-256 `point` into compressed or uncompressed bytes.
 pub fn point_to_bytes(point: &EcPointRef, compressed: bool) -> Result<Vec<u8>, WebauthnCError> {
     let group = get_group()?;
@@ -124,7 +124,7 @@ pub fn point_to_bytes(point: &EcPointRef, compressed: bool) -> Result<Vec<u8>, W
     )?)
 }
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 /// Gets the public key for a private `key`.
 pub fn public_key_from_private(key: &EcKeyRef<Private>) -> Result<EcKey<Public>, WebauthnCError> {
     Ok(EcKey::from_public_key(key.group(), key.public_key())?)

--- a/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
@@ -61,55 +61,55 @@ impl fmt::Display for GetInfoResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "versions: ")?;
         for v in self.versions.iter() {
-            write!(f, "{} ", v)?;
+            write!(f, "{v} ")?;
         }
         writeln!(f)?;
 
         write!(f, "extensions: ")?;
         for e in self.extensions.iter().flatten() {
-            write!(f, "{} ", e)?;
+            write!(f, "{e} ")?;
         }
         writeln!(f)?;
 
         if let Ok(aaguid) = Uuid::from_slice(self.aaguid.as_slice()) {
-            writeln!(f, "aaguid: {}", aaguid)?;
+            writeln!(f, "aaguid: {aaguid}")?;
         } else {
             writeln!(f, "aaguid: INVALID - {:?}", self.aaguid)?;
         }
 
         write!(f, "options: ")?;
         for (o, b) in self.options.iter().flatten() {
-            write!(f, "{}:{} ", o, b)?;
+            write!(f, "{o}:{b} ")?;
         }
         writeln!(f)?;
 
         if let Some(mms) = self.max_msg_size {
-            writeln!(f, "max message size: {}", mms)?;
+            writeln!(f, "max message size: {mms}")?;
         } else {
             writeln!(f, "max message size: N/A")?;
         }
 
         write!(f, "pin_protocols: ")?;
         for e in self.pin_protocols.iter().flatten() {
-            write!(f, "{} ", e)?;
+            write!(f, "{e} ")?;
         }
         writeln!(f)?;
 
         if let Some(mms) = self.max_cred_count_in_list {
-            writeln!(f, "max cred count in list: {}", mms)?;
+            writeln!(f, "max cred count in list: {mms}")?;
         } else {
             writeln!(f, "max cred count in list: N/A")?;
         }
 
         if let Some(mms) = self.max_cred_id_len {
-            writeln!(f, "max cred id len: {}", mms)?;
+            writeln!(f, "max cred id len: {mms}")?;
         } else {
             writeln!(f, "max cred id len: N/A")?;
         }
 
         write!(f, "transports: ")?;
         for e in self.transports.iter().flatten() {
-            write!(f, "{} ", e)?;
+            write!(f, "{e} ")?;
         }
         writeln!(f)?;
 
@@ -117,7 +117,7 @@ impl fmt::Display for GetInfoResponse {
         writeln!(f, "algorithms: {:?}", self.algorithms)?;
 
         if let Some(mms) = self.min_pin_length {
-            writeln!(f, "min pin len: {}", mms)
+            writeln!(f, "min pin len: {mms}")
         } else {
             writeln!(f, "min pin len: N/A")
         }

--- a/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
@@ -180,7 +180,7 @@ pub(crate) fn value_to_u32(v: &Value, loc: &str) -> Option<u32> {
     }
 }
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 pub(crate) fn value_to_u64(v: &Value, loc: &str) -> Option<u64> {
     if let Value::Integer(i) = v {
         u64::try_from(*i)

--- a/webauthn-authenticator-rs/src/ctap2/pin_uv.rs
+++ b/webauthn-authenticator-rs/src/ctap2/pin_uv.rs
@@ -61,7 +61,7 @@ impl PinUvPlatformInterface {
     ) -> Result<Self, WebauthnCError> {
         let public_key = get_public_key(&private_key)?;
         Ok(Self {
-            protocol: Box::new(T::default()),
+            protocol: Box::<T>::default(),
             public_key,
             private_key,
         })

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -1,3 +1,60 @@
+//! webauthn-authenticator-rs is a library for interfacing with FIDO/CTAP 2
+//! tokens.
+//!
+//! This performs the actions that would be taken by a client application (such
+//! as a web browser) to facilitate authentication with a remote service.
+//!
+//! This library aims to provide abstrations over many platform-specific APIs,
+//! so that client applications don't need to worry as much about the finer
+//! details of the protocol.
+//!
+//! **This is a "pre-1.0" library:** it is still under active development, and
+//! the API is not yet stable or final. *Some of the modules have edge cases
+//! which may cause you to get permanently locked out of your authenticator.*
+//!
+//! This library is not FIDO certified, and currently lacks a thorough security
+//! review.
+//!
+//! ## FIDO / CTAP version support
+//!
+//! This library currently only supports CTAP 2.0, 2.1 or 2.1-PRE.
+//!
+//! Authenticators which **only** support CTAP 1.x (U2F) are *unsupported*. This
+//! generally only is an issue for older tokens.
+//!
+//! The authors of this library recommend using [FIDO2 certified][] hardware
+//! authenticators with at least [Autenticator Certification Level 2][cert].
+//! Be cautious when buying, as there are many products on the market which
+//! falsely claim certification, have implementation errors, only support U2F,
+//! or use off-the-shelf microcontrollers which do not protect key material
+//! ([Level 1][cert]).
+//!
+//! ## Features and backends
+//!
+//! **Note:** these links may be broken unless you build the documentation with
+//! the appropriate `--features` flag listed inline.
+//!
+//! * [CTAP 2.0, 2.1 and 2.1-PRE protocol implementation][crate::ctap2]
+//! * [caBLE][] (with `--features cable`)
+//! * [Mozilla Authenticator][] (with `--features u2fhid`)
+//! * [NFC][] via PC/SC API (with `--features nfc`)
+//! * [SoftPasskey][] (for testing)
+//! * [SoftToken][] (for testing)
+//! * [USB HID][] (with `--features usb`)
+//! * [Windows 10][] WebAuthn API (with `--features win10`)
+//!
+//! [FIDO2 certified]: https://fidoalliance.org/fido-certified-showcase/
+//! [cert]: https://fidoalliance.org/certification/authenticator-certification-levels/
+//! [caBLE]: crate::cable
+//! [Mozilla Authenticator]: crate::u2fhid
+//! [NFC]: crate::nfc
+//! [SoftPasskey]: crate::softpasskey
+//! [SoftToken]: crate::softtoken
+//! [USB HID]: crate::usb
+//! [Windows 10]: crate::win10
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // #![deny(warnings)]
 #![warn(unused_extern_crates)]
 // #![warn(missing_docs)]
@@ -46,20 +103,24 @@ pub mod types;
 pub mod ui;
 mod util;
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 pub mod cable;
 
-#[cfg(feature = "nfc")]
+#[cfg(any(doc, feature = "nfc"))]
 pub mod nfc;
 
-#[cfg(feature = "usb")]
+#[cfg(any(doc, feature = "usb"))]
 pub mod usb;
 
-#[cfg(feature = "u2fhid")]
+#[cfg(any(doc, feature = "u2fhid"))]
 pub mod u2fhid;
 
-#[cfg(feature = "win10")]
+#[cfg(any(doc, feature = "win10"))]
 pub mod win10;
+
+#[cfg(doc)]
+#[doc(hidden)]
+mod stubs;
 
 pub use crate::authenticator_hashed::{
     perform_auth_with_request, perform_register_with_request, AuthenticatorBackendHashedClientData,

--- a/webauthn-authenticator-rs/src/nfc/atr.rs
+++ b/webauthn-authenticator-rs/src/nfc/atr.rs
@@ -1,5 +1,6 @@
 //! ISO/IEC 7816-3 _Answer-to-Reset_ and 7816-4 _Historical Bytes_ parser.
-use pcsc::*;
+#[cfg(feature = "nfc")]
+use pcsc::MAX_ATR_SIZE;
 
 use crate::WebauthnCError;
 
@@ -38,7 +39,7 @@ pub struct Atr {
     pub t1: Vec<u8>,
 
     /// If `true`, this is a contactless storage card per
-    /// [PC/SC Specification][pcsc] Part 3, §3.1.3.2.3.2, and Part 3
+    /// [PC/SC Specification][pcsc-spec] Part 3, §3.1.3.2.3.2, and Part 3
     /// Supplemental Document.
     ///
     /// Further clarification is available in the historical bytes

--- a/webauthn-authenticator-rs/src/nfc/mod.rs
+++ b/webauthn-authenticator-rs/src/nfc/mod.rs
@@ -99,10 +99,13 @@ impl NFCReader {
     ///
     /// Example:
     ///
-    /// ```rust
+    /// ```no_run
+    /// # #[cfg(feature = "nfc")]
     /// use pcsc::Scope;
+    /// # #[cfg(feature = "nfc")]
     /// use webauthn_authenticator_rs::nfc::NFCReader;
     ///
+    /// # #[cfg(feature = "nfc")]
     /// let reader = NFCReader::new(Scope::User);
     /// // TODO: Handle errors
     /// ```

--- a/webauthn-authenticator-rs/src/nfc/mod.rs
+++ b/webauthn-authenticator-rs/src/nfc/mod.rs
@@ -1,10 +1,47 @@
-//! [NFCReader] communicates with a FIDO token over NFC, using the [pcsc] API.
+//! [NFCReader] communicates with a FIDO authenticator using the PC/SC API.
+//!
+//! ## Transport
+//!
+//! The CTAP specifications describe an "ISO 7816, ISO 14443 and Near Field
+//! Communication" transport, but PC/SC supports both contact (ISO 7816-3) and
+//! contactless (ISO 14443 and others) smart card interfaces.
+//!
+//! For consistency with other implementations (Windows) and the existing
+//! WebAuthn specification, this library calls them all "NFC", even though
+//! interface entirely operates on an ISO 7816 level. This module should work
+//! with FIDO tokens regardless of physical transport.
+//!
+//! Some tokens (like Yubikey) provide a USB CCID (smart card) interface for
+//! other applets (such as PGP and PIV), but do not typically expose the FIDO
+//! applet over the same interface due to the possibility of websites bypassing
+//! the WebAuthn API on ChromeOS by using WebUSB[^1].
+//!
+//! [^1]: [ChromeOS' PC/SC implementation][2] is pcsclite running in a browser
+//! extension, which accesses USB CCID interfaces via WebUSB. By comparison,
+//! other platforms' PC/SC implementations take exclusive control of USB CCID
+//! devices outside of the browser, preventing access from WebUSB.
+//!
+//! [2]: https://github.com/GoogleChromeLabs/chromeos_smart_card_connector/blob/main/docs/index-developer.md
+//!
+//! ## Windows support
+//!
+//! Windows' WebAuthn API (on Windows 10 build 1903 and later) blocks
+//! non-Administrator access to **all** NFC FIDO tokens, throwing an error
+//! whenever an application attempts to select the FIDO applet, even if it is
+//! not present!
+//!
+//! Use [Win10][crate::win10::Win10] (available with the `win10` feature) on
+//! Windows instead.
 use crate::ctap2::commands::to_short_apdus;
 use crate::error::{CtapError, WebauthnCError};
 use crate::ui::UiCallback;
 
 use async_trait::async_trait;
 use futures::executor::block_on;
+
+#[cfg(doc)]
+use crate::stubs::*;
+
 use pcsc::*;
 use std::ffi::{CStr, CString};
 use std::fmt;

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -17,7 +17,7 @@ use std::iter;
 use std::{collections::BTreeMap, fs::File, io::Read};
 use std::{
     collections::BTreeSet,
-    io::{Seek, SeekFrom, Write},
+    io::{Seek, Write},
 };
 use uuid::Uuid;
 
@@ -783,7 +783,7 @@ impl SoftTokenFile {
         trace!("Saving SoftToken to {:?}", self.file);
         let d = self.token.to_cbor()?;
         self.file.set_len(0)?;
-        self.file.seek(SeekFrom::Start(0))?;
+        self.file.rewind()?;
         self.file.write_all(&d)?;
         self.file.flush()?;
         Ok(())
@@ -998,7 +998,7 @@ mod tests {
         assert!(file.stream_position().unwrap() > 0);
 
         // Rewind and reload
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
 
         let soft_token = SoftTokenFile::open(file).unwrap();
         assert_eq!(soft_token.token.tokens.len(), 1);

--- a/webauthn-authenticator-rs/src/stubs.rs
+++ b/webauthn-authenticator-rs/src/stubs.rs
@@ -31,7 +31,7 @@ pub mod pcsc {
     pub struct ReaderState {}
 }
 
-#[cfg(not(feature = "cable"))]
+#[cfg(not(any(test, doctest, feature = "cable")))]
 pub mod tokio {
     pub mod net {
         pub struct TcpStream {}

--- a/webauthn-authenticator-rs/src/stubs.rs
+++ b/webauthn-authenticator-rs/src/stubs.rs
@@ -1,0 +1,68 @@
+//! Dependency stubs for documentation.
+//!
+//! This allows you to build the documentation for all features without actually
+//! installing all of their depedencies.
+//!
+//! This isn't a complete set of stubs, only the types which are exposed across
+//! method boundaries.
+#[cfg(not(doc))]
+compile_error!("Documentation stubs must only be included with #[cfg(doc)]");
+
+#[cfg(not(feature = "u2fhid"))]
+pub mod authenticator {
+    pub mod authenticatorservice {
+        pub struct AuthenticatorService {}
+    }
+    pub struct StatusUpdate {}
+}
+
+#[cfg(not(feature = "usb"))]
+pub mod hidapi {
+    pub struct HidApi {}
+    pub struct HidDevice {}
+}
+
+#[cfg(not(feature = "nfc"))]
+pub mod pcsc {
+    pub struct Context {}
+    pub enum Scope {}
+    pub struct State {}
+    pub struct Card {}
+    pub struct ReaderState {}
+}
+
+#[cfg(not(feature = "cable"))]
+pub mod tokio {
+    pub mod net {
+        pub struct TcpStream {}
+    }
+    pub mod sync {
+        pub mod mpsc {
+            pub struct Sender<T> {}
+            pub struct Receiver<T> {}
+        }
+    }
+}
+
+#[cfg(not(feature = "cable"))]
+pub mod tokio_tungstenite {
+    pub mod tungstenite {
+        pub mod http {
+            pub struct Uri {}
+        }
+    }
+    pub struct MaybeTlsStream<T> {}
+    pub struct WebSocketStream<T> {}
+}
+
+#[cfg(not(feature = "bluetooth"))]
+pub mod btleplug {
+    pub mod api {
+        pub struct ScanFilter {}
+        pub mod bleuuid {
+            pub const fn uuid_from_u16(_: u16) -> uuid::Uuid {
+                uuid::Uuid::nil()
+            }
+        }
+    }
+}

--- a/webauthn-authenticator-rs/src/transport/any.rs
+++ b/webauthn-authenticator-rs/src/transport/any.rs
@@ -1,8 +1,8 @@
 //! Abstraction to merge all available transports for the platform.
-#[cfg(feature = "nfc")]
+#[cfg(any(doc, feature = "nfc"))]
 use crate::nfc::*;
 use crate::transport::*;
-#[cfg(feature = "usb")]
+#[cfg(any(doc, feature = "usb"))]
 use crate::usb::*;
 
 /// [AnyTransport] merges all available transports for the platform.
@@ -11,9 +11,9 @@ use crate::usb::*;
 /// [AnyTransport] for the best experience.
 #[derive(Debug)]
 pub struct AnyTransport {
-    #[cfg(feature = "nfc")]
+    #[cfg(any(doc, feature = "nfc"))]
     pub nfc: NFCReader,
-    #[cfg(feature = "usb")]
+    #[cfg(any(doc, feature = "usb"))]
     pub usb: USBTransport,
 }
 
@@ -22,9 +22,9 @@ pub struct AnyTransport {
 pub enum AnyToken {
     /// No-op stub entry, never used.
     Stub,
-    #[cfg(feature = "nfc")]
+    #[cfg(any(doc, feature = "nfc"))]
     Nfc(NFCCard),
-    #[cfg(feature = "usb")]
+    #[cfg(any(doc, feature = "usb"))]
     Usb(USBToken),
 }
 

--- a/webauthn-authenticator-rs/src/u2fhid.rs
+++ b/webauthn-authenticator-rs/src/u2fhid.rs
@@ -1,3 +1,7 @@
+//! Authenticator implementation using Mozilla's authenticator-rs library.
+#[cfg(doc)]
+use crate::stubs::*;
+
 use crate::error::WebauthnCError;
 use crate::AuthenticatorBackend;
 use crate::Url;
@@ -14,10 +18,13 @@ use webauthn_rs_proto::{
     AuthenticationExtensionsClientOutputs, AuthenticatorAssertionResponseRaw, PublicKeyCredential,
 };
 
+use authenticator::{authenticatorservice::AuthenticatorService, StatusUpdate};
+
+#[cfg(feature = "u2fhid")]
 use authenticator::{
     authenticatorservice::{
-        AuthenticatorService, CtapVersion, GetAssertionExtensions, GetAssertionOptions,
-        MakeCredentialsExtensions, MakeCredentialsOptions, RegisterArgsCtap2, SignArgsCtap2,
+        CtapVersion, GetAssertionExtensions, GetAssertionOptions, MakeCredentialsExtensions,
+        MakeCredentialsOptions, RegisterArgsCtap2, SignArgsCtap2,
     },
     ctap2::server::{
         PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, Transport, User,
@@ -25,7 +32,7 @@ use authenticator::{
     ctap2::AssertionObject,
     errors::PinError,
     statecallback::StateCallback,
-    COSEAlgorithm, Pin, RegisterResult, SignResult, StatusUpdate,
+    COSEAlgorithm, Pin, RegisterResult, SignResult,
 };
 
 use std::sync::mpsc::{channel, RecvError, Sender};

--- a/webauthn-authenticator-rs/src/ui/mod.rs
+++ b/webauthn-authenticator-rs/src/ui/mod.rs
@@ -65,9 +65,9 @@ impl UiCallback for Cli {
         feedback: Option<EnrollSampleStatus>,
     ) {
         let mut stderr = stderr();
-        writeln!(stderr, "Need {} more sample(s)", remaining_samples).ok();
+        writeln!(stderr, "Need {remaining_samples} more sample(s)").ok();
         if let Some(feedback) = feedback {
-            writeln!(stderr, "Last impression was {:?}", feedback).ok();
+            writeln!(stderr, "Last impression was {feedback:?}").ok();
         }
     }
 
@@ -99,7 +99,7 @@ impl UiCallback for Cli {
         {
             println!("QR code support not available in this build!")
         }
-        println!("{}", url);
+        println!("{url}");
     }
 
     fn dismiss_qr_code(&self) {
@@ -107,6 +107,6 @@ impl UiCallback for Cli {
     }
 
     fn cable_status_update(&self, state: CableState) {
-        println!("caBLE status: {:?}", state);
+        println!("caBLE status: {state:?}");
     }
 }

--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -3,9 +3,14 @@
 //! This module should work on most platforms with USB support, provided that
 //! the user has permissions.
 //!
-//! **Note:** Windows' WebAuthn API (on Windows 10 build 1903 and later) blocks
-//! non-Administrator access to all USB HID FIDO tokens, making them invisible
-//! to normal USB HID APIs.
+//! ## Windows support
+//!
+//! Windows' WebAuthn API (on Windows 10 build 1903 and later) blocks
+//! non-Administrator access to **all** USB HID FIDO tokens, making them
+//! invisible to normal USB HID APIs.
+//!
+//! Use [Win10][crate::win10::Win10] (available with the `win10` feature) on
+//! Windows instead.
 mod framing;
 mod responses;
 
@@ -15,6 +20,10 @@ use crate::ui::UiCallback;
 use crate::usb::framing::*;
 use crate::usb::responses::*;
 use async_trait::async_trait;
+
+#[cfg(doc)]
+use crate::stubs::*;
+
 use hidapi::{HidApi, HidDevice};
 use openssl::rand::rand_bytes;
 use std::fmt;

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -14,7 +14,7 @@ pub fn compute_sha256(data: &[u8]) -> [u8; 32] {
     hasher.finish()
 }
 
-#[cfg(feature = "cable")]
+#[cfg(any(doc, feature = "cable"))]
 /// Computes the SHA256 of `a || b`.
 pub fn compute_sha256_2(a: &[u8], b: &[u8]) -> [u8; 32] {
     let mut hasher = sha::Sha256::new();

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -58,7 +58,7 @@ pub fn get_to_clientdata(origin: Url, challenge: Base64UrlSafeData) -> Collected
 
 /// Normalises the PIN into Unicode Normal Form C, then ensures that the PIN
 /// is at least `min_length` Unicode codepoints, less than 64 bytes when encoded
-/// as UTF-8, and does not contain any null bytes (`\0`).
+/// as UTF-8, and does not contain any null bytes (`\x00`).
 ///
 /// If the PIN is valid, returns the PIN in Unicode Normal Form C.
 pub fn check_pin(pin: &str, min_length: usize) -> Result<String, WebauthnCError> {
@@ -67,7 +67,7 @@ pub fn check_pin(pin: &str, min_length: usize) -> Result<String, WebauthnCError>
     let pin_codepoints = pin.chars().count();
     let pin_bytes = pin.len();
 
-    if pin.contains('\0') {
+    if pin.contains('\x00') {
         Err(WebauthnCError::PinContainsNull)
     } else if pin_codepoints < min_length {
         trace!("PIN too short: {} codepoints", pin_codepoints);
@@ -98,10 +98,10 @@ mod test {
             ("1234", 6, Err(WebauthnCError::PinTooShort)),
             ("123456", 6, Ok("123456".to_string())),
             // PINs cannot contain null
-            ("\0\0\0\0", 4, Err(WebauthnCError::PinContainsNull)),
-            ("1234\0", 4, Err(WebauthnCError::PinContainsNull)),
-            ("\01234", 4, Err(WebauthnCError::PinContainsNull)),
-            ("1234\05678", 4, Err(WebauthnCError::PinContainsNull)),
+            ("\x00\x00\x00\x00", 4, Err(WebauthnCError::PinContainsNull)),
+            ("1234\x00", 4, Err(WebauthnCError::PinContainsNull)),
+            ("\x001234", 4, Err(WebauthnCError::PinContainsNull)),
+            ("1234\x005678", 4, Err(WebauthnCError::PinContainsNull)),
             // Full-width romaji
             // = 3 codepoints, 9 bytes
             ("\u{ff11}\u{ff12}\u{ff13}", 4, Err(WebauthnCError::PinTooShort)),

--- a/webauthn-authenticator-rs/src/win10/credential.rs
+++ b/webauthn-authenticator-rs/src/win10/credential.rs
@@ -56,7 +56,7 @@ pub fn native_to_transports(t: u32) -> Vec<AuthenticatorTransport> {
     o
 }
 
-/// Converts a [Vec<AuthenticatorTransport>] into a value for
+/// Converts a [`Vec<AuthenticatorTransport>`] into a value for
 /// [WEBAUTHN_CREDENTIAL_EX::dwTransports]
 fn transports_to_bitmask(transports: &Option<Vec<AuthenticatorTransport>>) -> u32 {
     match transports {

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -7,16 +7,25 @@
 //! * [MSDN: WebAuthn API](https://learn.microsoft.com/en-us/windows/win32/api/webauthn/)
 //! * [webauthn.h](github.com/microsoft/webauthn) (describes versions)
 //! * [windows-rs API](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WindowsWebServices/index.html)
+#[cfg(feature = "win10")]
 mod clientdata;
+#[cfg(feature = "win10")]
 mod cose;
+#[cfg(feature = "win10")]
 mod credential;
+#[cfg(feature = "win10")]
 mod extensions;
+#[cfg(feature = "win10")]
 mod gui;
+#[cfg(feature = "win10")]
 mod native;
+#[cfg(feature = "win10")]
 mod rp;
+#[cfg(feature = "win10")]
 mod user;
 
 use crate::error::WebauthnCError;
+#[cfg(feature = "win10")]
 use crate::win10::{
     clientdata::{creation_to_clientdata, get_to_clientdata, WinClientData},
     cose::WinCoseCredentialParameters,
@@ -39,6 +48,7 @@ use webauthn_rs_proto::{
     PublicKeyCredentialRequestOptions, RegisterPublicKeyCredential, UserVerificationPolicy,
 };
 
+#[cfg(feature = "win10")]
 use windows::{
     core::{HSTRING, PCWSTR},
     Win32::{Foundation::BOOL, Networking::WindowsWebServices::*},
@@ -329,6 +339,7 @@ impl AuthenticatorBackend for Win10 {
     }
 }
 
+#[cfg(feature = "win10")]
 /// Converts an [AuthenticatorAttachment] into a value for
 /// [WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS::dwAuthenticatorAttachment]
 fn attachment_to_native(attachment: Option<AuthenticatorAttachment>) -> u32 {
@@ -340,6 +351,7 @@ fn attachment_to_native(attachment: Option<AuthenticatorAttachment>) -> u32 {
     }
 }
 
+#[cfg(feature = "win10")]
 /// Converts a [UserVerificationPolicy] into a value for
 /// [WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS::dwUserVerificationRequirement]
 fn user_verification_to_native(policy: Option<&UserVerificationPolicy>) -> u32 {

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -13,6 +13,9 @@ license = "MPL-2.0"
 [features]
 default = []
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 base64urlsafedata = { version = "0.1.2", path = "../base64urlsafedata" }
 webauthn-rs-proto = { version = "0.5.0-dev", path = "../webauthn-rs-proto" }

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -969,11 +969,10 @@ impl WebauthnCore {
     /// On successful authentication, an Ok result is returned. The Ok may contain the CredentialID
     /// and associated counter, which you *should* update for security purposes. If the Ok returns
     /// `None` then the credential does not have a counter.
-    pub fn authenticate_credential<'a>(
+    pub fn authenticate_credential(
         &self,
         rsp: &PublicKeyCredential,
-        state: &'a AuthenticationState,
-        // ) -> Result<(&'a CredentialID, AuthenticatorData<Authentication>), WebauthnError> {
+        state: &AuthenticationState,
     ) -> Result<AuthenticationResult, WebauthnError> {
         // Steps 1 through 4 are client side.
 

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -1343,7 +1343,7 @@ mod tests {
         ];
 
         let tpms_attest = TpmsAttest::try_from(data.as_slice()).unwrap();
-        println!("{:?}", tpms_attest);
+        println!("{tpms_attest:?}");
         assert!(tpms_attest.magic == TPM_GENERATED_VALUE);
     }
 
@@ -1370,7 +1370,7 @@ mod tests {
             39, 252, 9, 69, 223,
         ];
         let tpmt_public = TpmtPublic::try_from(data.as_slice()).unwrap();
-        println!("{:?}", tpmt_public);
+        println!("{tpmt_public:?}");
     }
 
     #[test]
@@ -1393,7 +1393,7 @@ mod tests {
             147, 160, 176, 137, 30, 174, 245, 148, 189,
         ];
         let tpmt_sig = TpmtSignature::try_from(data.as_slice()).unwrap();
-        println!("{:?}", tpmt_sig);
+        println!("{tpmt_sig:?}");
     }
 
     #[test]
@@ -1407,7 +1407,7 @@ mod tests {
         let cred_protect = extensions
             .cred_protect
             .expect("should have cred protect extension");
-        println!("{:?}", cred_protect);
+        println!("{cred_protect:?}");
         assert_eq!(
             cred_protect.0,
             CredentialProtectionPolicy::UserVerificationRequired
@@ -1452,10 +1452,10 @@ mod tests {
 
         let cred: CredentialV3 = serde_json::from_str(legacy_cred).unwrap();
 
-        println!("{:?}", cred);
+        println!("{cred:?}");
 
         let cred_migrated: Credential = cred.into();
 
-        println!("{:?}", cred_migrated);
+        println!("{cred_migrated:?}");
     }
 }

--- a/webauthn-rs-core/src/lib.rs
+++ b/webauthn-rs-core/src/lib.rs
@@ -11,6 +11,8 @@
 //! develop site specific policy and configuration, and the `Webauthn` struct for Webauthn
 //! interactions.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -15,6 +15,9 @@ license = "MPL-2.0"
 [features]
 wasm = ["wasm-bindgen", "web-sys", "js-sys", "serde-wasm-bindgen"]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }
 serde = { version = "1", features = ["derive"] }

--- a/webauthn-rs-proto/src/attest.rs
+++ b/webauthn-rs-proto/src/attest.rs
@@ -194,7 +194,7 @@ impl From<web_sys::PublicKeyCredential> for RegisterPublicKeyCredential {
         let data_response_client_data_json_b64 = Base64UrlSafeData(data_response_client_data_json);
 
         RegisterPublicKeyCredential {
-            id: format!("{}", data_raw_id_b64),
+            id: format!("{data_raw_id_b64}"),
             raw_id: data_raw_id_b64,
             response: AuthenticatorAttestationResponseRaw {
                 attestation_object: data_response_attestation_object_b64,

--- a/webauthn-rs-proto/src/auth.rs
+++ b/webauthn-rs-proto/src/auth.rs
@@ -208,7 +208,7 @@ impl From<web_sys::PublicKeyCredential> for PublicKeyCredential {
         let data_response_user_handle_b64 = data_response_user_handle.map(Base64UrlSafeData);
 
         PublicKeyCredential {
-            id: format!("{}", data_raw_id_b64),
+            id: format!("{data_raw_id_b64}"),
             raw_id: data_raw_id_b64,
             response: AuthenticatorAssertionResponseRaw {
                 authenticator_data: data_response_authenticator_data_b64,

--- a/webauthn-rs-proto/src/lib.rs
+++ b/webauthn-rs-proto/src/lib.rs
@@ -1,6 +1,8 @@
 //! JSON Protocol Structs and representations for communication with authenticators
 //! and clients.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]

--- a/webauthn-rs/Cargo.toml
+++ b/webauthn-rs/Cargo.toml
@@ -12,6 +12,7 @@ license = "MPL-2.0"
 
 [package.metadata.docs.rs]
 features = ["danger-allow-state-serialisation", "danger-user-presence-only-security-keys", "danger-credential-internals"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 resident-key-support = []

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -229,14 +229,14 @@ impl PasswordlessKey {
     }
 }
 
-#[cfg(all(feature = "danger-credential-internals", feature="preview-features"))]
+#[cfg(all(feature = "danger-credential-internals", feature = "preview-features"))]
 impl From<PasswordlessKey> for Credential {
     fn from(pk: PasswordlessKey) -> Self {
         pk.cred
     }
 }
 
-#[cfg(all(feature = "danger-credential-internals", feature="preview-features"))]
+#[cfg(all(feature = "danger-credential-internals", feature = "preview-features"))]
 impl From<Credential> for PasswordlessKey {
     /// Convert a generic webauthn credential into a Passkey
     fn from(cred: Credential) -> Self {

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -229,16 +229,14 @@ impl PasswordlessKey {
     }
 }
 
-#[cfg(feature = "danger-credential-internals")]
-#[cfg(feature = "preview-features")]
+#[cfg(all(feature = "danger-credential-internals", feature="preview-features"))]
 impl From<PasswordlessKey> for Credential {
     fn from(pk: PasswordlessKey) -> Self {
         pk.cred
     }
 }
 
-#[cfg(feature = "danger-credential-internals")]
-#[cfg(feature = "preview-features")]
+#[cfg(all(feature = "danger-credential-internals", feature="preview-features"))]
 impl From<Credential> for PasswordlessKey {
     /// Convert a generic webauthn credential into a Passkey
     fn from(cred: Credential) -> Self {

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -206,7 +206,7 @@ impl<'a> WebauthnBuilder<'a> {
             .map(|effective_domain| {
                 // We need to prepend the '.' here to ensure that myexample.com != example.com,
                 // rather than just ends with.
-                effective_domain.ends_with(&format!(".{}", rp_id)) || effective_domain == rp_id
+                effective_domain.ends_with(&format!(".{rp_id}")) || effective_domain == rp_id
             })
             .unwrap_or(false);
 

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -106,6 +106,8 @@
 //!
 //! If in doubt, do not enable this feature.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]


### PR DESCRIPTION
* Show all features for `webauthn-authenticator-rs` when building documentation
* Include documentation target for CI
* Check that built documentation includes optional features
* Enable `doc_cfg` and `doc_auto_cfg` to show feature flags
* Fix `uninlined_format_args` added in clippy 1.66.0

Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
