### PR TITLE
BTLE authenticator transport

### DIFF
--- a/.github/doc_manifest
+++ b/.github/doc_manifest
@@ -7,6 +7,7 @@ fido_mds/index.html
 fido_mds_tool/index.html
 
 webauthn_authenticator_rs/index.html
+webauthn_authenticator_rs/bluetooth/index.html
 webauthn_authenticator_rs/cable/index.html
 webauthn_authenticator_rs/nfc/index.html
 webauthn_authenticator_rs/usb/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,12 @@ jobs:
         rust_version: [stable, 1.66.0]
         features:
           - ""
+          - --features bluetooth
           - --features cable
           - --features nfc
           - --features usb
-          - --features nfc,usb
-          - --features cable,nfc,usb
+          - --features bluetooth,nfc,usb
+          - --features cable,bluetooth,nfc,usb
         os:
           - ubuntu-latest
           - windows-latest
@@ -82,7 +83,7 @@ jobs:
             features: --features win10
             rust_version: stable
           - os: windows-latest
-            features: --features cable,nfc,usb,win10
+            features: --features cable,bluetooth,nfc,usb,win10
             rust_version: stable
         exclude:
           - os: windows-latest
@@ -105,7 +106,7 @@ jobs:
         run: sudo apt-get -y install libpcsclite-dev
       - if: contains(matrix.features, 'usb') && runner.os != 'windows'
         run: sudo apt-get -y install libusb-1.0-0-dev
-      - if: contains(matrix.features, 'cable') && runner.os != 'windows'
+      - if: (contains(matrix.features, 'bluetooth') || contains(matrix.features, 'cable'))  && runner.os != 'windows'
         run: sudo apt-get -y install libdbus-1-dev
 
       - if: runner.os == 'windows'

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kanidm/webauthn-rs"
 [features]
 nfc_raw_transmit = ["nfc"]
 u2fhid = ["authenticator"]
+bluetooth = ["btleplug", "tokio"]
 
 # caBLE / hybrid authenticator
 cable = ["btleplug", "hex", "tokio", "tokio-tungstenite", "qrcode"]

