### PR TITLE
Fix up user verification with CtapAuthenticator, and minor fixing

### DIFF
--- a/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
@@ -162,6 +162,60 @@ impl GetInfoResponse {
     pub fn supports_ctap21pre_biometrics(&self) -> bool {
         self.get_option("userVerificationMgmtPreview").is_some()
     }
+
+    /// Checks if the authenticator supports and has configured CTAP 2.1
+    /// biometric authentication.
+    ///
+    /// See also [`GetInfoResponse::ctap21pre_biometrics`][] for CTAP 2.1-PRE
+    /// authenticators.
+    ///
+    /// # Returns
+    ///
+    /// * `None`: if not supported.
+    /// * `Some(false)`: if supported, but not configured.
+    /// * `Some(true)`: if supported and configured.
+    pub fn ctap21_biometrics(&self) -> Option<bool> {
+        self.get_option("bioEnroll")
+    }
+
+    /// Checks if the authenticator supports and has configured CTAP 2.1-PRE
+    /// biometric authentication.
+    ///
+    /// See also [`GetInfoResponse::ctap21_biometrics`][] for CTAP 2.1
+    /// authenticators.
+    ///
+    /// # Returns
+    ///
+    /// * `None`: if not supported.
+    /// * `Some(false)`: if supported, but not configured.
+    /// * `Some(true)`: if supported and configured.
+    pub fn ctap21pre_biometrics(&self) -> Option<bool> {
+        self.get_option("userVerificationMgmtPreview")
+    }
+
+    /// Returns `true` if the authenticator supports built-in user verification,
+    /// and it has been configured.
+    pub fn user_verification_configured(&self) -> bool {
+        self.get_option("uv").unwrap_or_default()
+    }
+
+    /// Returns `true` if the authenticator supports CTAP 2.1 authenticator
+    /// configuration commands.
+    pub fn supports_config(&self) -> bool {
+        self.get_option("authnrCfg").unwrap_or_default()
+    }
+
+    /// Returns `true` if the authenticator supports CTAP 2.1 enterprise
+    /// attestation.
+    pub fn supports_enterprise_attestation(&self) -> bool {
+        self.get_option("ep").is_some()
+    }
+
+    /// Returns `true` if user verification is not required for `makeCredential`
+    /// requests.
+    pub fn make_cred_uv_not_required(&self) -> bool {
+        self.get_option("makeCredUvNotRqd").unwrap_or_default()
+    }
 }
 
 impl TryFrom<BTreeMap<u32, Value>> for GetInfoResponse {

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -68,6 +68,10 @@ pub enum WebauthnCError {
     /// The value of the nonce for this object has exceeded the limit.
     NonceOverflow,
     PermissionDenied,
+    /// User verification was required, but is not available for this
+    /// authenticator. You may need to set a PIN, or use a different
+    /// authenticator.
+    UserVerificationRequired,
 }
 
 #[cfg(feature = "nfc")]

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -33,7 +33,7 @@ pub type CredentialID = Base64UrlSafeData;
 /// that is is NOT possible assert verification has been bypassed or not from the server
 /// viewpoint, and to the user it may create confusion about when verification is or is
 /// not required.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
 #[serde(rename_all = "lowercase")]
 pub enum UserVerificationPolicy {
@@ -198,7 +198,7 @@ pub enum AuthenticatorAttachment {
 }
 
 /// <https://www.w3.org/TR/webauthn/#dictdef-authenticatorselectioncriteria>
-#[derive(Debug, Serialize, Clone, Deserialize)]
+#[derive(Debug, Default, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticatorSelectionCriteria {
     /// How the authenticator should be attached to the client machine.


### PR DESCRIPTION
The way that the `CtapAuthenticator` backend does user verification isn't [what the CTAP spec says to do][0], so this fixes things:

* add `verification_policy` flag to `authenticate` example, and plumb that through
* fix built-in user verification on CTAP 2.1-PRE authenticators
* `CtapAuthenticator` now follows [documented guidance][0] and requires user verification even if `userVerificationPolicy = preferred`; so effectively `required == preferred`
* return `UserVerificationRequired` error whenever a key does not meet verification policies

Related fixing:

* invalidate and refresh `GetInfoResponse` when the authenticator PIN is set, or fingerprint enrolments change
* `webauthn-rs-core`: when authenticating, check for consistent policies rather than trying to specifically use `Preferred` for unverified keys

Tested with:

* CTAP 2.1-PRE key with built-in UV and with PIN (works with all)
* CTAP 2.1 key with built-in UV (works with all)
* CTAP 2.0 key with PIN (works with all)
* CTAP 2.1-PRE and CTAP 2.0 keys with no configured UV (now only works with "discouraged", previously worked with "preferred")
* caBLE

I split this change out of #261 because it got complicated; I plan to rebase that PR on this one.

[0]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-makeCred-platf-actions



Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
