### PR TITLE
Expose sshkeys

### DIFF
--- a/sshkey-attest/src/proto.rs
+++ b/sshkey-attest/src/proto.rs
@@ -1,9 +1,10 @@
 //! Serialisable formats of attested ssh keys
 
 use serde::{Deserialize, Serialize};
-use sshkeys::PublicKey;
 use webauthn_rs_core::attestation::AttestationFormat;
 use webauthn_rs_core::proto::{ParsedAttestation, RegisteredExtensions};
+
+pub use sshkeys::PublicKey;
 
 /// An attested public key. This contains the ssh public key as well as the
 /// attestation metadata.


### PR DESCRIPTION
Expose the sshkeys library at our required commit version for sshkey-attest consumers. 

- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
