### PR TITLE
Fix PIN Protocol 2 implementation, and add a test.

### DIFF
--- a/webauthn-authenticator-rs/src/ctap2/ctap20.rs
+++ b/webauthn-authenticator-rs/src/ctap2/ctap20.rs
@@ -192,10 +192,8 @@ impl<'a, T: Token, U: UiCallback> Ctap20Authenticator<'a, T, U> {
 
         Ok(match session {
             AuthSession::InterfaceToken(iface, pin_token) => {
-                let mut pin_uv_auth_param =
+                let pin_uv_auth_param =
                     iface.authenticate(pin_token.as_slice(), client_data_hash)?;
-                pin_uv_auth_param.truncate(16);
-
                 AuthToken::ProtocolToken(iface.get_pin_uv_protocol(), pin_uv_auth_param)
             }
 


### PR DESCRIPTION
It looks like Token2 implemented this correctly, but Yubikey did not.

Fixes #269

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
