### PR TITLE
Fix broken deviceplug commit due to force-push of dev branch

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -60,7 +60,7 @@ futures = "0.3.25"
 qrcode = { version = "^0.12.0", optional = true }
 # btleplug pinned due to https://github.com/deviceplug/btleplug/issues/289
 # Advertisements for the same device get dropped by bluez (Linux).
-btleplug = { git = "https://github.com/deviceplug/btleplug.git", rev = "bb3212df36cfd00a1d5788de790240858847a5f1", optional = true }
+btleplug = { git = "https://github.com/deviceplug/btleplug.git", rev = "6cf2e8a56c73042a5e263e3afbd20603c6c8f4c0", optional = true }
 tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"], optional = true }
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"], optional = true }
 hex = { version = "0.4.3", optional = true }


### PR DESCRIPTION
We were pinning a commit of `deviceplug` for a Linux-specific bug fix; but this was only on the upstream `dev` branch.

That commit got stomped due to a force-push of that branch: https://github.com/deviceplug/btleplug/pull/302#issuecomment-1503946059