### PR TITLE
Fix axum example for credential creation

### DIFF
--- a/tutorial/server/axum/assets/auth.js
+++ b/tutorial/server/axum/assets/auth.js
@@ -12,6 +12,9 @@ function register () {
     .then(credentialCreationOptions => {
         credentialCreationOptions.publicKey.challenge = Base64.toUint8Array(credentialCreationOptions.publicKey.challenge);
         credentialCreationOptions.publicKey.user.id = Base64.toUint8Array(credentialCreationOptions.publicKey.user.id);
+        credentialCreationOptions.publicKey.excludeCredentials?.forEach(function (listItem) {
+            listItem.id = Base64.toUint8Array(listItem.id)
+        });
 
         return navigator.credentials.create({
             publicKey: credentialCreationOptions.publicKey
@@ -57,7 +60,7 @@ function login() {
     .then(response => response.json())
     .then((credentialRequestOptions) => {
         credentialRequestOptions.publicKey.challenge = Base64.toUint8Array(credentialRequestOptions.publicKey.challenge);
-        credentialRequestOptions.publicKey.allowCredentials.forEach(function (listItem) {
+        credentialRequestOptions.publicKey.allowCredentials?.forEach(function (listItem) {
             listItem.id = Base64.toUint8Array(listItem.id)
         });
 


### PR DESCRIPTION
While investigating #351 I noticed that the `excludeCredentials` id's were still in base64url and which was failing validation in 1Password. Here I mirror the same modifications done to the `allowCredentials` list.

Fixes #

- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