--- a/webauthn-authenticator-rs/src/bluetooth/framing.rs
+++ b/webauthn-authenticator-rs/src/bluetooth/framing.rs
@@ -1,0 +1,727 @@
+//! Helpers for framing Bluetooth Low Energy messages.
+//!
+
+use crate::error::WebauthnCError;
+use std::cmp::min;
+use std::iter::Sum;
+
+use super::VALID_MTU_RANGE;
+
+const INITIAL_FRAGMENT_HEADER: usize = 3;
+const CONTINUATION_FRAGMENT_HEADER: usize = 1;
+const CONTINUATION_FRAGMENT_COUNT: usize = 0x80;
+
+/// Bluetooth Low Energy frame.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BtleFrame {
+    /// Command identifier or status code
+    pub cmd: u8,
+    /// Complete length of the frame when unfragmented.
+    ///
+    /// This will exceed the length of [`BtleFrame::data`] for for the initial
+    /// fragement of a fragmented frame.
+    ///
+    /// This is set to 0 for continuation fragments.
+    pub len: u16,
+    /// Data payload, of up to [`BtleFrame::len`] bytes.
+    pub data: Vec<u8>,
+}
+
+impl BtleFrame {
+    /// Returns `true` if this is an initial frame.
+    fn is_initial(&self) -> bool {
+        self.cmd & 0x80 != 0
+    }
+
+    /// Returns the length of the header, in bytes.
+    fn header_length(&self) -> usize {
+        if self.is_initial() {
+            INITIAL_FRAGMENT_HEADER
+        } else {
+            CONTINUATION_FRAGMENT_HEADER
+        }
+    }
+
+    /// Returns `true` if the frame is an initial fragment and
+    /// [Self::len] == 0 or [Self::data.len].
+    ///
+    /// Frames fragmented by [BtleFrameIterator] return `false`.
+    ///
+    /// Frames that have been _partially_ or _fully_ reassembled by [Sum] return
+    /// `true`.
+    pub fn complete(&self) -> bool {
+        self.is_initial() && (self.len == 0 || self.data.len() == usize::from(self.len))
+    }
+
+    /// Serialises a [BtleFrame] to bytes to be sent via a BTLE GATT attribute.
+    ///
+    /// This does not fragment packets: see [BtleFrameIterator].
+    ///
+    /// # Errors
+    ///
+    /// * [`InvalidMessageLength`] if the `mtu` is not in [VALID_MTU_RANGE]
+    /// * [`MessageTooLarge`] if the message is too large for the `mtu`
+    ///
+    /// [`InvalidMessageLength`]: WebauthnCError::InvalidMessageLength
+    /// [`MessageTooLarge`]: WebauthnCError::MessageTooLarge
+    pub fn as_vec(&self, mtu: usize) -> Result<Vec<u8>, WebauthnCError> {
+        if !VALID_MTU_RANGE.contains(&mtu) {
+            return Err(WebauthnCError::InvalidMessageLength);
+        }
+        if mtu < self.header_length() + self.data.len() {
+            return Err(WebauthnCError::MessageTooLarge);
+        }
+        let mut o: Vec<u8> = Vec::with_capacity(mtu);
+
+        o.push(self.cmd);
+        if self.is_initial() {
+            o.extend_from_slice(&self.len.to_be_bytes());
+        }
+        o.extend_from_slice(&self.data);
+
+        Ok(o)
+    }
+}
+
+const EMPTY_FRAME: BtleFrame = BtleFrame {
+    cmd: 0,
+    len: 0,
+    data: vec![],
+};
+
+/// Iterator type for fragmenting a long [BtleFrame] into smaller pieces that
+/// fit within the BTLE GATT MTU.
+pub struct BtleFrameIterator<'a> {
+    /// The frame to fragment.
+    f: &'a BtleFrame,
+    /// The current position within the frame we're up to.
+    p: &'a [u8],
+    /// The fragment number we're up to.
+    i: u8,
+    /// If we've done the first iteration.
+    s: bool,
+    /// The MTU for messages to the device (`controlPointLength`)
+    mtu: usize,
+}
+
+impl<'a> BtleFrameIterator<'a> {
+    /// Creates a new iterator for fragmenting [BtleFrame]
+    pub fn new(f: &'a BtleFrame, mtu: usize) -> Result<Self, WebauthnCError> {
+        if !VALID_MTU_RANGE.contains(&mtu) {
+            return Err(WebauthnCError::InvalidMessageLength);
+        }
+        let max_size = min(
+            u16::MAX.into(),
+            (mtu - INITIAL_FRAGMENT_HEADER)
+                + (CONTINUATION_FRAGMENT_COUNT * (mtu - CONTINUATION_FRAGMENT_HEADER)),
+        );
+        if f.data.len() > max_size {
+            return Err(WebauthnCError::MessageTooLarge);
+        }
+        Ok(BtleFrameIterator {
+            f,
+            p: &f.data,
+            i: 0,
+            s: false,
+            mtu,
+        })
+    }
+}
+
+impl Iterator for BtleFrameIterator<'_> {
+    type Item = BtleFrame;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let l = self.p.len();
+        let (data, p) = self.p.split_at(min(
+            l,
+            self.mtu
+                - if self.s {
+                    CONTINUATION_FRAGMENT_HEADER
+                } else {
+                    INITIAL_FRAGMENT_HEADER
+                },
+        ));
+        self.p = p;
+
+        if !self.s {
+            // First round
+            self.s = true;
+            Some(BtleFrame {
+                len: l as u16,
+                data: data.to_vec(),
+                ..*self.f
+            })
+        } else if l == 0 {
+            // Already consumed iterator.
+            None
+        } else {
+            let i = self.i & 0x7f;
+            self.i = i + 1;
+            Some(BtleFrame {
+                cmd: i,
+                len: 0,
+                data: data.to_vec(),
+            })
+        }
+    }
+}
+
+/// Merges fragmented [BtleFrame]s back together. Assumes the first element
+/// is the initial fragment. Order of subsequent fragments doesn't matter.
+impl<'a> Sum<&'a BtleFrame> for BtleFrame {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        // First frame
+        let mut s: Option<&Self> = None;
+        let mut initial_fragment_size = 0usize;
+        let mut fragment_size = 0usize;
+        let mut o: Vec<u8> = Vec::with_capacity(0);
+
+        for f in iter {
+            match &s {
+                None => {
+                    o = vec![0; usize::from(f.len)];
+                    initial_fragment_size = f.data.len();
+                    fragment_size = initial_fragment_size + 2;
+                    let p = min(f.data.len(), usize::from(f.len));
+                    o[..p].copy_from_slice(&f.data[..p]);
+                    s = Some(f);
+                }
+
+                Some(first) => {
+                    let p = initial_fragment_size + (usize::from(f.cmd) * fragment_size);
+                    let q = min(p + f.data.len(), usize::from(first.len));
+                    o[p..q].copy_from_slice(&f.data[..q - p]);
+                }
+            }
+        }
+        match s {
+            Some(first) => BtleFrame { data: o, ..*first },
+            None => EMPTY_FRAME,
+        }
+    }
+}
+
+/// Deserialises bytes from a Bluetooth GATT notification into a [U2FHIDFrame].
+impl TryFrom<&[u8]> for BtleFrame {
+    type Error = WebauthnCError;
+
+    fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
+        let mut o = Self {
+            cmd: b[0],
+            ..Default::default()
+        };
+        let b = &b[1..];
+        if o.is_initial() {
+            // Initial
+            let (len, b) = b.split_at(2);
+            o.len = u16::from_be_bytes(
+                len.try_into()
+                    .map_err(|_| WebauthnCError::MessageTooShort)?,
+            );
+            // Resize the buffer for short messages
+            o.data = b[..min(b.len(), usize::from(o.len))].to_vec();
+        } else {
+            // Continuation
+            o.data = b.to_vec();
+        }
+        Ok(o)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::VecDeque;
+
+    use super::*;
+
+    #[test]
+    fn dont_malloc_huge_mtu() {
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 1,
+            data: vec![0xFF; 1],
+        };
+
+        assert!(frame.complete());
+        assert!(frame.is_initial());
+        assert_eq!(
+            frame.as_vec(usize::MAX),
+            Err(WebauthnCError::InvalidMessageLength)
+        );
+        assert_eq!(
+            frame.as_vec(u32::MAX as usize),
+            Err(WebauthnCError::InvalidMessageLength)
+        );
+    }
+
+    #[test]
+    fn initial_frame_minimum_size() {
+        // Minimum sized initial frame
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 17,
+            data: vec![0xFF; 17],
+        };
+        let expected = Ok(vec![
+            0x80, 0x00, 0x11, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ]);
+
+        assert!(frame.complete());
+        assert!(frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+
+        // Invalid MTUs
+        for mtu in (0..=19).chain([513].into_iter()) {
+            assert_eq!(
+                frame.as_vec(mtu),
+                Err(WebauthnCError::InvalidMessageLength),
+                "BtleFrame.as_vec should reject MTU of {mtu}"
+            );
+        }
+    }
+    #[test]
+    fn initial_frame_needing_fragmentation() {
+        // Longer initial frame should fail at small MTUs without fragmentation
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 18,
+            data: vec![0xFF; 18],
+        };
+        let expected = Ok(vec![
+            0x80, 0x00, 0x12, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ]);
+
+        assert!(frame.complete());
+        assert!(frame.is_initial());
+        assert_eq!(frame.as_vec(20), Err(WebauthnCError::MessageTooLarge));
+        assert_eq!(frame.as_vec(21), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+    }
+
+    #[test]
+    fn small_initial_frame_checks_mtu() {
+        // Even when the data is small enough, it should fail at small MTUs
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 1,
+            data: vec![0xFF; 1],
+        };
+        let expected = Ok(vec![0x80, 0x00, 0x01, 0xff]);
+
+        assert!(frame.complete());
+        assert!(frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+
+        // Invalid MTUs
+        for mtu in (0..=19).chain([513].into_iter()) {
+            assert_eq!(
+                frame.as_vec(mtu),
+                Err(WebauthnCError::InvalidMessageLength),
+                "BtleFrame.as_vec should reject MTU of {mtu}"
+            );
+        }
+    }
+
+    #[test]
+    fn frame_len_attribute_is_authoritative() {
+        // BtleFrameIterator puts in a proper length for us when fragmenting,
+        // and it is unset on continuation frames, so that the len attribute
+        // should be authoritative.
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 0,
+            data: vec![0xFF; 1],
+        };
+        let expected = Ok(vec![0x80, 0x00, 0x00, 0xff]);
+
+        assert!(frame.complete()); // because ==0
+        assert!(frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        // Should drop the excess bytes for a zero-length frame...
+        assert_eq!(
+            BtleFrame {
+                data: vec![],
+                ..frame
+            },
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+
+        // Technically invalid...
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 2,
+            data: vec![0xFF; 1],
+        };
+        let expected = Ok(vec![0x80, 0x00, 0x02, 0xff]);
+
+        assert!(!frame.complete()); // because !=0 and !=len
+        assert!(frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        // Keep the partial bytes
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+    }
+
+    #[test]
+    fn contination_frame_minimum_size() {
+        // Minimum sized continuation frame
+        let frame = BtleFrame {
+            cmd: 0x01,
+            len: 0,
+            data: vec![0xFF; 19],
+        };
+        let expected = Ok(vec![
+            0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ]);
+
+        assert!(!frame.complete());
+        assert!(!frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+
+        // Invalid MTUs
+        for mtu in (0..=19).chain([513].into_iter()) {
+            assert_eq!(
+                frame.as_vec(mtu),
+                Err(WebauthnCError::InvalidMessageLength),
+                "BtleFrame.as_vec should reject MTU of {mtu}"
+            );
+        }
+    }
+
+    #[test]
+    fn contination_frame_needing_fragmentation() {
+        // Longer continuation frame should fail at small MTUs without
+        // fragmentation
+        let frame = BtleFrame {
+            cmd: 0x01,
+            len: 0,
+            data: vec![0xFF; 20],
+        };
+        let expected = Ok(vec![
+            0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ]);
+
+        assert!(!frame.complete());
+        assert!(!frame.is_initial());
+        assert_eq!(frame.as_vec(20), Err(WebauthnCError::MessageTooLarge));
+        assert_eq!(frame.as_vec(21), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+    }
+
+    #[test]
+    fn small_continuation_frame_checks_mtu() {
+        // Even when the data is small enough, it should fail at small MTUs
+        let frame = BtleFrame {
+            cmd: 0x01,
+            len: 0,
+            data: vec![0xFF; 1],
+        };
+        let expected = Ok(vec![0x01, 0xff]);
+
+        assert!(!frame.complete());
+        assert!(!frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+
+        // Invalid MTUs
+        for mtu in (0..=19).chain([513].into_iter()) {
+            assert_eq!(
+                frame.as_vec(mtu),
+                Err(WebauthnCError::InvalidMessageLength),
+                "BtleFrame.as_vec should reject MTU of {mtu}"
+            );
+        }
+    }
+
+    #[test]
+    fn incomplete_initial_frame() {
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 512,
+            data: vec![0xFF; 17],
+        };
+        let expected = Ok(vec![
+            0x80, 0x02, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ]);
+
+        assert!(!frame.complete());
+        assert!(frame.is_initial());
+        assert_eq!(frame.as_vec(20), expected);
+        assert_eq!(frame.as_vec(512), expected);
+        assert_eq!(
+            frame,
+            BtleFrame::try_from(expected.unwrap().as_slice()).unwrap()
+        );
+    }
+
+    #[test]
+    fn fragment_short() {
+        let full = BtleFrame {
+            cmd: 0x81,
+            len: 2,
+            data: vec![1, 2],
+        };
+
+        let fragments: Vec<BtleFrame> = BtleFrameIterator::new(&full, 20).unwrap().collect();
+        assert_eq!(fragments.len(), 1);
+        assert_eq!(fragments[0], full);
+
+        let assembled: BtleFrame = fragments.iter().sum();
+        assert_eq!(assembled, full);
+    }
+
+    #[test]
+    fn fragment_small_mtu() {
+        let full = BtleFrame {
+            cmd: 0x81,
+            len: 40,
+            data: (0..40).collect(),
+        };
+        assert!(full.complete());
+
+        let mtu = 20;
+        let mut fragments: VecDeque<BtleFrame> =
+            BtleFrameIterator::new(&full, mtu).unwrap().collect();
+        let mut parsed: Vec<BtleFrame> = Vec::with_capacity(3);
+        // 17, 19, 4
+        assert_eq!(fragments.len(), 3);
+        for f in &fragments {
+            assert!(!f.complete());
+        }
+
+        let f = fragments.pop_front().unwrap();
+        assert_eq!(f.cmd, 0x81);
+        assert_eq!(f.len, 0x28);
+        assert_eq!(f.data, (0..17).collect::<Vec<u8>>());
+        let c = f.as_vec(mtu).unwrap();
+        assert_eq!(
+            c,
+            vec![
+                0x81, // cmd
+                0x00, 0x28, // len
+                // payload
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                0x0e, 0x0f, 0x10
+            ]
+        );
+        parsed.push(BtleFrame::try_from(c.as_slice()).unwrap());
+
+        let f = fragments.pop_front().unwrap();
+        assert_eq!(f.cmd, 0);
+        assert_eq!(f.data, (17..36).collect::<Vec<u8>>());
+        let c = f.as_vec(mtu).unwrap();
+        assert_eq!(
+            c,
+            vec![
+                0x00, // cmd
+                // payload
+                0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
+                0x1f, 0x20, 0x21, 0x22, 0x23,
+            ]
+        );
+        parsed.push(BtleFrame::try_from(c.as_slice()).unwrap());
+
+        let f = fragments.pop_front().unwrap();
+        assert_eq!(f.cmd, 1);
+        assert_eq!(f.data, (36..40).collect::<Vec<u8>>());
+        let c = f.as_vec(mtu).unwrap();
+        assert_eq!(
+            c,
+            vec![
+                0x01, // cmd
+                // payload
+                0x24, 0x25, 0x26, 0x27
+            ]
+        );
+        parsed.push(BtleFrame::try_from(c.as_slice()).unwrap());
+
+        let assembled: BtleFrame = parsed.iter().sum();
+        assert_eq!(assembled, full);
+        assert!(assembled.complete());
+    }
+
+    #[test]
+    fn fragment_large_mtu() {
+        let full = BtleFrame {
+            cmd: 0x81,
+            len: 400,
+            data: vec![0xff; 400],
+        };
+        assert!(full.complete());
+
+        let mtu = 512;
+        let mut fragments: VecDeque<BtleFrame> =
+            BtleFrameIterator::new(&full, mtu).unwrap().collect();
+        let mut parsed: Vec<BtleFrame> = Vec::with_capacity(1);
+        // 400
+        assert_eq!(fragments.len(), 1);
+
+        let f = fragments.pop_front().unwrap();
+        assert_eq!(f.cmd, 0x81);
+        assert_eq!(f.len, 0x190);
+        assert_eq!(f.data, vec![0xff; 400]);
+        let c = f.as_vec(mtu).unwrap();
+        assert_eq!(
+            c,
+            vec![
+                0x81, // cmd
+                0x01, 0x90, // len
+                // payload
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            ]
+        );
+
+        parsed.push(BtleFrame::try_from(c.as_slice()).unwrap());
+        let assembled: BtleFrame = parsed.iter().sum();
+        assert_eq!(assembled, full);
+        assert!(assembled.complete());
+    }
+
+    #[test]
+    fn iterator_invalid_mtus() {
+        let frame = BtleFrame {
+            cmd: 0x80,
+            len: 1,
+            data: vec![0xFF; 1],
+        };
+
+        for mtu in (0..=19).chain([513].into_iter()) {
+            assert_eq!(
+                BtleFrameIterator::new(&frame, mtu).err(),
+                Some(WebauthnCError::InvalidMessageLength),
+                "BtleFrameIterator should reject MTU of {mtu}"
+            );
+        }
+    }
+
+    macro_rules! fragment_max_mtu {
+        ($($name:ident: $value:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (mtu, max_size): (usize, usize) = $value;
+                let full = BtleFrame {
+                    cmd: 0x90,
+                    len: max_size as u16,
+                    data: vec![0xFF; max_size],
+                };
+
+                let mut fragments: VecDeque<BtleFrame> =
+                    BtleFrameIterator::new(&full, mtu).unwrap().collect();
+                let mut parsed: Vec<BtleFrame> = Vec::with_capacity(0x81);
+
+                assert_eq!(fragments.len(), 0x81, "expected 0x81 fragments, max_size is not the maximum");
+
+                let f = fragments.pop_front().unwrap();
+                assert_eq!(f.cmd, 0x90);
+                assert_eq!(f.len, max_size as u16);
+                assert_eq!(f.data, vec![0xff; mtu - 3]);
+                let c = f.as_vec(mtu).unwrap();
+                assert_eq!(c.len(), mtu);
+                assert!(c[3..].iter().all(|v| *v == 0xff));
+                parsed.push(BtleFrame::try_from(c.as_slice()).unwrap());
+
+                for f in fragments {
+                    assert_eq!(f.len, 0);
+                    assert!(f.data.iter().all(|v| *v == 0xff));
+
+                    let c = f.as_vec(mtu).unwrap();
+                    assert!(c[1..].iter().all(|v| *v == 0xff));
+                    parsed.push(BtleFrame::try_from(c.as_slice()).unwrap());
+                }
+
+                // Reassembly
+                let assembled: BtleFrame = parsed.iter().sum();
+                assert_eq!(assembled, full);
+                assert!(assembled.complete());
+
+                // One more byte should error, and it shouldn't matter what `len` says
+                let full = BtleFrame {
+                    cmd: 0x90,
+                    len: 1,
+                    data: vec![0; max_size + 1],
+                };
+
+                let err = BtleFrameIterator::new(&full, mtu).err();
+                assert_eq!(Some(WebauthnCError::MessageTooLarge), err, "expected max_size + 1 to error, max_size is not the maximum");
+            }
+        )*
+        }
+    }
+
+    fragment_max_mtu! {
+        fragment_max_mtu_20: (20, 2449),
+        fragment_max_mtu_509: (509, 65530),
+        // Limited by message length (u16)
+        fragment_max_mtu_510: (510, 65535),
+        fragment_max_mtu_512: (512, 65535),
+    }
+}

--- a/webauthn-authenticator-rs/src/bluetooth/mod.rs
+++ b/webauthn-authenticator-rs/src/bluetooth/mod.rs
@@ -1,0 +1,490 @@
+//! [BluetoothTransport] communicates with a FIDO token over Bluetooth Low
+//! Energy, using [btleplug].
+//!
+//! This module should work on most platforms with Bluetooth Low Energy support,
+//! provided that the user has permissions.
+//!
+//! ## Warning
+//!
+//! There are [API design issues][0] with [Transport] which make
+//! [BluetoothTransport::tokens] **extremely** flaky and timing sensitive.
+//!
+//! The [long term goal][0] is that this API (and its UI) will become as easy to
+//! use as Windows WebAuthn API, but it's not there just yet.
+//!
+//! [0]: https://github.com/kanidm/webauthn-rs/issues/214
+//!
+//! ## caBLE support
+//!
+//! To use a caBLE / hybrid authenticator, use the [cable][crate::cable] module
+//! (avaliable with `--features cable`) instead.
+//!
+//! ## Windows support
+//!
+//! Windows' WebAuthn API (on Windows 10 build 1903 and later) blocks
+//! non-Administrator access to BTLE FIDO tokens, and will return "permission
+//! denied" errors when accessed via normal Bluetooth APIs. This does not impact
+//! use of caBLE authenticators.
+//!
+//! Use [Win10][crate::win10::Win10] (available with `--features win10`) on
+//! Windows instead.
+use std::{ops::RangeInclusive, time::Duration};
+
+#[cfg(doc)]
+use crate::stubs::*;
+
+use async_trait::async_trait;
+use btleplug::{
+    api::{
+        bleuuid::uuid_from_u16, Central, Characteristic, Manager as _, Peripheral as _, ScanFilter,
+        WriteType,
+    },
+    platform::{Manager, Peripheral},
+};
+use futures::{executor::block_on, StreamExt};
+use tokio::time::sleep;
+use uuid::{uuid, Uuid};
+use webauthn_rs_proto::AuthenticatorTransport;
+
+use crate::{
+    error::WebauthnCError,
+    transport::{
+        types::{
+            CBORResponse, KeepAliveStatus, Response, U2FError, BTLE_CANCEL, BTLE_KEEPALIVE,
+            TYPE_INIT, U2FHID_ERROR, U2FHID_MSG, U2FHID_PING,
+        },
+        Token, Transport,
+    },
+    ui::UiCallback,
+};
+
+use self::framing::{BtleFrame, BtleFrameIterator};
+
+mod framing;
+
+/// The FIDO Bluetooth GATT [Service] [Uuid].
+///
+/// Reference: [Bluetooth Assigned Numbers][], Section 3.10 (SDO Services)
+///
+/// [Bluetooth Assigned Numbers]: https://www.bluetooth.com/specifications/assigned-numbers/
+/// [Service]: btleplug::api::Service
+const FIDO_GATT_SERVICE: Uuid = uuid_from_u16(0xfffd);
+
+/// FIDO Control Point [Characteristic] [Uuid].
+///
+/// This is a write-only command buffer for the initiator.
+const FIDO_CONTROL_POINT: Uuid = uuid!("F1D0FFF1-DEAA-ECEE-B42F-C9BA7ED623BB");
+
+/// FIDO Status [Characteristic] [Uuid].
+///
+/// The authenticator sends notifications to respond to commands sent to
+/// [FIDO_CONTROL_POINT].
+const FIDO_STATUS: Uuid = uuid!("F1D0FFF2-DEAA-ECEE-B42F-C9BA7ED623BB");
+
+/// FIDO Control Point Length [Characteristic] [Uuid].
+///
+/// This is a read-only value in [VALID_MTU_RANGE] which indicates the MTU of
+/// the [FIDO_CONTROL_POINT] and [FIDO_STATUS] [Characteristic]s.
+const FIDO_CONTROL_POINT_LENGTH: Uuid = uuid!("F1D0FFF3-DEAA-ECEE-B42F-C9BA7ED623BB");
+
+/// FIDO Service Revision Bitfield [Characteristic] [Uuid].
+///
+/// When read by the initiator, the authenticator sends which protocol versions
+/// are supported as a bitfield, and then the initiator writes a single bit
+/// indicating which protocol it will use.
+///
+/// This is not present on U2F 1.0 authenticators.
+const FIDO_SERVICE_REVISION_BITFIELD: Uuid = uuid!("F1D0FFF4-DEAA-ECEE-B42F-C9BA7ED623BB");
+
+/// Valid MTU range for [FIDO_CONTROL_POINT_LENGTH].
+const VALID_MTU_RANGE: RangeInclusive<usize> = 20..=512;
+
+/// Bitfield value in [FIDO_SERVICE_REVISION_BITFIELD] to indicate an
+/// authenticator supports CTAP2.
+const SERVICE_REVISION_CTAP2: u8 = 0x20;
+
+#[derive(Debug)]
+pub struct BluetoothTransport {
+    manager: Manager,
+}
+
+impl BluetoothTransport {
+    /// Creates a new instance of the Bluetooth Low Energy scanner.
+    pub async fn new() -> Result<Self, WebauthnCError> {
+        Ok(Self {
+            manager: Manager::new().await?,
+        })
+    }
+
+    async fn scan(&self) -> Result<Vec<BluetoothToken>, WebauthnCError> {
+        // https://github.com/deviceplug/btleplug/blob/master/examples/subscribe_notify_characteristic.rs
+        let adapters = self.manager.adapters().await?;
+        let adapter = adapters
+            .into_iter()
+            .next()
+            .ok_or(WebauthnCError::NoBluetoothAdapter)?;
+        // TODO: filtering
+        adapter.start_scan(ScanFilter::default()).await?;
+        // TODO: this should probably be longer because you need to press a button
+        trace!("waiting for scan");
+        sleep(Duration::from_secs(5)).await;
+        adapter.stop_scan().await?;
+        let peripherals = adapter.peripherals().await?;
+        let mut o = Vec::new();
+
+        if peripherals.is_empty() {
+            trace!("No devices found");
+            return Ok(o);
+        }
+
+        for peripheral in peripherals.into_iter() {
+            let properties = peripheral.properties().await?;
+            trace!(?peripheral);
+            trace!(?properties);
+            let properties = if let Some(p) = properties {
+                p
+            } else {
+                trace!("No properties available, skipping");
+                continue;
+            };
+
+            if !properties.services.contains(&FIDO_GATT_SERVICE) {
+                trace!("Device is not a FIDO token, skipping");
+                continue;
+            }
+
+            // let local_name = properties
+            //     .local_name
+            //     .unwrap_or(String::from("(peripheral name unknown)"));
+            // trace!(
+            //     "Peripheral {:?} is connected: {:?}",
+            //     &local_name,
+            //     is_connected
+            // );
+            o.push(BluetoothToken::new(peripheral));
+        }
+
+        Ok(o)
+    }
+}
+
+impl<'b> Transport<'b> for BluetoothTransport {
+    type Token = BluetoothToken;
+
+    /// Scans for all *already-connected* Bluetooth Low Energy authenticators.
+    ///
+    /// ## Warning
+    ///
+    /// There are [API design issues][0] with [Transport] which make this
+    /// function **extremely** flaky and timing sensitive.
+    ///
+    /// The [long term goal][0] is that this API (and its UI) will become as
+    /// easy to use as Windows WebAuthn API, but it's not there just yet.
+    ///
+    /// [0]: https://github.com/kanidm/webauthn-rs/issues/214
+    fn tokens(&mut self) -> Result<Vec<Self::Token>, WebauthnCError> {
+        // TODO: handle async properly
+        trace!("Scanning for BTLE tokens");
+        block_on(self.scan())
+    }
+}
+
+#[derive(Debug)]
+pub struct BluetoothToken {
+    device: Peripheral,
+    mtu: usize,
+    control_point: Option<Characteristic>,
+}
+
+impl BluetoothToken {
+    fn new(device: Peripheral) -> Self {
+        BluetoothToken {
+            device,
+            mtu: 0,
+            control_point: None,
+        }
+    }
+
+    /// Gets the current MTU for the authenticator.
+    ///
+    /// Returns [WebauthnCError::UnexpectedState] if it is out of range.
+    #[inline]
+    fn checked_mtu(&self) -> Result<usize, WebauthnCError> {
+        if !VALID_MTU_RANGE.contains(&self.mtu) {
+            Err(WebauthnCError::UnexpectedState)
+        } else {
+            Ok(self.mtu)
+        }
+    }
+
+    /// Sends a single [BtleFrame] to the device, without fragmentation.
+    async fn send_one(&self, frame: BtleFrame) -> Result<(), WebauthnCError> {
+        let d = frame.as_vec(self.checked_mtu()?)?;
+        trace!(">>> {:02x?}", d);
+        self.device
+            .write(
+                self.control_point
+                    .as_ref()
+                    .ok_or(WebauthnCError::UnexpectedState)?,
+                &d,
+                WriteType::WithoutResponse,
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Sends a [BtleFrame] to the device, fragmenting the message to fit
+    /// within the BTLE MTU.
+    async fn send(&self, frame: &BtleFrame) -> Result<(), WebauthnCError> {
+        for f in BtleFrameIterator::new(frame, self.checked_mtu()?)? {
+            self.send_one(f).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Token for BluetoothToken {
+    async fn transmit_raw<U>(&mut self, cmd: &[u8], ui: &U) -> Result<Vec<u8>, WebauthnCError>
+    where
+        U: UiCallback,
+    {
+        // We need to get the notification stream for each command, because
+        // otherwise could lose messages while waiting for a response. This
+        // provides an asynchronous stream of events as they come in.
+        let mut stream = self.device.notifications().await?;
+
+        // In CTAP2 mode, `U2FHID_MSG` is a raw CBOR message.
+        let cmd = BtleFrame {
+            cmd: U2FHID_MSG,
+            len: cmd.len() as u16,
+            data: cmd.to_vec(),
+        };
+        self.send(&cmd).await?;
+
+        // Get a response, checking for keep-alive
+        let resp = loop {
+            let mut t = 0usize;
+            let mut s = 0usize;
+            let mut c = Vec::new();
+
+            while let Some(data) = stream.next().await {
+                trace!("<<< {:02x?}", data.value);
+                if data.uuid != FIDO_STATUS {
+                    trace!("Ignoring notification for unknown UUID: {:?}", data.uuid);
+                    continue;
+                }
+
+                let frame = BtleFrame::try_from(data.value.as_slice())?;
+                if frame.cmd >= TYPE_INIT {
+                    if t == 0 {
+                        // Initial frame contains length
+                        t = usize::from(frame.len);
+                    } else {
+                        error!("Unexpected initial frame");
+                        return Err(WebauthnCError::Unknown);
+                    }
+                } else if t == 0 {
+                    error!("Unexpected continuation frame");
+                    return Err(WebauthnCError::Unknown);
+                }
+
+                s += frame.data.len();
+                c.push(frame);
+
+                if s >= t {
+                    // We have all the chunks we expected.
+                    break;
+                }
+            }
+
+            if s < t {
+                error!("Stream stopped before getting complete message");
+                return Err(WebauthnCError::Unknown);
+            }
+
+            let f: BtleFrame = c.iter().sum();
+            trace!("recv done: {f:?}");
+            let resp = Response::try_from(&f)?;
+            trace!("Response: {resp:?}");
+
+            if let Response::KeepAlive(r) = resp {
+                trace!("waiting for {:?}", r);
+                if r == KeepAliveStatus::UserPresenceNeeded {
+                    ui.request_touch();
+                }
+                // TODO: maybe time out at some point
+                // thread::sleep(Duration::from_millis(100));
+            } else {
+                break resp;
+            }
+        };
+
+        // Get a response
+        match resp {
+            Response::Cbor(c) => {
+                if c.status.is_ok() {
+                    Ok(c.data)
+                } else {
+                    let e = WebauthnCError::Ctap(c.status);
+                    error!("Ctap error: {:?}", e);
+                    Err(e)
+                }
+            }
+            e => {
+                error!("Unhandled response type: {:?}", e);
+                Err(WebauthnCError::Cbor)
+            }
+        }
+    }
+
+    async fn init(&mut self) -> Result<(), WebauthnCError> {
+        if !self.device.is_connected().await? {
+            self.device.connect().await?;
+        }
+
+        self.device.discover_services().await?;
+        let service = self
+            .device
+            .services()
+            .into_iter()
+            .find(|s| s.uuid == FIDO_GATT_SERVICE)
+            .ok_or(WebauthnCError::NotSupported)?;
+
+        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#ble-protocol-overview
+        // 5. Client checks if the fidoServiceRevisionBitfield characteristic is
+        // present. If so, the client selects a supported version by writing a
+        // value with a single bit set.
+        if let Some(c) = service
+            .characteristics
+            .iter()
+            .find(|c| c.uuid == FIDO_SERVICE_REVISION_BITFIELD)
+        {
+            trace!("Selecting protocol version");
+            if let Some(b) = self.device.read(c).await?.first() {
+                trace!("Service revision bitfield: {b:#08b}");
+                if b & SERVICE_REVISION_CTAP2 == 0 {
+                    error!("Device does not support CTAP2, not supported!");
+                    return Err(WebauthnCError::NotSupported);
+                }
+
+                trace!("Requesting CTAP2");
+                self.device
+                    .write(c, &[SERVICE_REVISION_CTAP2], WriteType::WithResponse)
+                    .await?;
+                trace!("Done");
+            } else {
+                error!("Could not read protocol version");
+                return Err(WebauthnCError::MissingRequiredField);
+            }
+        } else {
+            error!("Device does not support CTAP2, not supported!");
+            return Err(WebauthnCError::NotSupported);
+        }
+
+        // 6. Client reads the fidoControlPointLength characteristic.
+        if let Some(c) = service
+            .characteristics
+            .iter()
+            .find(|c| c.uuid == FIDO_CONTROL_POINT_LENGTH)
+        {
+            let b = self.device.read(c).await?;
+            if b.len() < 2 {
+                return Err(WebauthnCError::MessageTooShort);
+            }
+            self.mtu = u16::from_be_bytes(
+                b[0..2]
+                    .try_into()
+                    .map_err(|_| WebauthnCError::MessageTooShort)?,
+            ) as usize;
+            trace!("Control point length: {}", self.mtu);
+            if self.mtu < 20 || self.mtu > 512 {
+                error!("Control point length must be between 20 and 512 bytes");
+                return Err(WebauthnCError::NotSupported);
+            }
+        } else {
+            error!("No control point length specified!");
+            return Err(WebauthnCError::MissingRequiredField);
+        }
+
+        // 7. Client registers for notifications on the fidoStatus
+        // characteristic.
+        if let Some(c) = service
+            .characteristics
+            .iter()
+            .find(|c| c.uuid == FIDO_STATUS)
+        {
+            self.device.subscribe(c).await?;
+        } else {
+            error!("No status attribute, cannot get responses to commands!");
+            return Err(WebauthnCError::MissingRequiredField);
+        }
+
+        // We want to be able to send some messages later.
+        if let Some(c) = service
+            .characteristics
+            .iter()
+            .find(|c| c.uuid == FIDO_CONTROL_POINT)
+        {
+            self.control_point = Some(c.to_owned());
+        } else {
+            error!("No control point attribute, cannot send commands!");
+            return Err(WebauthnCError::MissingRequiredField);
+        }
+
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), WebauthnCError> {
+        if self.device.is_connected().await.unwrap_or_default() {
+            self.device.disconnect().await?;
+        }
+        Ok(())
+    }
+
+    fn get_transport(&self) -> AuthenticatorTransport {
+        AuthenticatorTransport::Ble
+    }
+
+    async fn cancel(&self) -> Result<(), WebauthnCError> {
+        self.send_one(BtleFrame {
+            cmd: BTLE_CANCEL,
+            len: 0,
+            data: vec![],
+        })
+        .await
+    }
+}
+
+impl Drop for BluetoothToken {
+    fn drop(&mut self) {
+        trace!("dropping");
+        block_on(self.close()).ok();
+    }
+}
+
+/// Parser for a response [BtleFrame].
+///
+/// The frame must be complete (ie: all fragments received) before parsing.
+impl TryFrom<&BtleFrame> for Response {
+    type Error = WebauthnCError;
+
+    fn try_from(f: &BtleFrame) -> Result<Response, WebauthnCError> {
+        if !f.complete() {
+            error!("cannot parse incomplete frame");
+            return Err(WebauthnCError::UnexpectedState);
+        }
+
+        let b = &f.data[..];
+        Ok(match f.cmd {
+            U2FHID_PING => Response::Ping(b.to_vec()),
+            BTLE_KEEPALIVE => Response::KeepAlive(KeepAliveStatus::from(b)),
+            U2FHID_MSG => CBORResponse::try_from(b).map(Response::Cbor)?,
+            U2FHID_ERROR => Response::Error(U2FError::from(b)),
+            _ => {
+                error!("unknown BTLE command: 0x{:02x}", f.cmd,);
+                Response::Unknown
+            }
+        })
+    }
+}

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -35,6 +35,7 @@
 //! the appropriate `--features` flag listed inline.
 //!
 //! * [CTAP 2.0, 2.1 and 2.1-PRE protocol implementation][crate::ctap2]
+//! * [Bluetooth][] (with `--features bluetooth`)
 //! * [caBLE][] (with `--features cable`)
 //! * [NFC][] via PC/SC API (with `--features nfc`)
 //! * [SoftPasskey][] (for testing)
@@ -44,6 +45,7 @@
 //! * [Windows 10][] WebAuthn API (with `--features win10`)
 //!
 //! [FIDO2 certified]: https://fidoalliance.org/fido-certified-showcase/
+//! [Bluetooth]: crate::bluetooth
 //! [cert]: https://fidoalliance.org/certification/authenticator-certification-levels/
 //! [caBLE]: crate::cable
 //! [Mozilla Authenticator]: crate::u2fhid
@@ -102,6 +104,9 @@ pub mod transport;
 pub mod types;
 pub mod ui;
 mod util;
+
+#[cfg(any(all(doc, not(doctest)), feature = "bluetooth"))]
+pub mod bluetooth;
 
 #[cfg(any(all(doc, not(doctest)), feature = "cable"))]
 pub mod cable;

--- a/webauthn-authenticator-rs/src/stubs.rs
+++ b/webauthn-authenticator-rs/src/stubs.rs
@@ -31,7 +31,7 @@ pub mod pcsc {
     pub struct ReaderState {}
 }
 
-#[cfg(not(feature = "cable"))]
+#[cfg(not(feature = "tokio"))]
 pub mod tokio {
     pub mod net {
         pub struct TcpStream {}
@@ -41,6 +41,9 @@ pub mod tokio {
             pub struct Sender<T> {}
             pub struct Receiver<T> {}
         }
+    }
+    pub mod time {
+        pub async fn sleep(_: std::time::Duration) {}
     }
 }
 

--- a/webauthn-authenticator-rs/src/transport/any.rs
+++ b/webauthn-authenticator-rs/src/transport/any.rs
@@ -2,6 +2,8 @@
 //!
 //! This is still a work in progress, and doesn't yet handle tokens quite as
 //! well as we'd like.
+#[cfg(any(all(doc, not(doctest)), feature = "bluetooth"))]
+use crate::bluetooth::*;
 #[cfg(any(all(doc, not(doctest)), feature = "nfc"))]
 use crate::nfc::*;
 use crate::transport::*;
@@ -11,6 +13,8 @@ use crate::usb::*;
 /// [AnyTransport] merges all available transports for the platform.
 #[derive(Debug)]
 pub struct AnyTransport {
+    #[cfg(any(all(doc, not(doctest)), feature = "bluetooth"))]
+    pub bluetooth: BluetoothTransport,
     #[cfg(any(all(doc, not(doctest)), feature = "nfc"))]
     pub nfc: NFCReader,
     #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
@@ -22,6 +26,8 @@ pub struct AnyTransport {
 pub enum AnyToken {
     /// No-op stub entry, never used.
     Stub,
+    #[cfg(any(all(doc, not(doctest)), feature = "bluetooth"))]
+    Bluetooth(BluetoothToken),
     #[cfg(any(all(doc, not(doctest)), feature = "nfc"))]
     Nfc(NFCCard),
     #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
@@ -34,6 +40,8 @@ impl AnyTransport {
     /// For NFC, uses `Scope::User`.
     pub async fn new() -> Result<Self, WebauthnCError> {
         Ok(AnyTransport {
+            #[cfg(feature = "bluetooth")]
+            bluetooth: BluetoothTransport::new().await?,
             #[cfg(feature = "nfc")]
             nfc: NFCReader::new(pcsc::Scope::User)?,
             #[cfg(feature = "usb")]
@@ -47,13 +55,21 @@ impl<'b> Transport<'b> for AnyTransport {
 
     #[allow(unreachable_code)]
     fn tokens(&mut self) -> Result<Vec<Self::Token>, WebauthnCError> {
-        #[cfg(not(any(feature = "nfc", feature = "usb")))]
+        #[cfg(not(any(feature = "bluetooth", feature = "nfc", feature = "usb")))]
         {
             error!("No transports available!");
             return Err(WebauthnCError::NotSupported);
         }
 
         let mut o: Vec<Self::Token> = Vec::new();
+        #[cfg(feature = "bluetooth")]
+        o.extend(
+            self.bluetooth
+                .tokens()?
+                .into_iter()
+                .map(AnyToken::Bluetooth),
+        );
+
         #[cfg(feature = "nfc")]
         o.extend(self.nfc.tokens()?.into_iter().map(AnyToken::Nfc));
 
@@ -74,6 +90,8 @@ impl Token for AnyToken {
     {
         match self {
             AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(b) => Token::transmit_raw(b, cmd, ui).await,
             #[cfg(feature = "nfc")]
             AnyToken::Nfc(n) => Token::transmit_raw(n, cmd, ui).await,
             #[cfg(feature = "usb")]
@@ -84,6 +102,8 @@ impl Token for AnyToken {
     async fn init(&mut self) -> Result<(), WebauthnCError> {
         match self {
             AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(b) => b.init().await,
             #[cfg(feature = "nfc")]
             AnyToken::Nfc(n) => n.init().await,
             #[cfg(feature = "usb")]
@@ -94,6 +114,8 @@ impl Token for AnyToken {
     async fn close(&mut self) -> Result<(), WebauthnCError> {
         match self {
             AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(b) => b.close().await,
             #[cfg(feature = "nfc")]
             AnyToken::Nfc(n) => n.close().await,
             #[cfg(feature = "usb")]
@@ -104,6 +126,8 @@ impl Token for AnyToken {
     fn get_transport(&self) -> AuthenticatorTransport {
         match self {
             AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(b) => b.get_transport(),
             #[cfg(feature = "nfc")]
             AnyToken::Nfc(n) => n.get_transport(),
             #[cfg(feature = "usb")]
@@ -114,6 +138,8 @@ impl Token for AnyToken {
     async fn cancel(&self) -> Result<(), WebauthnCError> {
         match self {
             AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(b) => b.cancel().await,
             #[cfg(feature = "nfc")]
             AnyToken::Nfc(n) => n.cancel().await,
             #[cfg(feature = "usb")]
@@ -124,6 +150,8 @@ impl Token for AnyToken {
     fn has_button(&self) -> bool {
         match self {
             AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(b) => b.has_button(),
             #[cfg(feature = "nfc")]
             AnyToken::Nfc(n) => n.has_button(),
             #[cfg(feature = "usb")]

--- a/webauthn-authenticator-rs/src/transport/mod.rs
+++ b/webauthn-authenticator-rs/src/transport/mod.rs
@@ -3,7 +3,7 @@
 //! See [crate::ctap2] for a higher-level abstraction over this API.
 mod any;
 pub mod iso7816;
-#[cfg(any(doc, feature = "usb"))]
+#[cfg(any(doc, feature = "bluetooth", feature = "usb"))]
 pub(crate) mod types;
 
 pub use crate::transport::any::{AnyToken, AnyTransport};

--- a/webauthn-authenticator-rs/src/transport/types.rs
+++ b/webauthn-authenticator-rs/src/transport/types.rs
@@ -5,6 +5,8 @@ use super::iso7816::ISO7816ResponseAPDU;
 
 pub const TYPE_INIT: u8 = 0x80;
 pub const U2FHID_PING: u8 = TYPE_INIT | 0x01;
+#[cfg(any(doc, feature = "bluetooth"))]
+pub const BTLE_KEEPALIVE: u8 = TYPE_INIT | 0x02;
 pub const U2FHID_MSG: u8 = TYPE_INIT | 0x03;
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_INIT: u8 = TYPE_INIT | 0x06;
@@ -14,6 +16,8 @@ pub const U2FHID_CBOR: u8 = TYPE_INIT | 0x10;
 pub const U2FHID_CANCEL: u8 = TYPE_INIT | 0x11;
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_KEEPALIVE: u8 = TYPE_INIT | 0x3b;
+#[cfg(any(doc, feature = "bluetooth"))]
+pub const BTLE_CANCEL: u8 = TYPE_INIT | 0x3e;
 pub const U2FHID_ERROR: u8 = TYPE_INIT | 0x3f;
 
 /// Type for parsing all responses from a BTLE or USB FIDO token.


### PR DESCRIPTION
This adds basic support for using Bluetooth Low Energy authenticators.

Because of API design and UI problems (see #214), the interface is *extremely* flaky and timing sensitive.  Fixing that will be a lot more work (refactoring more of the library to be `async`, and use `tokio` `Streams`); but should be easier to approach building around a transport which has the same model.

However, the important part of actually being able to use BTLE GATT as a transport layer, and being able to frame requests properly with CTAP's variable MTU works.

Tested with:

* Hideez Key 4
* Feitian MultiPass K16

Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
