### PR TITLE
SessionLayer::with_secure(false)

### DIFF
--- a/tutorial/server/axum/src/main.rs
+++ b/tutorial/server/axum/src/main.rs
@@ -43,7 +43,7 @@ async fn main() {
     let session_layer = SessionLayer::new(store, &secret)
         .with_cookie_name("webauthnrs")
         .with_same_site_policy(SameSite::Lax)
-        .with_secure(true);
+        .with_secure(false); // TODO: change this to true when running on an HTTPS/production server instead of locally
 
     // build our application with a route
     let app = Router::new()


### PR DESCRIPTION
Enables the tutorial to be runnable locally by default. Without this, `finish_register` returns `Err(WebauthnError::CorruptSession)` when running locally.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
