### PR TITLE
20230220 opportunistic cred protect

### DIFF
--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -665,6 +665,8 @@ impl Webauthn {
         };
 
         let cred_protect = if self.user_presence_only_security_keys {
+            None
+        } else {
             Some(CredProtect {
                     // We want the device to strictly enforce it's UV state.
                     credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
@@ -672,8 +674,6 @@ impl Webauthn {
                     // have the same strict rules about attestation, then we just use this opportunistically.
                     enforce_credential_protection_policy: Some(false),
                 })
-        } else {
-            None
         };
 
         let extensions = Some(RequestRegistrationExtensions {

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -668,12 +668,12 @@ impl Webauthn {
             None
         } else {
             Some(CredProtect {
-                    // We want the device to strictly enforce it's UV state.
-                    credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
-                    // If set to true, causes many authenticators to shit the bed. Since this type doesn't
-                    // have the same strict rules about attestation, then we just use this opportunistically.
-                    enforce_credential_protection_policy: Some(false),
-                })
+                // We want the device to strictly enforce it's UV state.
+                credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
+                // If set to true, causes many authenticators to shit the bed. Since this type doesn't
+                // have the same strict rules about attestation, then we just use this opportunistically.
+                enforce_credential_protection_policy: Some(false),
+            })
         };
 
         let extensions = Some(RequestRegistrationExtensions {


### PR DESCRIPTION
This improves protection of created credentials that are capable of cred protect, by requesting the extension opportunistically or as a requirement. 

- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
