### PR TITLE
Update Base64 & MSRV to 1.57.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, 1.45.0]
+        rust_version: [stable, 1.57.0]
         features:
           - ""
           - --features cable

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@
 * Eric Mark Martin (ericmarkmartin)
 * Ben Wishovich (benwis)
 * Niklas Pfister (myOmikron)
+* Cynthia Coan (Mythra): cynthia@coan.dev

--- a/base64urlsafedata/Cargo.toml
+++ b/base64urlsafedata/Cargo.toml
@@ -14,5 +14,5 @@ readme = "README.md"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-base64 = "0.13"
+base64 = "0.21"
 serde_json = "1.0"

--- a/base64urlsafedata/src/lib.rs
+++ b/base64urlsafedata/src/lib.rs
@@ -14,7 +14,12 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-use base64::{engine::general_purpose::{GeneralPurpose, STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD}, Engine};
+use base64::{
+    engine::general_purpose::{
+        GeneralPurpose, STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD,
+    },
+    Engine,
+};
 use serde::de::{Error, SeqAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Borrow;
@@ -22,12 +27,8 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::hash::Hash;
 
-static ALLOWED_DECODING_FORMATS: &[GeneralPurpose] = &[
-    URL_SAFE_NO_PAD,
-    URL_SAFE,
-    STANDARD,
-    STANDARD_NO_PAD,
-];
+static ALLOWED_DECODING_FORMATS: &[GeneralPurpose] =
+    &[URL_SAFE_NO_PAD, URL_SAFE, STANDARD, STANDARD_NO_PAD];
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 /// A container for binary that should be base64 encoded in serialisation. In reverse
@@ -36,11 +37,7 @@ pub struct Base64UrlSafeData(pub Vec<u8>);
 
 impl fmt::Display for Base64UrlSafeData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            URL_SAFE_NO_PAD.encode(self)
-        )
+        write!(f, "{}", URL_SAFE_NO_PAD.encode(self))
     }
 }
 

--- a/fido-mds/Cargo.toml
+++ b/fido-mds/Cargo.toml
@@ -13,7 +13,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 compact_jwt = "^0.2.3"
 peg = "0.8.1"
 openssl = { version = "0.10" }

