### PR TITLE
Move common dependencies into workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,30 @@ members = [
 exclude = [
     "compat_tester/webauthn-rs-demo-wasm",
 ]
+
+[workspace.dependencies]
+base64urlsafedata = { path = "./base64urlsafedata" }
+webauthn-rs = { path = "./webauthn-rs" }
+webauthn-rs-core = { path = "./webauthn-rs-core" }
+webauthn-rs-proto = { path = "./webauthn-rs-proto" }
+
+async-std = { version = "1.6", features = ["attributes"] }
+base64 = "0.21"
+clap = { version = "^3.2", features = ["derive", "env"] }
+compact_jwt = "0.2.3"
+futures = "^0.3.25"
+hex = "0.4.3"
+nom = "7.1"
+openssl = "^0.10.41"
+rand = "0.8"
+serde = { version = "^1.0.141", features = ["derive"] }
+serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
+serde_json = "^1.0.79"
+tide = "0.16"
+thiserror = "^1.0.37"
+tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"] }
+tokio-tungstenite = { version = "^0.18.0", features = ["native-tls"] }
+tracing = "^0.1.35"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
+url = "2"
+uuid = "^1.1.2"

--- a/authenticator-cli/Cargo.toml
+++ b/authenticator-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "authenticator-cli"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66.0"
 repository = "https://github.com/kanidm/webauthn-rs"
 license = "MPL-2.0"
 readme = "README.md"
@@ -10,9 +11,9 @@ description = "Webauthn Authenticator Management Tool"
 [dependencies]
 
 authenticator = { version = "0.3.2-dev.1", default-features = false, features = ["crypto_openssl"], package = "authenticator-ctap2-2021" }
-clap = { version = "^3.0", features = ["derive"] }
+clap.workspace = true
 
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 tracing-log = { version = "0.1.3" }
 

--- a/base64urlsafedata/Cargo.toml
+++ b/base64urlsafedata/Cargo.toml
@@ -3,6 +3,7 @@ name = "base64urlsafedata"
 version = "0.1.3"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 description = "Base 64 Url Safe wrapper for Serde"
 repository = "https://github.com/kanidm/webauthn-rs"
 keywords = ["base64", "serde"]
@@ -13,6 +14,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-base64 = "0.21"
-serde_json = "1.0"
+serde.workspace = true
+base64.workspace = true
+serde_json.workspace = true

--- a/compat_tester/webauthn-rs-demo-shared/Cargo.toml
+++ b/compat_tester/webauthn-rs-demo-shared/Cargo.toml
@@ -2,13 +2,14 @@
 name = "webauthn-rs-demo-shared"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66.0"
 
 [features]
 core = ["webauthn-rs-core"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 
-webauthn-rs-core = { path = "../../webauthn-rs-core", optional = true }
-webauthn-rs-proto = { path = "../../webauthn-rs-proto" }
+webauthn-rs-core = { workspace = true, optional = true }
+webauthn-rs-proto.workspace = true
 

--- a/compat_tester/webauthn-rs-demo-wasm/Cargo.toml
+++ b/compat_tester/webauthn-rs-demo-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "webauthn_rs_demo_wasm"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -10,15 +11,15 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 webauthn-rs-demo-shared = { path = "../webauthn-rs-demo-shared", default-features = false }
-webauthn-rs-proto = { path = "../../webauthn-rs-proto", default-features = false, features = ["wasm"] }
+webauthn-rs-proto = { workspace = true, default-features = false, features = ["wasm"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4" }
 yew-router = "0.16.0"
 yew = "0.19"
 js-sys = "0.3"
-serde_json = "1.0"
+serde_json.workspace = true
 gloo = "0.6"
-url = "2"
+url.workspace = true
 
 [dependencies.web-sys]
 version = "0.3"

--- a/compat_tester/webauthn-rs-demo/Cargo.toml
+++ b/compat_tester/webauthn-rs-demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "webauthn-rs-demo"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 build = "build.rs"
 
 description = "Webauthn Demonstration Server"
@@ -12,17 +13,17 @@ license = "MPL-2.0"
 
 [dependencies]
 webauthn-rs-demo-shared = { path = "../webauthn-rs-demo-shared", features = ["core"] }
-webauthn-rs-core = { path = "../../webauthn-rs-core" }
-webauthn-rs = { path = "../../webauthn-rs", features = ["resident-key-support", "preview-features", "danger-allow-state-serialisation"] }
-tide = "0.16"
+webauthn-rs-core.workspace = true
+webauthn-rs = { workspace = true, features = ["resident-key-support", "preview-features", "danger-allow-state-serialisation"] }
+tide.workspace = true
 tide-rustls = "0.3"
-async-std = { version = "1.6", features = ["attributes"] }
-openssl = "0.10"
+async-std.workspace = true
+openssl.workspace = true
 structopt = { version = "0.3", default-features = false }
 rustls = "0.19.0"
-tracing = "0.1"
-tracing-subscriber = "0.3"
-rand = "0.8"
-url = { version = "2", features = ["serde"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+rand.workspace = true
+url = { workspace = true , features = ["serde"] }
 
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true

--- a/fido-mds-tool/Cargo.toml
+++ b/fido-mds-tool/Cargo.toml
@@ -3,6 +3,7 @@ name = "fido-mds-tool"
 version = "0.5.0-dev"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 description = "Fido Metadata Service parsing tool"
 repository = "https://github.com/kanidm/webauthn-rs"
 readme = "README.md"
@@ -13,10 +14,7 @@ license = "MPL-2.0"
 [dependencies]
 fido-mds = { version = "0.5.0-dev", path = "../fido-mds" }
 
-clap = { version = "^3.2", features = ["derive", "env"] }
-
-tracing = "^0.1.35"
-tracing-subscriber = { version = "^0.3.14", features = ["env-filter", "fmt"] }
-uuid = "1"
-
-
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true

--- a/fido-mds/Cargo.toml
+++ b/fido-mds/Cargo.toml
@@ -3,6 +3,7 @@ name = "fido-mds"
 version = "0.5.0-dev"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 description = "Fido Metadata Service parser"
 repository = "https://github.com/kanidm/webauthn-rs"
 readme = "README.md"
@@ -13,12 +14,12 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.21"
-compact_jwt = "^0.2.3"
+base64.workspace = true
+compact_jwt.workspace = true
+openssl.workspace = true
 peg = "0.8.1"
-openssl = { version = "0.10" }
-serde = { version = "^1.0.141", features = ["derive"] }
-serde_json = "^1.0.79"
-tracing = "^0.1.35"
-uuid = { version = "1", features = ["v4", "serde"] }
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+uuid = { workspace = true, features = ["v4", "serde"] }
 

--- a/tutorial/server/actix_web/Cargo.toml
+++ b/tutorial/server/actix_web/Cargo.toml
@@ -2,6 +2,7 @@
 name = "actix_web"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66.0"
 authors = ["Niklas Pfister <git@omikron.dev>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -19,17 +20,17 @@ async-trait = { version = "~0.1" }
 anyhow = { version = "~1.0" }
 chrono = { version = "~0.4" }
 once_cell = { version = "~1.17" }
-rand = { version = "~0.8" }
+rand.workspace = true
 
 # Serve static file. Used to serve wasm
 actix-files = { version = "~0.6" }
 
 # Async runtime
-tokio = { version = "~1.24", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # Logging framework + facade
 env_logger = { version = "~0.10" }
 log = { version = "~0.4" }
 
 # Webauthn framework
-webauthn-rs = { path = "../../../webauthn-rs", features = ["danger-allow-state-serialisation"] }
+webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"] }

--- a/tutorial/server/axum/Cargo.toml
+++ b/tutorial/server/axum/Cargo.toml
@@ -2,23 +2,24 @@
 name = "web_authn"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66.0"
 authors = ["William Brown <william@blackhats.net.au>, Ben Wishovich <ben@benw.is>"]
 license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = "0.1"
-tracing-subscriber = "0.3"
-serde = { version = "1", features = ["derive"] }
-rand = {version="0.8", features=["min_const_gen"]}
-webauthn-rs = { path = "../../../webauthn-rs", features = ["danger-allow-state-serialisation"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+serde.workspace = true
+rand = { workspace = true, features = ["min_const_gen"] }
+webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"] }
 axum = {version = "0.6.1", features = ["http2"]}
 axum-extra = { version = "0.4.2" , features = ["spa"]}
-tokio = {version="1.19.2", features = ["full"]}
-uuid = {version="1.1.2", features=["v4"]}
-url = "2.2.2"
-thiserror = "1.0.31"
+tokio = { workspace = true, features = ["full"] }
+uuid = { workspace = true, features=["v4"] }
+url.workspace = true
+thiserror.workspace = true
 axum-sessions = "0.4.1"
 tower = "0.4.13"
 tower-http = {version="0.3.4", features=["fs"]}

--- a/tutorial/server/tide/Cargo.toml
+++ b/tutorial/server/tide/Cargo.toml
@@ -2,18 +2,19 @@
 name = "tide-server"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webauthn-rs = { path = "../../../webauthn-rs", features = ["danger-allow-state-serialisation"] }
-tide = "0.16"
-async-std = { version = "1.6", features = ["attributes"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
-serde = { version = "1", features = ["derive"] }
-rand = "0.8"
+webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"] }
+tide.workspace = true
+async-std.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+serde.workspace = true
+rand.workspace = true
 anyhow = "1.0"
 

--- a/tutorial/wasm/Cargo.toml
+++ b/tutorial/wasm/Cargo.toml
@@ -2,13 +2,14 @@
 name = "wasm"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-webauthn-rs-proto = { path = "../../webauthn-rs-proto", default-features = false, features = ["wasm"] }
+webauthn-rs-proto = { workspace = true, default-features = false, features = ["wasm"] }
 
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde-wasm-bindgen = "0.4"
@@ -16,8 +17,8 @@ wasm-bindgen-futures = { version = "0.4" }
 yew = "0.19"
 js-sys = "0.3"
 gloo = "0.6"
-url = "2"
-serde_json = "1.0"
+url.workspace = true
+serde_json.workspace = true
 
 [dependencies.web-sys]
 version = "0.3"

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -3,6 +3,7 @@ name = "webauthn-authenticator-rs"
 version = "0.5.0-dev"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 license = "MPL-2.0"
 description = "Webauthn Authenticator Client Library"
 # documentation = "https://docs.rs/kanidm/latest/kanidm/"
@@ -35,17 +36,17 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }
-webauthn-rs-proto = { version = "0.5.0-dev", path = "../webauthn-rs-proto" }
-webauthn-rs-core = { path = "../webauthn-rs-core" }
+base64urlsafedata.workspace = true
+webauthn-rs-proto.workspace = true
+webauthn-rs-core.workspace = true
 
-tracing = "0.1"
-url = "2"
-uuid = "1"
-serde_json = "1.0"
-nom = "7.1"
-serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
-openssl = "0.10.41"
+tracing.workspace = true
+url.workspace = true
+uuid.workspace = true
+serde_json.workspace = true
+nom.workspace = true
+serde_cbor.workspace = true
+openssl.workspace = true
 rpassword = "5.0"
 
 # authenticator = { path = "../../../authenticator-rs", optional = true, default-features = false, features = ["crypto_openssl"], package = "authenticator-ctap2-2021" }
@@ -56,26 +57,26 @@ pcsc = { git = "https://github.com/bluetech/pcsc-rust.git", rev = "13e24649be969
 # https://github.com/ruabmbua/hidapi-rs/issues/94
 hidapi = { version = "1.5.0", optional = true, features = ["linux-static-hidraw"], default-features = false }
 windows = { version = "0.41.0", optional = true, features = ["Win32_Graphics_Gdi", "Win32_Networking_WindowsWebServices", "Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_LibraryLoader", "Win32_Graphics_Dwm" ] }
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
 bitflags = "1.3.2"
 unicode-normalization = "0.1.22"
 num-traits = "0.2"
 num-derive = "0.3"
 async-trait = "0.1.58"
-futures = "0.3.25"
+futures.workspace = true
 
 qrcode = { version = "^0.12.0", optional = true }
 # btleplug pinned due to https://github.com/deviceplug/btleplug/issues/289
 # Advertisements for the same device get dropped by bluez (Linux).
 btleplug = { git = "https://github.com/deviceplug/btleplug.git", rev = "6cf2e8a56c73042a5e263e3afbd20603c6c8f4c0", optional = true }
-tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"], optional = true }
-tokio-tungstenite = { version = "0.18.0", features = ["native-tls"], optional = true }
-hex = { version = "0.4.3", optional = true }
+tokio = { workspace = true, optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
-clap = { version = "^3.2", features = ["derive", "env"] }
-tokio = { version = "1.22.0", features = ["sync", "test-util", "macros", "rt-multi-thread", "time"] }
+tracing-subscriber.workspace = true
+clap.workspace = true
+tokio.workspace = true
 tempfile = { version = "3.3.0" }
 
 # cable_tunnel - used for connecting to Bluetooth HCI controller over serial
@@ -89,4 +90,4 @@ bardecoder = "=0.4.0"
 image = ">= 0.23.14, < 0.24"
 
 [build-dependencies]
-openssl = "0.10"
+openssl.workspace = true

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "webauthn-rs-core"
 version = "0.5.0-dev"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 description = "Webauthn Cryptographic Operation Handling"
 repository = "https://github.com/kanidm/webauthn-rs"
 readme = "README.md"
@@ -17,24 +18,24 @@ default = []
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base64urlsafedata = { version = "0.1.2", path = "../base64urlsafedata" }
-webauthn-rs-proto = { version = "0.5.0-dev", path = "../webauthn-rs-proto" }
-serde = { version = "1", features = ["derive"] }
-serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }
-serde_json = "1.0"
-nom = "7.1"
-base64 = "0.21"
-thiserror = "1.0"
-tracing = "0.1"
-openssl = "0.10.41"
+base64urlsafedata.workspace = true
+webauthn-rs-proto.workspace = true
+serde.workspace = true
+serde_cbor.workspace = true
+serde_json.workspace = true
+nom.workspace = true
+base64.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+openssl.workspace = true
 # We could consider replacing this with openssl rand.
-rand = { version = "0.8" }
-url = { version = "2", features = ["serde"] }
+rand.workspace = true
+url = { workspace = true, features = ["serde"] }
 x509-parser = "0.13.0"
 der-parser = "7.0.0"
-compact_jwt = "0.2.3"
-uuid = { version = "1", features = ["serde"] }
+compact_jwt.workspace = true
+uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 hex-literal = "0.3"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
+tracing-subscriber.workspace = true

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -20,10 +20,10 @@ wasm = ["wasm-bindgen", "web-sys", "js-sys", "serde-wasm-bindgen"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
-url = { version = "2", features = ["serde"] }
+base64urlsafedata.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+url = { workspace = true, features = ["serde"] }
 # num_enum = "0.5"
 
 # Webauthn Components

--- a/webauthn-rs/Cargo.toml
+++ b/webauthn-rs/Cargo.toml
@@ -3,6 +3,7 @@ name = "webauthn-rs"
 version = "0.5.0-dev"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
+rust-version = "1.66.0"
 description = "Webauthn Framework for Rust Web Servers"
 repository = "https://github.com/kanidm/webauthn-rs"
 readme = "../README.md"
@@ -22,9 +23,9 @@ danger-credential-internals = []
 danger-user-presence-only-security-keys = []
 
 [dependencies]
-base64urlsafedata = { version = "0.1", path = "../base64urlsafedata" }
-webauthn-rs-core = { version = "0.5.0-dev", path = "../webauthn-rs-core" }
-url = { version = "2", features = ["serde"] }
-tracing = "0.1"
-serde = { version = "1", features = ["derive"] }
-uuid = { version = "1", features = ["v4", "serde"] }
+base64urlsafedata.workspace = true
+webauthn-rs-core.workspace = true
+url = { workspace = true, features = ["serde"] }
+tracing.workspace = true
+serde.workspace = true
+uuid = { workspace = true, features = ["v4", "serde"] }


### PR DESCRIPTION
This makes it easier to track our versions of everything.

This also sets MSRV to 1.66.0 to be consistent with `webauthn-rs-core`.

Fixes #

- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
