### PR TITLE
clippy: fix multiple issues

### DIFF
--- a/compat_tester/webauthn-rs-demo-shared/src/lib.rs
+++ b/compat_tester/webauthn-rs-demo-shared/src/lib.rs
@@ -234,8 +234,9 @@ impl CTestAttestState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub enum CTestAuthState {
+    #[default]
     NotTested,
     FailedPrerequisite,
     Passed {
@@ -253,12 +254,6 @@ pub enum CTestAuthState {
         rcr: Option<RequestChallengeResponse>,
         pkc: Option<PublicKeyCredential>,
     },
-}
-
-impl Default for CTestAuthState {
-    fn default() -> Self {
-        CTestAuthState::NotTested
-    }
 }
 
 impl CTestAuthState {
@@ -347,19 +342,14 @@ impl CTestAuthState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub enum CTestSimpleState {
+    #[default]
     NotTested,
     FailedPrerequisite,
     Passed,
     Warning,
     Failed,
-}
-
-impl Default for CTestSimpleState {
-    fn default() -> Self {
-        CTestSimpleState::NotTested
-    }
 }
 
 impl CTestSimpleState {

--- a/compat_tester/webauthn-rs-demo-shared/src/lib.rs
+++ b/compat_tester/webauthn-rs-demo-shared/src/lib.rs
@@ -112,8 +112,9 @@ pub struct AuthenticationSuccess {
     pub extensions: AuthenticationExtensions,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub enum CTestAttestState {
+    #[default]
     NotTested,
     Passed {
         rs: RegistrationSuccess,
@@ -130,12 +131,6 @@ pub enum CTestAttestState {
         ccr: Option<CreationChallengeResponse>,
         rpkc: Option<RegisterPublicKeyCredential>,
     },
-}
-
-impl Default for CTestAttestState {
-    fn default() -> Self {
-        CTestAttestState::NotTested
-    }
 }
 
 impl CTestAttestState {

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -75,8 +75,8 @@ tempfile = { version = "3.3.0" }
 serialport = { version = "4.2.0" }
 serialport-hci = { git = "https://github.com/micolous/serialport-hci.git", rev = "7931ad32510ac162f9c4e1147bdd411e40cffa0e" }
 bluetooth-hci = { git = "https://github.com/micolous/bluetooth-hci.git", rev = "04f98f734b0b9f0304e433335357307f63f6bc26" }
-bardecoder = "0.4.0"
-image = "0.23"
+bardecoder = "=0.4.1"
+image = "=0.23.14"
 
 [build-dependencies]
 openssl = "0.10"

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -75,8 +75,11 @@ tempfile = { version = "3.3.0" }
 serialport = { version = "4.2.0" }
 serialport-hci = { git = "https://github.com/micolous/serialport-hci.git", rev = "7931ad32510ac162f9c4e1147bdd411e40cffa0e" }
 bluetooth-hci = { git = "https://github.com/micolous/bluetooth-hci.git", rev = "04f98f734b0b9f0304e433335357307f63f6bc26" }
-bardecoder = "=0.4.1"
-image = "=0.23.14"
+
+# image version needs to match bardecoder's version:
+# https://github.com/piderman314/bardecoder/blame/master/Cargo.toml
+bardecoder = "=0.4.0"
+image = ">= 0.23.14, < 0.24"
 
 [build-dependencies]
 openssl = "0.10"

--- a/webauthn-authenticator-rs/examples/authenticate/main.rs
+++ b/webauthn-authenticator-rs/examples/authenticate/main.rs
@@ -141,9 +141,9 @@ impl Provider {
                     .unwrap(),
             ),
             #[cfg(feature = "u2fhid")]
-            Provider::Mozilla => Box::new(webauthn_authenticator_rs::u2fhid::U2FHid::default()),
+            Provider::Mozilla => Box::<webauthn_authenticator_rs::u2fhid::U2FHid>::default(),
             #[cfg(feature = "win10")]
-            Provider::Win10 => Box::new(webauthn_authenticator_rs::win10::Win10::default()),
+            Provider::Win10 => Box::<webauthn_authenticator_rs::win10::Win10>::default(),
         }
     }
 }

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -155,7 +155,7 @@ impl Discovery {
     /// Derives the pre-shared key for an [Eid] targetting this [Discovery]
     pub fn derive_psk(&self, eid: &Eid) -> Result<Psk, WebauthnCError> {
         let mut psk: Psk = [0; size_of::<Psk>()];
-        DerivedValueType::Psk.derive(&self.qr_secret, &eid.to_bytes(), &mut psk)?;
+        DerivedValueType::Psk.derive(&self.qr_secret, &eid.as_bytes(), &mut psk)?;
         Ok(psk)
     }
 
@@ -222,7 +222,7 @@ impl Eid {
     }
 
     /// Converts this [Eid] into unencrypted bytes.
-    fn to_bytes(&self) -> CableEid {
+    fn as_bytes(&self) -> CableEid {
         let mut o: CableEid = [0; size_of::<CableEid>()];
         let mut p = 1;
         let mut q = p + size_of::<BleNonce>();
@@ -321,7 +321,7 @@ impl Eid {
     ///
     /// See [Discovery::encrypt_advert] for a public API.
     fn encrypt_advert(&self, key: &EidKey) -> Result<BleAdvert, WebauthnCError> {
-        let eid = self.to_bytes();
+        let eid = self.as_bytes();
         let c = encrypt(&key[..32], None, &eid)?;
 
         let mut crypted: BleAdvert = [0; size_of::<BleAdvert>()];

--- a/webauthn-authenticator-rs/src/nfc/atr.rs
+++ b/webauthn-authenticator-rs/src/nfc/atr.rs
@@ -325,7 +325,7 @@ mod tests {
         assert_eq!(expected_protocols, a1.protocols);
         assert_eq!(None, a1.command_chaining);
         assert_eq!(None, a1.extended_lc);
-        assert_eq!(false, a1.storage_card);
+        assert!(!a1.storage_card);
 
         let i2 = [0x3b, 0x84, 0x80, 0x01, 0x80, 0x71, 0xc0, 0x21, 0x15];
         let a2 = Atr::try_from(&i2[..]).expect("short caps atr2");
@@ -333,7 +333,7 @@ mod tests {
         assert_eq!(expected_protocols, a2.protocols);
         assert_eq!(None, a2.command_chaining);
         assert_eq!(None, a2.extended_lc);
-        assert_eq!(false, a2.storage_card);
+        assert!(!a2.storage_card);
     }
 
     #[test]

--- a/webauthn-authenticator-rs/src/usb/responses.rs
+++ b/webauthn-authenticator-rs/src/usb/responses.rs
@@ -382,7 +382,7 @@ mod tests {
 
         let frames: Vec<U2FHIDFrame> = d
             .iter()
-            .map(|f| <U2FHIDFrame>::try_from(f))
+            .map(<U2FHIDFrame>::try_from)
             .collect::<Result<Vec<U2FHIDFrame>, WebauthnCError>>()
             .unwrap();
 

--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -357,12 +357,13 @@ impl From<web_sys::AuthenticationExtensionsClientOutputs> for RegistrationExtens
 }
 
 /// The result state of an extension as returned from the authenticator.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum ExtnState<T>
 where
     T: Clone + std::fmt::Debug,
 {
     /// This extension was not requested, and so no result was provided.
+    #[default]
     NotRequested,
     /// The extension was requested, and the authenticator did NOT act on it.
     Ignored,
@@ -373,15 +374,6 @@ where
     /// ⚠️  WARNING: The data in this extension is not signed cryptographically, and can not be
     /// trusted for security assertions. It MAY be used for UI/UX hints.
     Unsigned(T),
-}
-
-impl<T> Default for ExtnState<T>
-where
-    T: Clone + std::fmt::Debug,
-{
-    fn default() -> Self {
-        ExtnState::NotRequested
-    }
 }
 
 /// The set of extensions that were registered by this credential.

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -33,7 +33,7 @@ pub type CredentialID = Base64UrlSafeData;
 /// that is is NOT possible assert verification has been bypassed or not from the server
 /// viewpoint, and to the user it may create confusion about when verification is or is
 /// not required.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
 #[serde(rename_all = "lowercase")]
 pub enum UserVerificationPolicy {
@@ -43,16 +43,11 @@ pub enum UserVerificationPolicy {
     Required,
     /// TO FILL IN
     #[serde(rename = "preferred")]
+    #[default]
     Preferred,
     /// TO FILL IN
     #[serde(rename = "discouraged")]
     Discouraged_DO_NOT_USE,
-}
-
-impl Default for UserVerificationPolicy {
-    fn default() -> Self {
-        UserVerificationPolicy::Preferred
-    }
 }
 
 /// Relying Party Entity

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -1228,13 +1228,14 @@ impl Webauthn {
 
 #[test]
 /// Test that building a webauthn object from a chrome extension origin is successful.
-fn test_webauthnbuilder_chrome_url() {
+fn test_webauthnbuilder_chrome_url() -> Result<(), Box<dyn std::error::Error>> {
     use crate::prelude::*;
     let rp_id = "2114c9f524d0cbd74dbe846a51c3e5b34b83ac02c5220ec5cdff751096fa25a5";
-    let rp_origin = Url::parse(&format!("chrome-extension://{rp_id}")).expect("Invalid URL");
+    let rp_origin = Url::parse(&format!("chrome-extension://{rp_id}"))?;
     eprintln!("{rp_origin:?}");
-    let builder = WebauthnBuilder::new(rp_id, &rp_origin).expect("Invalid configuration");
+    let builder = WebauthnBuilder::new(rp_id, &rp_origin)?;
     eprintln!("rp_id: {:?}", builder.rp_id);
-    let built = builder.build().expect("Failed to build");
+    let built = builder.build()?;
     eprintln!("rp_name: {}", built.core.rp_name());
+    Ok(())
 }


### PR DESCRIPTION
Fixes multiple clippy failures in CI:

* (error) `derivable_impls` for many `Default` implementations (added in new clippy)
* (error) `expect_used` regressions missed in #289
* (error) mismatched `image` library versions from `bardecoder`
* (warning) `wrong_self_convention` in `Eid::to_bytes()`
* (warning) `bool_assert_comparison` in `nfc/atr.rs` tests
* (warning) `box_default`  in multiple places

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