--- a/fido-mds/src/lib.rs
+++ b/fido-mds/src/lib.rs
@@ -39,6 +39,7 @@ use crate::mds::{
 
 use crate::query::{AttrValueAssertion, CompareOp, Query};
 
+use base64::{engine::general_purpose::STANDARD, Engine};
 use compact_jwt::JwtError;
 use std::cmp::Ordering;
 use std::fmt;
@@ -979,7 +980,7 @@ impl TryFrom<RawFidoDevice> for FidoDevice {
                     invalid_metadata = true;
                     None
                 } else {
-                    match base64::decode_config(trim_cert, base64::STANDARD) {
+                    match STANDARD.decode(trim_cert) {
                         Ok(der) => Some(der),
                         Err(e) => {
                             warn!(

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
 serde_json = "1.0"
 nom = "7.1"
-base64 = "0.13"
+base64 = "0.21"
 thiserror = "1.0"
 tracing = "0.1"
 openssl = "0.10.41"

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -1397,8 +1397,11 @@ mod tests {
             None,
         );
 
-        let chal =
-            Challenge::new(STANDARD.decode("+Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc=").unwrap());
+        let chal = Challenge::new(
+            STANDARD
+                .decode("+Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc=")
+                .unwrap(),
+        );
 
         let rsp = r#"
         {
@@ -1439,8 +1442,11 @@ mod tests {
             None,
         );
 
-        let chal =
-            Challenge::new(STANDARD.decode("lP6mWNAtG+/Vv15iM7lb/XRkdWMvVQ+lTyKwZuOg1Vo=").unwrap());
+        let chal = Challenge::new(
+            STANDARD
+                .decode("lP6mWNAtG+/Vv15iM7lb/XRkdWMvVQ+lTyKwZuOg1Vo=")
+                .unwrap(),
+        );
 
         // Example generated using navigator.credentials.create on Chrome Version 77.0.3865.120
         // using Touch ID on MacBook running MacOS 10.15
@@ -1864,8 +1870,11 @@ mod tests {
             None,
         );
 
-        let chal =
-            Challenge::new(STANDARD.decode("tvR1m+d/ohXrwVxQjMgH8KnovHZ7BRWhZmDN4TVMpNU=").unwrap());
+        let chal = Challenge::new(
+            STANDARD
+                .decode("tvR1m+d/ohXrwVxQjMgH8KnovHZ7BRWhZmDN4TVMpNU=")
+                .unwrap(),
+        );
 
         let rsp_d = RegisterPublicKeyCredential {
             id: "uZcVDBVS68E_MtAgeQpElJxldF_6cY9sSvbWqx_qRh8wiu42lyRBRmh5yFeD_r9k130dMbFHBHI9RTFgdJQIzQ".to_string(),

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -1324,6 +1324,7 @@ mod tests {
     use crate::proto::*;
     use crate::WebauthnCore as Webauthn;
     use crate::{internals::*, AttestationFormat};
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use base64urlsafedata::Base64UrlSafeData;
     use url::Url;
 
@@ -1397,7 +1398,7 @@ mod tests {
         );
 
         let chal =
-            Challenge::new(base64::decode("+Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc").unwrap());
+            Challenge::new(STANDARD.decode("+Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc=").unwrap());
 
         let rsp = r#"
         {
@@ -1439,7 +1440,7 @@ mod tests {
         );
 
         let chal =
-            Challenge::new(base64::decode("lP6mWNAtG+/Vv15iM7lb/XRkdWMvVQ+lTyKwZuOg1Vo=").unwrap());
+            Challenge::new(STANDARD.decode("lP6mWNAtG+/Vv15iM7lb/XRkdWMvVQ+lTyKwZuOg1Vo=").unwrap());
 
         // Example generated using navigator.credentials.create on Chrome Version 77.0.3865.120
         // using Touch ID on MacBook running MacOS 10.15
@@ -1864,19 +1865,19 @@ mod tests {
         );
 
         let chal =
-            Challenge::new(base64::decode("tvR1m+d/ohXrwVxQjMgH8KnovHZ7BRWhZmDN4TVMpNU=").unwrap());
+            Challenge::new(STANDARD.decode("tvR1m+d/ohXrwVxQjMgH8KnovHZ7BRWhZmDN4TVMpNU=").unwrap());
 
         let rsp_d = RegisterPublicKeyCredential {
             id: "uZcVDBVS68E_MtAgeQpElJxldF_6cY9sSvbWqx_qRh8wiu42lyRBRmh5yFeD_r9k130dMbFHBHI9RTFgdJQIzQ".to_string(),
             raw_id: Base64UrlSafeData(
-                base64::decode("uZcVDBVS68E/MtAgeQpElJxldF/6cY9sSvbWqx/qRh8wiu42lyRBRmh5yFeD/r9k130dMbFHBHI9RTFgdJQIzQ==").unwrap()
+                STANDARD.decode("uZcVDBVS68E/MtAgeQpElJxldF/6cY9sSvbWqx/qRh8wiu42lyRBRmh5yFeD/r9k130dMbFHBHI9RTFgdJQIzQ==").unwrap()
             ),
             response: AuthenticatorAttestationResponseRaw {
                 attestation_object: Base64UrlSafeData(
-                    base64::decode("o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIhAKAZODmj+uF5qXsDY2NFol3apRjld544KRUpHzwfk5cbAiBnp2gHmamr2xr46ilQuhzIR9BwMlwtxWd6IT2QEYeo7WN4NWOBWQLBMIICvTCCAaWgAwIBAgIEK/F8eDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNzM3MjQ2MzI4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdMLHhCPIcS6bSPJZWGb8cECuTN8H13fVha8Ek5nt+pI8vrSflxb59Vp4bDQlH8jzXj3oW1ZwUDjHC6EnGWB5i6NsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCAiQwIQYLKwYBBAGC5RwBAQQEEgQQxe9V/62aS5+1gK3rr+Am0DAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCLbpN2nXhNbunZANJxAn/Cd+S4JuZsObnUiLnLLS0FPWa01TY8F7oJ8bE+aFa4kTe6NQQfi8+yiZrQ8N+JL4f7gNdQPSrH+r3iFd4SvroDe1jaJO4J9LeiFjmRdcVa+5cqNF4G1fPCofvw9W4lKnObuPakr0x/icdVq1MXhYdUtQk6Zr5mBnc4FhN9qi7DXqLHD5G7ZFUmGwfIcD2+0m1f1mwQS8yRD5+/aDCf3vutwddoi3crtivzyromwbKklR4qHunJ75LGZLZA8pJ/mXnUQ6TTsgRqPvPXgQPbSyGMf2z/DIPbQqCD/Bmc4dj9o6LozheBdDtcZCAjSPTAd/uiaGF1dGhEYXRhWMS3tF916xTswLEZrAO3fy8EzMmvvR8f5wWM7F5+4KJ0ikEAAAACxe9V/62aS5+1gK3rr+Am0ABAuZcVDBVS68E/MtAgeQpElJxldF/6cY9sSvbWqx/qRh8wiu42lyRBRmh5yFeD/r9k130dMbFHBHI9RTFgdJQIzaUBAgMmIAEhWCDCfn9t/BeDFfwG32Ms/owb5hFeBYUcaCmQRauVoRrI8yJYII97t5wYshX4dZ+iRas0vPwaOwYvZ1wTOnVn+QDbCF/E").unwrap()
+                    STANDARD.decode("o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIhAKAZODmj+uF5qXsDY2NFol3apRjld544KRUpHzwfk5cbAiBnp2gHmamr2xr46ilQuhzIR9BwMlwtxWd6IT2QEYeo7WN4NWOBWQLBMIICvTCCAaWgAwIBAgIEK/F8eDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNzM3MjQ2MzI4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdMLHhCPIcS6bSPJZWGb8cECuTN8H13fVha8Ek5nt+pI8vrSflxb59Vp4bDQlH8jzXj3oW1ZwUDjHC6EnGWB5i6NsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCAiQwIQYLKwYBBAGC5RwBAQQEEgQQxe9V/62aS5+1gK3rr+Am0DAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCLbpN2nXhNbunZANJxAn/Cd+S4JuZsObnUiLnLLS0FPWa01TY8F7oJ8bE+aFa4kTe6NQQfi8+yiZrQ8N+JL4f7gNdQPSrH+r3iFd4SvroDe1jaJO4J9LeiFjmRdcVa+5cqNF4G1fPCofvw9W4lKnObuPakr0x/icdVq1MXhYdUtQk6Zr5mBnc4FhN9qi7DXqLHD5G7ZFUmGwfIcD2+0m1f1mwQS8yRD5+/aDCf3vutwddoi3crtivzyromwbKklR4qHunJ75LGZLZA8pJ/mXnUQ6TTsgRqPvPXgQPbSyGMf2z/DIPbQqCD/Bmc4dj9o6LozheBdDtcZCAjSPTAd/uiaGF1dGhEYXRhWMS3tF916xTswLEZrAO3fy8EzMmvvR8f5wWM7F5+4KJ0ikEAAAACxe9V/62aS5+1gK3rr+Am0ABAuZcVDBVS68E/MtAgeQpElJxldF/6cY9sSvbWqx/qRh8wiu42lyRBRmh5yFeD/r9k130dMbFHBHI9RTFgdJQIzaUBAgMmIAEhWCDCfn9t/BeDFfwG32Ms/owb5hFeBYUcaCmQRauVoRrI8yJYII97t5wYshX4dZ+iRas0vPwaOwYvZ1wTOnVn+QDbCF/E").unwrap()
                 ),
                 client_data_json: Base64UrlSafeData(
-                    base64::decode("eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwib3JpZ2luIjoiaHR0cHM6XC9cLzE3Mi4yMC4wLjE0MTo4NDQzIiwiY2hhbGxlbmdlIjoidHZSMW0tZF9vaFhyd1Z4UWpNZ0g4S25vdkhaN0JSV2habURONFRWTXBOVSJ9").unwrap()
+                    STANDARD.decode("eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwib3JpZ2luIjoiaHR0cHM6XC9cLzE3Mi4yMC4wLjE0MTo4NDQzIiwiY2hhbGxlbmdlIjoidHZSMW0tZF9vaFhyd1Z4UWpNZ0g4S25vdkhaN0JSV2habURONFRWTXBOVSJ9").unwrap()
                 ),
                 transports: None,
             },

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -1290,6 +1290,7 @@ mod tests {
         RegisterPublicKeyCredential, Registration, RegistrationSignedExtensions, TpmsAttest,
         TpmtPublic, TpmtSignature, TPM_GENERATED_VALUE,
     };
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use crate::interface::*;
     use std::convert::TryFrom;
 
@@ -1310,7 +1311,7 @@ mod tests {
 
     #[test]
     fn deserialise_attestation_object() {
-        let raw_ao = base64::decode(
+        let raw_ao = STANDARD.decode(
             "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEEsoXtJryKJQ28wPgFmAwoh5SXSZuIJJnQzgBqP1AcaBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQCgxaVISCxE+DrcxP5/+aPM88CTI+04J+o61SK6mnepjGZYv062AbtydzWmbAxF00VSAyp0ImP94uoy+0y7w9yilAQIDJiABIVggGT9woA+UoX+jBxuiHQpdkm0kCVh75WTj3TXl4zLJuzoiWCBKiCneKgWJgWiwrZedNwl06GTaXyaGrYS4bPbBraInyg=="
         ).unwrap();
 

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -1290,8 +1290,8 @@ mod tests {
         RegisterPublicKeyCredential, Registration, RegistrationSignedExtensions, TpmsAttest,
         TpmtPublic, TpmtSignature, TPM_GENERATED_VALUE,
     };
-    use base64::{engine::general_purpose::STANDARD, Engine};
     use crate::interface::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use std::convert::TryFrom;
 
     #[test]


### PR DESCRIPTION
Fixes #278 

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)

this upgrades all of the crates within webauthn-rs to using base64
to the latest version 0.21. the interface changed significantly
since 0.13, and although i'm not a huge fan of it, receiving updates
is good, and this is the last crate in my workspace that needs updating
so here i am updating the crate :)

lemme know if there's anything you'd like changed with how we call
the new API's!