### PR TITLE
Update base64urlsafe version flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 
 
 [workspace]
+resolver = "2"
 members = [
     # Support Libraries
     "base64urlsafedata",

--- a/base64urlsafedata/Cargo.toml
+++ b/base64urlsafedata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64urlsafedata"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
 rust-version = "1.67.0"


### PR DESCRIPTION
Update version of base64urlsafe to allow vendoring from git in Kanidm, update workspace resolver.