### PR TITLE
API changes needed for BTLE work

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -13,11 +13,8 @@ repository = "https://github.com/kanidm/webauthn-rs"
 nfc_raw_transmit = ["nfc"]
 u2fhid = ["authenticator"]
 
-# BTLE authenticators are not yet supported - this is currently only for caBLE
-bluetooth = ["btleplug"]
-
 # caBLE / hybrid authenticator
-cable = ["bluetooth", "hex", "tokio", "tokio-tungstenite", "qrcode"]
+cable = ["btleplug", "hex", "tokio", "tokio-tungstenite", "qrcode"]
 
 # Add APIs which allow overriding the caBLE tunnel server protocol and domain.
 #

--- a/webauthn-authenticator-rs/examples/authenticate/main.rs
+++ b/webauthn-authenticator-rs/examples/authenticate/main.rs
@@ -55,7 +55,7 @@ impl From<UvPolicy> for UserVerificationPolicy {
 }
 
 fn select_transport<U: UiCallback>(ui: &U) -> impl AuthenticatorBackend + '_ {
-    let mut reader = AnyTransport::new().unwrap();
+    let mut reader = block_on(AnyTransport::new()).unwrap();
     info!("Using reader: {:?}", reader);
 
     match reader.tokens() {

--- a/webauthn-authenticator-rs/examples/cable_tunnel/core.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel/core.rs
@@ -249,7 +249,7 @@ pub(super) async fn main() {
         .unwrap();
     } else {
         // Use a physical authenticator
-        let mut transport = AnyTransport::new().unwrap();
+        let mut transport = AnyTransport::new().await.unwrap();
         let token = transport.tokens().unwrap().pop().unwrap();
         let mut authenticator = CtapAuthenticator::new(token, &ui).await.unwrap();
         let info = authenticator.get_info().to_owned();

--- a/webauthn-authenticator-rs/examples/nfc_token_info/core.rs
+++ b/webauthn-authenticator-rs/examples/nfc_token_info/core.rs
@@ -1,10 +1,9 @@
-use futures::executor::block_on;
 use webauthn_authenticator_rs::{ctap2::CtapAuthenticator, transport::*, ui::Cli};
 
-fn access_card<T: Token>(card: T) {
+async fn access_card<T: Token>(card: T) {
     info!("Card detected ...");
 
-    let auth = block_on(CtapAuthenticator::new(card, &Cli {}));
+    let auth = CtapAuthenticator::new(card, &Cli {}).await;
 
     match auth {
         Some(x) => {
@@ -14,14 +13,14 @@ fn access_card<T: Token>(card: T) {
     }
 }
 
-pub(crate) fn event_loop() {
-    let mut reader = block_on(AnyTransport::new()).unwrap();
+pub(crate) async fn event_loop() {
+    let mut reader = AnyTransport::new().await.unwrap();
     info!("Using reader: {:?}", reader);
 
     match reader.tokens() {
         Ok(mut tokens) => {
             while let Some(card) = tokens.pop() {
-                access_card(card);
+                access_card(card).await;
             }
         }
         Err(e) => panic!("Error: {e:?}"),

--- a/webauthn-authenticator-rs/examples/nfc_token_info/core.rs
+++ b/webauthn-authenticator-rs/examples/nfc_token_info/core.rs
@@ -15,7 +15,7 @@ fn access_card<T: Token>(card: T) {
 }
 
 pub(crate) fn event_loop() {
-    let mut reader = AnyTransport::new().unwrap();
+    let mut reader = block_on(AnyTransport::new()).unwrap();
     info!("Using reader: {:?}", reader);
 
     match reader.tokens() {

--- a/webauthn-authenticator-rs/examples/nfc_token_info/main.rs
+++ b/webauthn-authenticator-rs/examples/nfc_token_info/main.rs
@@ -3,7 +3,8 @@ extern crate tracing;
 
 mod core;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     tracing_subscriber::fmt::init();
-    core::event_loop();
+    core::event_loop().await;
 }

--- a/webauthn-authenticator-rs/src/cable/btle.rs
+++ b/webauthn-authenticator-rs/src/cable/btle.rs
@@ -15,13 +15,10 @@
 #[cfg(doc)]
 use crate::stubs::*;
 
-#[cfg(feature = "bluetooth")]
 use btleplug::{
-    api::{Central, CentralEvent, Manager as _},
+    api::{bleuuid::uuid_from_u16, Central, CentralEvent, Manager as _, ScanFilter},
     platform::Manager,
 };
-
-use btleplug::api::{bleuuid::uuid_from_u16, ScanFilter};
 
 #[cfg(feature = "cable")]
 use futures::StreamExt;
@@ -84,7 +81,6 @@ pub trait Advertiser {
 
 /// Bluetooth Low Energy service data advertisement scanner.
 pub struct Scanner {
-    #[cfg(feature = "bluetooth")]
     manager: Manager,
 }
 

--- a/webauthn-authenticator-rs/src/cable/tunnel.rs
+++ b/webauthn-authenticator-rs/src/cable/tunnel.rs
@@ -387,7 +387,7 @@ impl Token for Tunnel {
         Ok(data)
     }
 
-    fn cancel(&self) -> Result<(), WebauthnCError> {
+    async fn cancel(&self) -> Result<(), WebauthnCError> {
         // There is no way to cancel transactions without closing in caBLE
         Ok(())
     }

--- a/webauthn-authenticator-rs/src/ctap2/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/mod.rs
@@ -230,7 +230,14 @@ impl<'a, T: Token, U: UiCallback> CtapAuthenticator<'a, T, U> {
     ///
     /// Returns `None` if we don't support any version of CTAP which the token supports.
     pub async fn new(mut token: T, ui_callback: &'a U) -> Option<CtapAuthenticator<'a, T, U>> {
-        token.init().await.ok()?;
+        token
+            .init()
+            .await
+            .map_err(|e| {
+                error!("Error initialising token: {e:?}");
+                e
+            })
+            .ok()?;
         let info = token.transmit(GetInfoRequest {}, ui_callback).await.ok()?;
 
         Self::new_with_info(info, token, ui_callback)

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -72,6 +72,10 @@ pub enum WebauthnCError {
     /// authenticator. You may need to set a PIN, or use a different
     /// authenticator.
     UserVerificationRequired,
+    /// The library is in an unexpected state. This could indicate that
+    /// something has not been initialised correctly, or that the authenticator
+    /// is sending unexpected messages.
+    UnexpectedState,
 }
 
 #[cfg(feature = "nfc")]
@@ -130,7 +134,7 @@ impl From<tokio_tungstenite::tungstenite::error::Error> for WebauthnCError {
     }
 }
 
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "btleplug")]
 impl From<btleplug::Error> for WebauthnCError {
     fn from(v: btleplug::Error) -> Self {
         use btleplug::Error::*;

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -36,11 +36,11 @@
 //!
 //! * [CTAP 2.0, 2.1 and 2.1-PRE protocol implementation][crate::ctap2]
 //! * [caBLE][] (with `--features cable`)
-//! * [Mozilla Authenticator][] (with `--features u2fhid`)
 //! * [NFC][] via PC/SC API (with `--features nfc`)
 //! * [SoftPasskey][] (for testing)
 //! * [SoftToken][] (for testing)
 //! * [USB HID][] (with `--features usb`)
+//! * [Mozilla Authenticator][] (with `--features u2fhid`)
 //! * [Windows 10][] WebAuthn API (with `--features win10`)
 //!
 //! [FIDO2 certified]: https://fidoalliance.org/fido-certified-showcase/

--- a/webauthn-authenticator-rs/src/nfc/mod.rs
+++ b/webauthn-authenticator-rs/src/nfc/mod.rs
@@ -446,7 +446,7 @@ impl Token for NFCCard {
         AuthenticatorTransport::Nfc
     }
 
-    fn cancel(&self) -> Result<(), WebauthnCError> {
+    async fn cancel(&self) -> Result<(), WebauthnCError> {
         // There does not appear to be a "cancel" command over NFC.
         Ok(())
     }

--- a/webauthn-authenticator-rs/src/stubs.rs
+++ b/webauthn-authenticator-rs/src/stubs.rs
@@ -58,14 +58,24 @@ pub mod tokio_tungstenite {
     pub struct WebSocketStream<T> {}
 }
 
-#[cfg(not(feature = "bluetooth"))]
+#[cfg(not(feature = "btleplug"))]
 pub mod btleplug {
     pub mod api {
+        pub struct Central {}
+        pub enum CentralEvent {}
+        pub struct Characteristic {}
+        pub struct Manager {}
+        pub struct Peripheral {}
         pub struct ScanFilter {}
+        pub enum WriteType {}
         pub mod bleuuid {
             pub const fn uuid_from_u16(_: u16) -> uuid::Uuid {
                 uuid::Uuid::nil()
             }
         }
+    }
+    pub mod platform {
+        pub struct Manager {}
+        pub struct Peripheral {}
     }
 }

--- a/webauthn-authenticator-rs/src/transport/mod.rs
+++ b/webauthn-authenticator-rs/src/transport/mod.rs
@@ -3,6 +3,8 @@
 //! See [crate::ctap2] for a higher-level abstraction over this API.
 mod any;
 pub mod iso7816;
+#[cfg(any(doc, feature = "usb"))]
+pub(crate) mod types;
 
 pub use crate::transport::any::{AnyToken, AnyTransport};
 
@@ -89,7 +91,7 @@ pub trait Token: Sized + fmt::Debug + Sync + Send {
         U: UiCallback;
 
     /// Cancels a pending request.
-    fn cancel(&self) -> Result<(), WebauthnCError>;
+    async fn cancel(&self) -> Result<(), WebauthnCError>;
 
     /// Initializes the [Token]
     async fn init(&mut self) -> Result<(), WebauthnCError>;

--- a/webauthn-authenticator-rs/src/transport/types.rs
+++ b/webauthn-authenticator-rs/src/transport/types.rs
@@ -1,28 +1,28 @@
 use crate::error::{CtapError, WebauthnCError};
 
-#[cfg(any(doc, feature = "usb"))]
+#[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 use super::iso7816::ISO7816ResponseAPDU;
 
 pub const TYPE_INIT: u8 = 0x80;
 pub const U2FHID_PING: u8 = TYPE_INIT | 0x01;
 pub const U2FHID_MSG: u8 = TYPE_INIT | 0x03;
-#[cfg(any(doc, feature = "usb"))]
+#[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_INIT: u8 = TYPE_INIT | 0x06;
-#[cfg(any(doc, feature = "usb"))]
+#[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_CBOR: u8 = TYPE_INIT | 0x10;
-#[cfg(any(doc, feature = "usb"))]
+#[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_CANCEL: u8 = TYPE_INIT | 0x11;
-#[cfg(any(doc, feature = "usb"))]
+#[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_KEEPALIVE: u8 = TYPE_INIT | 0x3b;
 pub const U2FHID_ERROR: u8 = TYPE_INIT | 0x3f;
 
 /// Type for parsing all responses from a BTLE or USB FIDO token.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Response {
-    #[cfg(any(doc, feature = "usb"))]
+    #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
     Init(crate::usb::InitResponse),
     Ping(Vec<u8>),
-    #[cfg(any(doc, feature = "usb"))]
+    #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
     Msg(ISO7816ResponseAPDU),
     Cbor(CBORResponse),
     Error(U2FError),

--- a/webauthn-authenticator-rs/src/transport/types.rs
+++ b/webauthn-authenticator-rs/src/transport/types.rs
@@ -1,0 +1,124 @@
+use crate::error::{CtapError, WebauthnCError};
+
+#[cfg(any(doc, feature = "usb"))]
+use super::iso7816::ISO7816ResponseAPDU;
+
+pub const TYPE_INIT: u8 = 0x80;
+pub const U2FHID_PING: u8 = TYPE_INIT | 0x01;
+pub const U2FHID_MSG: u8 = TYPE_INIT | 0x03;
+#[cfg(any(doc, feature = "usb"))]
+pub const U2FHID_INIT: u8 = TYPE_INIT | 0x06;
+#[cfg(any(doc, feature = "usb"))]
+pub const U2FHID_CBOR: u8 = TYPE_INIT | 0x10;
+#[cfg(any(doc, feature = "usb"))]
+pub const U2FHID_CANCEL: u8 = TYPE_INIT | 0x11;
+#[cfg(any(doc, feature = "usb"))]
+pub const U2FHID_KEEPALIVE: u8 = TYPE_INIT | 0x3b;
+pub const U2FHID_ERROR: u8 = TYPE_INIT | 0x3f;
+
+/// Type for parsing all responses from a BTLE or USB FIDO token.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Response {
+    #[cfg(any(doc, feature = "usb"))]
+    Init(crate::usb::InitResponse),
+    Ping(Vec<u8>),
+    #[cfg(any(doc, feature = "usb"))]
+    Msg(ISO7816ResponseAPDU),
+    Cbor(CBORResponse),
+    Error(U2FError),
+    KeepAlive(KeepAliveStatus),
+    Unknown,
+}
+
+/// CTAPv2 CBOR message
+#[derive(Debug, PartialEq, Eq)]
+pub struct CBORResponse {
+    /// Status code
+    pub status: CtapError,
+    /// Data payload
+    pub data: Vec<u8>,
+}
+
+impl TryFrom<&[u8]> for CBORResponse {
+    type Error = WebauthnCError;
+    fn try_from(d: &[u8]) -> Result<Self, Self::Error> {
+        if d.is_empty() {
+            return Err(WebauthnCError::MessageTooShort);
+        }
+        Ok(Self {
+            status: d[0].into(),
+            data: d[1..].to_vec(),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum KeepAliveStatus {
+    Processing,
+    UserPresenceNeeded,
+    Unknown(u8),
+}
+
+impl From<u8> for KeepAliveStatus {
+    fn from(v: u8) -> Self {
+        use KeepAliveStatus::*;
+        match v {
+            1 => Processing,
+            2 => UserPresenceNeeded,
+            v => Unknown(v),
+        }
+    }
+}
+
+impl From<&[u8]> for KeepAliveStatus {
+    fn from(d: &[u8]) -> Self {
+        if !d.is_empty() {
+            Self::from(d[0])
+        } else {
+            Self::Unknown(0)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum U2FError {
+    None,
+    InvalidCommand,
+    InvalidParameter,
+    InvalidMessageLength,
+    InvalidMessageSequencing,
+    MessageTimeout,
+    ChannelBusy,
+    ChannelRequiresLock,
+    SyncCommandFailed,
+    Unspecified,
+    Unknown,
+}
+
+impl From<u8> for U2FError {
+    fn from(v: u8) -> Self {
+        match v {
+            0x00 => U2FError::None,
+            0x01 => U2FError::InvalidCommand,
+            0x02 => U2FError::InvalidParameter,
+            0x03 => U2FError::InvalidMessageLength,
+            0x04 => U2FError::InvalidMessageSequencing,
+            0x05 => U2FError::MessageTimeout,
+            0x06 => U2FError::ChannelBusy,
+            0x0a => U2FError::ChannelRequiresLock,
+            0x0b => U2FError::SyncCommandFailed,
+            0x7f => U2FError::Unspecified,
+            _ => U2FError::Unknown,
+        }
+    }
+}
+
+impl From<&[u8]> for U2FError {
+    fn from(d: &[u8]) -> Self {
+        if !d.is_empty() {
+            U2FError::from(d[0])
+        } else {
+            U2FError::Unknown
+        }
+    }
+}


### PR DESCRIPTION
Changes:

* Replace `bluetooth` feature with `btleplug` for things that need Bluetooth support. The `bluetooth` feature will be used to activate BTLE authenticator support in #272. 
* Make `AnyTransport::new()` and `Token::cancel()` async
* Use proper async stuff in `key_manager`
* Stub more of `btleplug`
* Extract common request handling layer out of `usb` into common module, as Bluetooth tokens use some of the same things
* Add support for USB PING command

Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)

