### PR TITLE
webauthn-rs-demo: make tls support optional

### DIFF
--- a/compat_tester/webauthn-rs-demo/Cargo.toml
+++ b/compat_tester/webauthn-rs-demo/Cargo.toml
@@ -11,6 +11,12 @@ repository = "https://github.com/kanidm/webauthn-rs"
 readme = "README.md"
 license = "MPL-2.0"
 
+[features]
+# TLS support is disabled by default due rustls depending on ring 0.16, which
+# doesn't build on aarch64-pc-windows-msvc and lots of cross-compiling problems:
+# https://github.com/rustls/rustls/issues/1103
+tls = ["dep:tide-rustls", "dep:rustls"]
+
 [dependencies]
 webauthn-rs-demo-shared = { path = "../webauthn-rs-demo-shared", features = ["core"] }
 webauthn-rs-core.workspace = true
@@ -18,11 +24,11 @@ webauthn-rs = { workspace = true, features = ["resident-key-support", "preview-f
 webauthn-rs-device-catalog.workspace = true
 
 tide.workspace = true
-tide-rustls = "0.3"
+tide-rustls = { version = "0.3", optional = true }
 async-std.workspace = true
 openssl.workspace = true
 structopt = { version = "0.3", default-features = false }
-rustls = "0.19.0"
+rustls = { version = "0.19.0", optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rand.workspace = true


### PR DESCRIPTION
[`rustls` depends on `ring 0.16`](https://github.com/rustls/rustls/issues/1103), which doesn't build on `aarch64-pc-windows-msvc`, and has lots of other cross-compiling issues. Many of these issues have been fixed, but only on the `ring 0.17` branch.

This PR makes `webauthn-rs-demo` TLS support optional (`--features tls`).

Longer term, I'd rather switch this over to using OpenSSL like everything else, but this at least unblocks building the entire workspace with default features on a system `ring 0.16` doesn't support.
