### PR TITLE
Update base64urlsafedata

### DIFF
--- a/base64urlsafedata/Cargo.toml
+++ b/base64urlsafedata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64urlsafedata"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
 description = "Base 64 Url Safe wrapper for Serde"


### PR DESCRIPTION
Update the Cargo.toml version as I intend to publish an update to the base64urlsafe data support crate. 

- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
