### PR TITLE
Fix CI failure in clippy check

### DIFF
--- a/compat_tester/webauthn-rs-demo-shared/src/lib.rs
+++ b/compat_tester/webauthn-rs-demo-shared/src/lib.rs
@@ -112,8 +112,9 @@ pub struct AuthenticationSuccess {
     pub extensions: AuthenticationExtensions,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub enum CTestAttestState {
+    #[default]
     NotTested,
     Passed {
         rs: RegistrationSuccess,
@@ -130,12 +131,6 @@ pub enum CTestAttestState {
         ccr: Option<CreationChallengeResponse>,
         rpkc: Option<RegisterPublicKeyCredential>,
     },
-}
-
-impl Default for CTestAttestState {
-    fn default() -> Self {
-        CTestAttestState::NotTested
-    }
 }
 
 impl CTestAttestState {
@@ -239,8 +234,9 @@ impl CTestAttestState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub enum CTestAuthState {
+    #[default]
     NotTested,
     FailedPrerequisite,
     Passed {
@@ -258,12 +254,6 @@ pub enum CTestAuthState {
         rcr: Option<RequestChallengeResponse>,
         pkc: Option<PublicKeyCredential>,
     },
-}
-
-impl Default for CTestAuthState {
-    fn default() -> Self {
-        CTestAuthState::NotTested
-    }
 }
 
 impl CTestAuthState {
@@ -352,19 +342,14 @@ impl CTestAuthState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub enum CTestSimpleState {
+    #[default]
     NotTested,
     FailedPrerequisite,
     Passed,
     Warning,
     Failed,
-}
-
-impl Default for CTestSimpleState {
-    fn default() -> Self {
-        CTestSimpleState::NotTested
-    }
 }
 
 impl CTestSimpleState {

--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -357,12 +357,13 @@ impl From<web_sys::AuthenticationExtensionsClientOutputs> for RegistrationExtens
 }
 
 /// The result state of an extension as returned from the authenticator.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub enum ExtnState<T>
 where
     T: Clone + std::fmt::Debug,
 {
     /// This extension was not requested, and so no result was provided.
+    #[default]
     NotRequested,
     /// The extension was requested, and the authenticator did NOT act on it.
     Ignored,
@@ -373,15 +374,6 @@ where
     /// ⚠️  WARNING: The data in this extension is not signed cryptographically, and can not be
     /// trusted for security assertions. It MAY be used for UI/UX hints.
     Unsigned(T),
-}
-
-impl<T> Default for ExtnState<T>
-where
-    T: Clone + std::fmt::Debug,
-{
-    fn default() -> Self {
-        ExtnState::NotRequested
-    }
 }
 
 /// The set of extensions that were registered by this credential.

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -33,7 +33,7 @@ pub type CredentialID = Base64UrlSafeData;
 /// that is is NOT possible assert verification has been bypassed or not from the server
 /// viewpoint, and to the user it may create confusion about when verification is or is
 /// not required.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[allow(non_camel_case_types)]
 #[serde(rename_all = "lowercase")]
 pub enum UserVerificationPolicy {
@@ -42,17 +42,12 @@ pub enum UserVerificationPolicy {
     /// usable with this policy.
     Required,
     /// TO FILL IN
+    #[default]
     #[serde(rename = "preferred")]
     Preferred,
     /// TO FILL IN
     #[serde(rename = "discouraged")]
     Discouraged_DO_NOT_USE,
-}
-
-impl Default for UserVerificationPolicy {
-    fn default() -> Self {
-        UserVerificationPolicy::Preferred
-    }
 }
 
 /// Relying Party Entity


### PR DESCRIPTION
CI check in #292 fails because of clippy errors that are fixed by this PR. 

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
