### PR TITLE
base16 encode tracing output

### DIFF
--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -35,7 +35,7 @@ cable = ["dep:btleplug", "crypto", "ctap2", "dep:hex", "dep:tokio", "dep:tokio-t
 # server, and most library users should not need this!
 cable-override-tunnel = ["cable"]
 
-ctap2 = ["crypto"]
+ctap2 = ["crypto", "dep:hex"]
 ctap2-management = ["ctap2"]
 nfc = ["ctap2", "dep:pcsc"]
 # TODO: allow running softpasskey without softtoken

--- a/webauthn-authenticator-rs/src/bluetooth/mod.rs
+++ b/webauthn-authenticator-rs/src/bluetooth/mod.rs
@@ -220,7 +220,7 @@ impl BluetoothToken {
     /// Sends a single [BtleFrame] to the device, without fragmentation.
     async fn send_one(&self, frame: BtleFrame) -> Result<(), WebauthnCError> {
         let d = frame.as_vec(self.checked_mtu()?)?;
-        trace!(">>> {:02x?}", d);
+        trace!(">>> {}", hex::encode(&d));
         self.device
             .write(
                 self.control_point
@@ -269,7 +269,7 @@ impl Token for BluetoothToken {
             let mut c = Vec::new();
 
             while let Some(data) = stream.next().await {
-                trace!("<<< {:02x?}", data.value);
+                trace!("<<< {}", hex::encode(&data.value));
                 if data.uuid != FIDO_STATUS {
                     trace!("Ignoring notification for unknown UUID: {:?}", data.uuid);
                     continue;

--- a/webauthn-authenticator-rs/src/cable/noise.rs
+++ b/webauthn-authenticator-rs/src/cable/noise.rs
@@ -275,7 +275,6 @@ impl CableNoise {
     /// `SymmetricState.DecryptAndHash(ciphertext)`
     fn decrypt_and_hash(&mut self, ct: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
         let pt = self.cipher_state.decrypt(ct, Some(&self.h))?;
-        trace!("decrypted: {:?}", pt);
         self.mix_hash(ct);
         Ok(pt)
     }

--- a/webauthn-authenticator-rs/src/ctap2/commands/make_credential.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/make_credential.rs
@@ -434,7 +434,7 @@ mod test {
         ];
         let a = <MakeCredentialResponse as CBORResponse>::try_from(r.as_slice())
             .expect("Failed to decode message");
-        info!(?r);
+        info!("r = {}", hex::encode(r));
 
         assert_eq!(
             a,
@@ -606,6 +606,6 @@ mod test {
 
         // let pdu = mc.to_short_apdus();
         // info!("got APDU: {:?}", pdu);
-        info!("got inner APDU: {:?}", b);
+        info!("got inner APDU: {}", hex::encode(b));
     }
 }

--- a/webauthn-authenticator-rs/src/nfc/mod.rs
+++ b/webauthn-authenticator-rs/src/nfc/mod.rs
@@ -258,14 +258,14 @@ fn transmit(
     })?;
     let mut resp = vec![0; MAX_BUFFER_SIZE_EXTENDED];
 
-    trace!(">>> {:02x?}", req);
+    trace!(">>> {}", hex::encode(&req));
 
     let rapdu = card.transmit(&req, &mut resp).map_err(|e| {
         error!("Failed to transmit APDU command to card: {}", e);
         e
     })?;
 
-    trace!("<<< {:02x?}", rapdu);
+    trace!("<<< {}", hex::encode(rapdu));
 
     ISO7816ResponseAPDU::try_from(rapdu).map_err(|e| {
         error!("Failed to parse card response: {:?}", e);
@@ -330,7 +330,7 @@ impl NFCCard {
         reader_name: &CStr,
         atr: &[u8],
     ) -> Result<NFCCard, WebauthnCError> {
-        trace!("ATR: {:02x?}", atr);
+        trace!("ATR: {}", hex::encode(atr));
         let atr = Atr::try_from(atr)?;
         trace!("Parsed: {:?}", &atr);
 

--- a/webauthn-authenticator-rs/src/transport/mod.rs
+++ b/webauthn-authenticator-rs/src/transport/mod.rs
@@ -71,8 +71,11 @@ pub trait Token: Sized + fmt::Debug + Sync + Send {
         U: UiCallback,
     {
         let cbor = cmd.cbor().map_err(|_| WebauthnCError::Cbor)?;
+        trace!(">>> {}", hex::encode(&cbor));
+
         let resp = self.transmit_raw(&cbor, ui).await?;
 
+        trace!("<<< {}", hex::encode(&resp));
         R::try_from(resp.as_slice()).map_err(|_| {
             //error!("error: {:?}", e);
             WebauthnCError::Cbor

--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -157,7 +157,7 @@ impl USBToken {
     /// Sends a single [U2FHIDFrame] to the device, without fragmentation.
     fn send_one(&self, frame: &U2FHIDFrame) -> Result<(), WebauthnCError> {
         let d: HidSendReportBytes = frame.into();
-        trace!(">>> {:02x?}", d);
+        trace!(">>> {}", hex::encode(d));
         let guard = self.device.lock()?;
         guard.deref().write(&d)?;
         Ok(())
@@ -182,7 +182,7 @@ impl USBToken {
         }
         .await?;
 
-        trace!("<<< {:02x?}", &ret);
+        trace!("<<< {}", hex::encode(ret));
         U2FHIDFrame::try_from(&ret)
     }
 


### PR DESCRIPTION
This makes things a bit easier to debug.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
