### PR TITLE
Automatically cancel jobs in CI when a revision is obsolete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     name: rustfmt


### PR DESCRIPTION
This should free up CI capacity when updating PRs / branches.

Example: https://github.com/micolous/webauthn-rs/actions/runs/4826108718

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
