### PR TITLE
Update metadata for cable-tunnel-server to allow publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 
 [workspace.dependencies]
 base64urlsafedata = { path = "./base64urlsafedata" }
-cable-tunnel-server-common = { path = "./cable-tunnel-server/common" }
+cable-tunnel-server-common = { path = "./cable-tunnel-server/common", version = "0.1.0" }
 webauthn-authenticator-rs = { path = "./webauthn-authenticator-rs" }
 webauthn-rs = { path = "./webauthn-rs" }
 webauthn-rs-core = { path = "./webauthn-rs-core" }

--- a/cable-tunnel-server/frontend/Cargo.toml
+++ b/cable-tunnel-server/frontend/Cargo.toml
@@ -7,7 +7,7 @@ description = "webauthn-rs caBLE tunnel server frontend"
 edition = "2021"
 keywords = ["cable", "hybrid", "fido", "webauthn"]
 license = "MPL-2.0"
-readme = "README.md"
+# readme = "README.md"
 repository = "https://github.com/kanidm/webauthn-rs/"
 rust-version = "1.66.0"
 


### PR DESCRIPTION
Crates needs you to publish a version to reserve a name, so publishing current git HEAD for now. I've set these at v0.1.0 until we get proper versioning sorted out.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
