### PR TITLE
Null pointer dereference for GetAssertion on Windows 10

### DIFF
--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -318,7 +318,11 @@ impl AuthenticatorBackend for Win10 {
                 .to_string()
                 .map_err(|_| WebauthnCError::Internal)?;
 
-            let mut extensions = native_to_assertion_extensions(&a.Extensions)?;
+            let mut extensions = if a.dwVersion >= 2 {
+                native_to_assertion_extensions(&a.Extensions)?
+            } else {
+                Default::default()
+            };
             extensions.appid = Some(app_id_used.into());
 
             Ok(PublicKeyCredential {


### PR DESCRIPTION
Windows 10 returns a `WEBAUTHN_ASSERTION` with `dwVersion = 1` if there are no extensions.

It appears this only triggers a null pointer dereference when using a platform authenticator, because it returns an uninitialised `Extensions.cExtensions` value which then ends in dereferencing a null `PCWSTR`:

```
(4ef8.5710): Access violation - code c0000005 (first chance)
First chance exceptions are reported before any exception handling.
This exception may be expected and handled.
*** WARNING: Unable to verify checksum for authenticate.exe
authenticate!windows::core::strings::pcwstr::PCWSTR::as_wide+0xe:
00007ff7`e8e5f39e 488b09          mov     rcx,qword ptr [rcx] ds:00000000`00000000=????????????????
0:000> k
 # Child-SP          RetAddr               Call Site
00 000000be`ff9e9fa0 00007ff7`e8e5f3f5     authenticate!windows::core::strings::pcwstr::PCWSTR::as_wide+0xe [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\windows-0.41.0\src\core\strings\pcwstr.rs @ 35] 
01 000000be`ff9e9fe0 00007ff7`e8dc67c6     authenticate!windows::core::strings::pcwstr::PCWSTR::to_string+0x25 [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\windows-0.41.0\src\core\strings\pcwstr.rs @ 45] 
02 000000be`ff9ea030 00007ff7`e8dc6f20     authenticate!webauthn_authenticator_rs::win10::extensions::impl$3::try_from+0x36 [C:\Users\admin\Documents\webauthn-rs\webauthn-authenticator-rs\src\win10\extensions.rs @ 227] 
03 000000be`ff9ea420 00007ff7`e8db66ff     authenticate!webauthn_authenticator_rs::win10::extensions::native_to_assertion_extensions+0x120 [C:\Users\admin\Documents\webauthn-rs\webauthn-authenticator-rs\src\win10\extensions.rs @ 251] 
04 000000be`ff9ea5f0 00007ff7`e8aa430e     authenticate!webauthn_authenticator_rs::win10::impl$1::perform_auth+0xfbf [C:\Users\admin\Documents\webauthn-rs\webauthn-authenticator-rs\src\win10\mod.rs @ 321] 
05 000000be`ff9eb520 00007ff7`e8a7d3d0     authenticate!authenticate::main::async_block$0+0x168e [C:\Users\admin\Documents\webauthn-rs\webauthn-authenticator-rs\examples\authenticate\main.rs @ 228] 
06 000000be`ff9ed250 00007ff7`e8a7d1ac     authenticate!tokio::runtime::park::impl$4::block_on::closure$0<enum2$<authenticate::main::async_block_env$0> >+0x40 [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\park.rs @ 283] 
07 (Inline Function) --------`--------     authenticate!tokio::runtime::coop::with_budget+0x58 [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\coop.rs @ 102] 
08 (Inline Function) --------`--------     authenticate!tokio::runtime::coop::budget+0xa8 [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\coop.rs @ 68] 
09 000000be`ff9ed2b0 00007ff7`e8a79776     authenticate!tokio::runtime::park::CachedParkThread::block_on<enum2$<authenticate::main::async_block_env$0> >+0x20c [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\park.rs @ 283] 
0a 000000be`ff9ed7e0 00007ff7`e8a9bdab     authenticate!tokio::runtime::context::BlockingRegionGuard::block_on<enum2$<authenticate::main::async_block_env$0> >+0x66 [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\context.rs @ 315] 
0b 000000be`ff9edc20 00007ff7`e8a956a5     authenticate!tokio::runtime::scheduler::multi_thread::MultiThread::block_on<enum2$<authenticate::main::async_block_env$0> >+0x7b [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\scheduler\multi_thread\mod.rs @ 66] 
0c 000000be`ff9ee080 00007ff7`e8a980ea     authenticate!tokio::runtime::runtime::Runtime::block_on<enum2$<authenticate::main::async_block_env$0> >+0x105 [C:\Users\admin\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.24.2\src\runtime\runtime.rs @ 284] 
0d 000000be`ff9ee8e0 00007ff7`e8a79ccb     authenticate!authenticate::main+0xda [C:\Users\admin\Documents\webauthn-rs\webauthn-authenticator-rs\examples\authenticate\main.rs @ 213] 
0e 000000be`ff9ef610 00007ff7`e8a9ef2e     authenticate!core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483\library\core\src\ops\function.rs @ 507] 
0f (Inline Function) --------`--------     authenticate!core::hint::black_box [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483\library\core\src\hint.rs @ 226] 
10 000000be`ff9ef650 00007ff7`e8a9ecd1     authenticate!std::sys_common::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >+0xe [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483\library\std\src\sys_common\backtrace.rs @ 124] 
11 000000be`ff9ef680 00007ff7`e930c10e     authenticate!std::rt::lang_start::closure$0<tuple$<> >+0x11 [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483\library\std\src\rt.rs @ 166] 
12 (Inline Function) --------`--------     authenticate!core::ops::function::impls::impl$2::call_once+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\core\src\ops\function.rs @ 606] 
13 (Inline Function) --------`--------     authenticate!std::panicking::try::do_call+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\panicking.rs @ 483] 
14 (Inline Function) --------`--------     authenticate!std::panicking::try+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\panicking.rs @ 447] 
15 (Inline Function) --------`--------     authenticate!std::panic::catch_unwind+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\panic.rs @ 137] 
16 (Inline Function) --------`--------     authenticate!std::rt::lang_start_internal::closure$2+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\rt.rs @ 148] 
17 (Inline Function) --------`--------     authenticate!std::panicking::try::do_call+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\panicking.rs @ 483] 
18 (Inline Function) --------`--------     authenticate!std::panicking::try+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\panicking.rs @ 447] 
19 (Inline Function) --------`--------     authenticate!std::panic::catch_unwind+0xb [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\panic.rs @ 137] 
1a 000000be`ff9ef6c0 00007ff7`e8a9ecaa     authenticate!std::rt::lang_start_internal+0xbe [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library\std\src\rt.rs @ 148] 
1b 000000be`ff9ef810 00007ff7`e8a981c9     authenticate!std::rt::lang_start<tuple$<> >+0x3a [/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483\library\std\src\rt.rs @ 165] 
1c 000000be`ff9ef880 00007ff7`e9588710     authenticate!main+0x19
1d (Inline Function) --------`--------     authenticate!invoke_main+0x22 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 78] 
1e 000000be`ff9ef8b0 00007fff`bbb87614     authenticate!__scrt_common_main_seh+0x10c [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 288] 
1f 000000be`ff9ef8f0 00007fff`bd5c26a1     KERNEL32!BaseThreadInitThunk+0x14
20 000000be`ff9ef920 00000000`00000000     ntdll!RtlUserThreadStart+0x21
```

When using a physical key on Windows 10, `Extensions.cExtensions = 0` so it doesn't hit this issue.

Fixes #262

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
