### PR TITLE
Show "processing" status for BTLE and USB keys

### DIFF
--- a/webauthn-authenticator-rs/src/bluetooth/mod.rs
+++ b/webauthn-authenticator-rs/src/bluetooth/mod.rs
@@ -524,8 +524,10 @@ impl Token for BluetoothToken {
 
             if let Response::KeepAlive(r) = resp {
                 trace!("waiting for {:?}", r);
-                if r == KeepAliveStatus::UserPresenceNeeded {
-                    ui.request_touch();
+                match r {
+                    KeepAliveStatus::UserPresenceNeeded => ui.request_touch(),
+                    KeepAliveStatus::Processing => ui.processing(),
+                    _ => (),
                 }
                 // TODO: maybe time out at some point
                 // thread::sleep(Duration::from_millis(100));

--- a/webauthn-authenticator-rs/src/ui/cli.rs
+++ b/webauthn-authenticator-rs/src/ui/cli.rs
@@ -25,6 +25,11 @@ impl UiCallback for Cli {
         writeln!(stderr, "Touch the authenticator").ok();
     }
 
+    fn processing(&self) {
+        let mut stderr = stderr();
+        writeln!(stderr, "Processing...").ok();
+    }
+
     fn fingerprint_enrollment_feedback(
         &self,
         remaining_samples: u32,

--- a/webauthn-authenticator-rs/src/ui/mod.rs
+++ b/webauthn-authenticator-rs/src/ui/mod.rs
@@ -18,6 +18,9 @@ pub trait UiCallback: Sync + Send + Debug {
     /// This method will be called synchronously, and must not block.
     fn request_touch(&self);
 
+    /// Tell the user that the key is currently processing a request.
+    fn processing(&self);
+
     /// Provide the user feedback when they are enrolling fingerprints.
     ///
     /// This method will be called synchronously, and must not block.

--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -229,8 +229,10 @@ impl Token for USBToken {
 
             if let Response::KeepAlive(r) = resp {
                 trace!("waiting for {:?}", r);
-                if r == KeepAliveStatus::UserPresenceNeeded {
-                    ui.request_touch();
+                match r {
+                    KeepAliveStatus::UserPresenceNeeded => ui.request_touch(),
+                    KeepAliveStatus::Processing => ui.processing(),
+                    _ => (),
                 }
                 // TODO: maybe time out at some point
                 tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
When device selection was added, some operations prompt for touch multiple times (possibly depending on key firmware?), but there's no feedback for "processing" status. This will bubble that up.

However, some keys do weird flip-flops between `Processing` and `UserPresenceNeeded` even when they're still waiting for user presence.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
