### PR TITLE
352 serde bincode

### DIFF
--- a/base64urlsafedata/src/lib.rs
+++ b/base64urlsafedata/src/lib.rs
@@ -35,6 +35,12 @@ static ALLOWED_DECODING_FORMATS: &[GeneralPurpose] =
 /// when deserializing, will decode from many different types of base64 possible.
 pub struct Base64UrlSafeData(pub Vec<u8>);
 
+impl Base64UrlSafeData {
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
 impl fmt::Display for Base64UrlSafeData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", URL_SAFE_NO_PAD.encode(self))
@@ -125,7 +131,8 @@ impl<'de> Deserialize<'de> for Base64UrlSafeData {
     where
         D: Deserializer<'de>,
     {
-        // Was previously _str
+        // This is deserialize_any because it allows us to pivot between arrays
+        // of bytes, and strings inside the visitor.
         deserializer.deserialize_any(Base64UrlSafeDataVisitor)
     }
 }

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -14,6 +14,8 @@ license = "MPL-2.0"
 [features]
 default = []
 
+danger_serde_bincode = []
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -741,7 +741,7 @@ pub(crate) fn verify_tpm_attestation(
             // cose_rsa.e != tpm_parms.exponent ||
 
             // check the pkey is the same.
-            if cose_rsa.n.as_ref() != tpm_modulus {
+            if cose_rsa.n.as_slice() != tpm_modulus {
                 return Err(WebauthnError::AttestationTpmPubAreaMismatch);
             }
         }
@@ -762,7 +762,7 @@ pub(crate) fn verify_tpm_attestation(
                 }
             }
 
-            if x.0 != ecc_points.x || y.0 != ecc_points.y {
+            if x.as_slice() != ecc_points.x || y.as_slice() != ecc_points.y {
                 debug!("Invalid X or Y coords in TpmuPublicId");
                 return Err(WebauthnError::AttestationTpmPubAreaMismatch);
             }

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -927,6 +927,7 @@ impl WebauthnCore {
             .iter()
             .map(|cred| AllowCredentials {
                 type_: "public-key".to_string(),
+                #[allow(clippy::useless_conversion)]
                 id: cred.cred_id.clone().into(),
                 transports: cred.transports.clone(),
             })
@@ -1095,6 +1096,7 @@ impl WebauthnCore {
             }
         }
 
+        #[allow(clippy::useless_conversion)]
         Ok(AuthenticationResult {
             cred_id: cred.cred_id.clone().into(),
             needs_update,

--- a/webauthn-rs-core/src/crypto.rs
+++ b/webauthn-rs-core/src/crypto.rs
@@ -677,8 +677,8 @@ impl COSEKey {
             COSEKeyType::EC_EC2(ecpk) => {
                 let r: [u8; 1] = [0x04];
                 Ok(r.iter()
-                    .chain(ecpk.x.0.iter())
-                    .chain(ecpk.y.0.iter())
+                    .chain(ecpk.x.as_slice().iter())
+                    .chain(ecpk.y.as_slice().iter())
                     .copied()
                     .collect())
             }

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -186,6 +186,7 @@ impl Credential {
         let transports = None;
 
         Credential {
+            #[allow(clippy::useless_conversion)]
             cred_id: acd.credential_id.clone().into(),
             cred: ck,
             counter,

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -186,7 +186,7 @@ impl Credential {
         let transports = None;
 
         Credential {
-            cred_id: acd.credential_id.clone(),
+            cred_id: acd.credential_id.clone().into(),
             cred: ck,
             counter,
             transports,


### PR DESCRIPTION
Fixes #352 - This adds a hidden feature that allows the storage of vec<u8> to skip base64 for some users. 

We can't apply this into base64urlsafedata because features taint and having a flag to skip base64 would break wasm and json front ends. So as a result, the only way to proceed is to swap the type in the struct based on the cfg flag. It is a teeny bit messy because it introduces some useless into()/from() where without the feature we are doing base64 into base64, but it's needed when the feature is enabled. 

I can't think of a better way to actually achieve this though without breaking existing users horrendously. @micolous do you have any better ideas perhaps? 

- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
