### PR TITLE
CI performance improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,41 @@ env:
 
 jobs:
   build_and_test:
+    name: Other build/test
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_version: [stable, 1.66.0]
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: clippy, rustfmt
+
+      - if: runner.os != 'windows'
+        run: |
+          sudo apt-get update && \
+          sudo apt-get -y install libudev-dev
+
+      - if: runner.os == 'windows'
+        uses: johnwason/vcpkg-action@v4
+        with:
+          pkgs: openssl
+          triplet: x64-windows-static-md
+          token: ${{ github.token }}
+      - run: cargo build --workspace --exclude webauthn-authenticator-rs --release
+      - run: cargo fmt --workspace --exclude webauthn-authenticator-rs --check
+      - run: cargo clippy --workspace --exclude webauthn-authenticator-rs --all-targets
+      - run: cargo test --workspace --exclude webauthn-authenticator-rs --all
+
+  authenticator:
+    name: webauthn-authenticator-rs test
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +67,6 @@ jobs:
           - os: windows-latest
             rust_version: 1.66.0
 
-    name: Build and Test
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -58,10 +92,10 @@ jobs:
           pkgs: openssl
           triplet: x64-windows-static-md
           token: ${{ github.token }}
-      - run: cargo build --release ${{ matrix.features }}
-      - run: cargo fmt --check
-      - run: cargo clippy --all-targets ${{ matrix.features }}
-      - run: cargo test --all ${{ matrix.features }}
+      - run: cargo build -p webauthn-authenticator-rs --release ${{ matrix.features }}
+      - run: cargo fmt -p webauthn-authenticator-rs --check
+      - run: cargo clippy -p webauthn-authenticator-rs --all-targets ${{ matrix.features }}
+      - run: cargo test -p webauthn-authenticator-rs --all ${{ matrix.features }}
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ name: CI
 
 env:
   VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   fmt:
@@ -35,6 +37,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.3
 
       - if: runner.os != 'windows'
         run: |
@@ -47,13 +50,13 @@ jobs:
           pkgs: openssl
           triplet: x64-windows-static-md
           token: ${{ github.token }}
-      - run: cargo build --workspace --exclude webauthn-authenticator-rs --release
+      - run: cargo build --workspace --exclude webauthn-authenticator-rs
 
       # Don't run clippy on Windows, we only need to run it on Linux
       - if: runner.os != 'windows'
         run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs --all-targets
 
-      - run: cargo test --workspace --exclude webauthn-authenticator-rs --all
+      - run: cargo test --workspace --exclude webauthn-authenticator-rs
 
   authenticator:
     name: webauthn-authenticator-rs test
@@ -89,6 +92,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.3
 
       - if: runner.os != 'windows'
         run: |
@@ -107,14 +111,14 @@ jobs:
           pkgs: openssl
           triplet: x64-windows-static-md
           token: ${{ github.token }}
-      - run: cargo build -p webauthn-authenticator-rs --release ${{ matrix.features }}
+      - run: cargo build -p webauthn-authenticator-rs ${{ matrix.features }}
 
       # Don't run clippy on Windows unless it is using a Windows-specific
       # feature which wasn't checked on Linux.
       - if: contains(matrix.features, 'windows') || runner.os != 'windows'
         run: cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets ${{ matrix.features }}
 
-      - run: cargo test -p webauthn-authenticator-rs --all ${{ matrix.features }}
+      - run: cargo test -p webauthn-authenticator-rs ${{ matrix.features }}
 
   docs:
     name: Documentation
@@ -128,6 +132,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - run: |
           sudo apt-get update && \
           sudo apt-get -y install libudev-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,18 @@ env:
   VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
 
 jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - run: cargo fmt --check
+
   build_and_test:
     name: Other build/test
     strategy:
@@ -22,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
-          components: clippy, rustfmt
+          components: clippy
 
       - if: runner.os != 'windows'
         run: |
@@ -36,8 +48,11 @@ jobs:
           triplet: x64-windows-static-md
           token: ${{ github.token }}
       - run: cargo build --workspace --exclude webauthn-authenticator-rs --release
-      - run: cargo fmt --workspace --exclude webauthn-authenticator-rs --check
-      - run: cargo clippy --workspace --exclude webauthn-authenticator-rs --all-targets
+
+      # Don't run clippy on Windows, we only need to run it on Linux
+      - if: runner.os != 'windows'
+        run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs --all-targets
+
       - run: cargo test --workspace --exclude webauthn-authenticator-rs --all
 
   authenticator:
@@ -73,7 +88,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
-          components: clippy, rustfmt
+          components: clippy
 
       - if: runner.os != 'windows'
         run: |
@@ -93,8 +108,12 @@ jobs:
           triplet: x64-windows-static-md
           token: ${{ github.token }}
       - run: cargo build -p webauthn-authenticator-rs --release ${{ matrix.features }}
-      - run: cargo fmt -p webauthn-authenticator-rs --check
-      - run: cargo clippy -p webauthn-authenticator-rs --all-targets ${{ matrix.features }}
+
+      # Don't run clippy on Windows unless it is using a Windows-specific
+      # feature which wasn't checked on Linux.
+      - if: contains(matrix.features, 'windows') || runner.os != 'windows'
+        run: cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets ${{ matrix.features }}
+
       - run: cargo test -p webauthn-authenticator-rs --all ${{ matrix.features }}
 
   docs:


### PR DESCRIPTION
This does a few things to speed up CI tasks:

* build in debug mode (rather than release mode), so the tests don't trigger a full rebuild
* only build the many features with `webauthn-authenticator-rs`, rather than the whole library
* split `cargo fmt` into its own action
* don't run clippy for `webauthn-authenticator-rs` on Windows unless using Windows-specific features
* use sccache

There's more jobs now, but they're smaller jobs, so less likely to block things up when you have a few branches running in parallel.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
