### PR TITLE
Add subjectAltName to webauthn-rs-demo example

### DIFF
--- a/compat_tester/webauthn-rs-demo/README.md
+++ b/compat_tester/webauthn-rs-demo/README.md
@@ -34,7 +34,7 @@ If you're testing locally, you can build a short-lived self-signed certificate
 
 ```sh
 openssl genrsa -out /tmp/demo.key
-openssl req -new -x509 -key /tmp/demo.key -out /tmp/demo.pem -days 5 -subj "/CN=localhost/"
+openssl req -new -x509 -key /tmp/demo.key -out /tmp/demo.pem -days 5 -subj "/CN=localhost/" -addext "subjectAltName = DNS:localhost"
 ```
 
 Configuring and managing certificates properly is outside the scope of this


### PR DESCRIPTION
Before #360, `webauthn-rs-demo` would generate a certificate with a SAN. This seems to be required by Chrome on desktop.

This updates the docs to set a SAN.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
