### PR TITLE
fido-key-manager: disable tests

### DIFF
--- a/fido-key-manager/Cargo.toml
+++ b/fido-key-manager/Cargo.toml
@@ -12,6 +12,12 @@ repository = "https://github.com/kanidm/webauthn-rs/"
 rust-version = "1.70.0"
 build = "build.rs"
 
+[[bin]]
+name = "fido-key-manager"
+# cargo can't run binaries needing elevation on Windows, and there's no tests
+# here anyway.
+test = false
+
 [features]
 # Bluetooth support is flakey on Linux and Windows, so not enabled by default.
 bluetooth = ["webauthn-authenticator-rs/bluetooth"]


### PR DESCRIPTION
`fido-key-manager` requires elevation on Windows:

* For simplicity, this is declared in the application's manifest, included at link time. Elevation is handled by the platform before it calls `.main`.
* There are ways to conditionally elevate actions, but this is much more complicated to implement. The only thing this tool which _doesn't_ require elevation is `--help`, so this is much simpler.

`cargo` can't launch binaries requiring elevation. There's also no way to detect at a `build.rs` level whether a binary target will be used for a test, and conditionally disable elevation support.

There's no tests in `fido-key-manager` anyway – so this just disables them explicitly so that a project-wide `cargo test` won't fail on Windows.

