### PR TITLE
Resolve potential client side UV bypass in passkeys

### DIFF
--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -427,7 +427,7 @@ impl Webauthn {
         let credential_algorithms = self.algorithms.clone();
         let require_resident_key = false;
         let authenticator_attachment = None;
-        let policy = Some(UserVerificationPolicy::Preferred);
+        let policy = Some(UserVerificationPolicy::Required);
         let reject_passkeys = false;
 
         let extensions = Some(RequestRegistrationExtensions {
@@ -502,7 +502,7 @@ impl Webauthn {
     ) -> WebauthnResult<(RequestChallengeResponse, PasskeyAuthentication)> {
         let extensions = None;
         let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
-        let policy = UserVerificationPolicy::Preferred;
+        let policy = UserVerificationPolicy::Required;
         let allow_backup_eligible_upgrade = true;
 
         self.core


### PR DESCRIPTION
Fixes #281 In response to this issue we should take proactive steps to prevent client side UV bypassing in our apis. Since firefox is soon to gain CTAP2 support, being the last limiting factor for this, I believe it's time to enforce required UV in passkey flows. Since this won't be released for a bit until some other library changes occur, we can wait for ff to support this by default. 

- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
