### PR TITLE
fix redundant clone

### DIFF
--- a/fido-mds/src/lib.rs
+++ b/fido-mds/src/lib.rs
@@ -1374,11 +1374,11 @@ impl From<RawFidoMds> for FidoMds {
                     // let akis = dev.attestation_certificate_key_identifiers.clone();
                     let dev = rc::Rc::new(dev);
 
-                    u2f.push(dev.clone());
+                    u2f.push(dev);
                 }
                 FidoDevice::FIDO2(dev) => {
                     let dev = rc::Rc::new(dev);
-                    fido2.push(dev.clone())
+                    fido2.push(dev)
                 }
             });
 


### PR DESCRIPTION
Clippy on 1.70.0 fails

- [x] cargo test has been run and passes
- ~~documentation has been updated with relevant examples (if relevant)~~
