### PR TITLE
Switch to dtolnay/rust-toolchain, bump MSRV to 1.66.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
+          components: clippy, rustfmt
 
       - if: runner.os != 'windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, 1.63.0]
+        rust_version: [stable, 1.66.0]
         features:
           - ""
           - --features cable
@@ -30,7 +30,7 @@ jobs:
             rust_version: stable
         exclude:
           - os: windows-latest
-            rust_version: 1.63.0
+            rust_version: 1.66.0
 
     name: Build and Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, 1.60.0]
+        rust_version: [stable, 1.63.0]
         features:
           - ""
           - --features cable
@@ -30,7 +30,7 @@ jobs:
             rust_version: stable
         exclude:
           - os: windows-latest
-            rust_version: 1.60.0
+            rust_version: 1.63.0
 
     name: Build and Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
 
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, 1.57.0]
+        rust_version: [stable, 1.60.0]
         features:
           - ""
           - --features cable
@@ -30,7 +30,7 @@ jobs:
             rust_version: stable
         exclude:
           - os: windows-latest
-            rust_version: 1.45.0
+            rust_version: 1.60.0
 
     name: Build and Test
     runs-on: ${{ matrix.os }}

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -3,6 +3,7 @@ name = "webauthn-rs-proto"
 version = "0.5.0-dev"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 description = "Webauthn Specification Bindings"
 repository = "https://github.com/kanidm/webauthn-rs"
 readme = "README.md"


### PR DESCRIPTION
`actions-rs/toolchain` appears unmaintained, it didn't build with the proper compiler version (unsure whether this was an error in the config), and depends on an old version of NodeJS which is deprecated (and makes noisy warnings).

[All the cool kids][0] are using https://github.com/dtolnay/rust-toolchain

Because this Action actually enforces MSRV checks and uses the correct compiler version, this uncovered some problems:

* https://github.com/kanidm/webauthn-rs/pull/258 bumped axum to 0.6.1, and [its MSRV is 1.60.0][1] ([log][2])
* There are multiple transitive dependencies on `time v0.3.20`, which [requires rustc 1.63.0][3].
* https://github.com/kanidm/webauthn-rs/pull/293 changed to using derived `Default` impl (to address a clippy lint), which only works properly on `rustc >= 1.66.0`, which has a weird compile error:

```
error[E0277]: the trait bound `CredentialProtectionPolicy: std::default::Default` is not satisfied
   --> webauthn-rs-proto/src/extensions.rs:380:35
    |
380 | #[derive(Clone, Debug, Serialize, Deserialize)]
    |                                   ^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `CredentialProtectionPolicy`
    |
    = help: the trait `std::default::Default` is implemented for `ExtnState<T>`
note: required because of the requirements on the impl of `std::default::Default` for `ExtnState<CredentialProtectionPolicy>`
   --> webauthn-rs-proto/src/extensions.rs:360:24
    |
360 | #[derive(Clone, Debug, Default, Serialize, Deserialize)]
    |                        ^^^^^^^
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `CredProps: std::default::Default` is not satisfied
   --> webauthn-rs-proto/src/extensions.rs:380:35
    |
380 | #[derive(Clone, Debug, Serialize, Deserialize)]
    |                                   ^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `CredProps`
    |
    = help: the trait `std::default::Default` is implemented for `ExtnState<T>`
note: required because of the requirements on the impl of `std::default::Default` for `ExtnState<CredProps>`
   --> webauthn-rs-proto/src/extensions.rs:360:24
    |
360 | #[derive(Clone, Debug, Default, Serialize, Deserialize)]
    |                        ^^^^^^^
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `CredProps` with `#[derive(Default)]`
    |
286 | #[derive(Default)]
    |

error[E0277]: the trait bound `CredentialProtectionPolicy: std::default::Default` is not satisfied
   --> webauthn-rs-proto/src/extensions.rs:384:5
    |
384 |     /// The state of the cred_protect extension
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `CredentialProtectionPolicy`
    |
    = help: the trait `std::default::Default` is implemented for `ExtnState<T>`
note: required because of the requirements on the impl of `std::default::Default` for `ExtnState<CredentialProtectionPolicy>`
   --> webauthn-rs-proto/src/extensions.rs:360:24
    |
360 | #[derive(Clone, Debug, Default, Serialize, Deserialize)]
    |                        ^^^^^^^
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `CredProps: std::default::Default` is not satisfied
   --> webauthn-rs-proto/src/extensions.rs:393:5
    |
393 |     /// The state of the client credential properties extension
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `CredProps`
    |
    = help: the trait `std::default::Default` is implemented for `ExtnState<T>`
note: required because of the requirements on the impl of `std::default::Default` for `ExtnState<CredProps>`
   --> webauthn-rs-proto/src/extensions.rs:360:24
    |
360 | #[derive(Clone, Debug, Default, Serialize, Deserialize)]
    |                        ^^^^^^^
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `CredProps` with `#[derive(Default)]`
    |
286 | #[derive(Default)]
    |

For more information about this error, try `rustc --explain E0277`.
error: could not compile `webauthn-rs-proto` due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

The [rustc bug on this][4] is a little long, and has a few different issues, but the one that hits us here is that deriving `Default` on an `enum` with a generic type parameter forces `T: Default` regardless of whether that type used in the default case.

As a simplified example, `Foo<T>` implements something similar to `Option<T>`, and tries to derive `Default`:

```rust
#[derive(Debug, Default)]
enum Foo<T> {
    #[default]
    None,
    Some(T),
}

#[derive(Debug)]
struct Bar {
    v: u8,
}

fn main() {
    let a: Foo<Bar> = Default::default();
    let b = Foo::Some(Bar { v: 1 });
    
    println!("{a:?}, {b:?}");
}
```

Compiling that with `rustc >= 1.62.0, <= 1.65.0` results in:

```
error[E0277]: the trait bound `Bar: Default` is not satisfied
  --> ./defaults.rs:14:23
   |
14 |     let a: Foo<Bar> = Default::default();
   |                       ^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `Bar`
   |
   = help: the trait `Default` is implemented for `Foo<T>`
note: required for `Foo<Bar>` to implement `Default`
  --> ./defaults.rs:1:17
   |
1  | #[derive(Debug, Default)]
   |                 ^^^^^^^
   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `Bar` with `#[derive(Default)]`
   |
9  | #[derive(Default)]
   |
```

Compiling it with `rustc < 1.62.0` results in an additional warning that deriving `Default` for enums is experimental.

It compiles fine with `rustc >= 1.66.0`, so I've set the MSRV explicitly for `webauthn-rs-proto`. It's not clear which PR actually fixed this for `rustc`, and [the bug is still open][4]. 🤷 

`kanidm` already needs Rust 1.66.0.

The other packages can have their MSRV updated as things go.

[0]: https://old.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/ig54zv7/
[1]: https://crates.io/crates/axum/0.6.1#user-content-minimum-supported-rust-version
[2]: https://github.com/micolous/webauthn-rs/actions/runs/4684510868/jobs/8300730956
[3]: https://github.com/micolous/webauthn-rs/actions/runs/4684549653/jobs/8300810953
[4]: https://github.com/rust-lang/rust/issues/26925

Fixes #

- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
