### PR TITLE
Implement some SoloKeys2/Trussed vendor commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       # handle.
       - if: runner.os != 'windows'
         run: cargo run --bin fido-key-manager -- --help
+      - if: runner.os != 'windows'
+        run: cargo run --bin fido-key-manager --features solokey -- --help
       - run: cargo run --bin fido-mds-tool -- --help
 
   authenticator:
@@ -88,7 +90,7 @@ jobs:
           - softtoken
           - usb
           - bluetooth,nfc,usb,ctap2-management
-          - bluetooth,cable,cable-override-tunnel,ctap2-management,nfc,softpasskey,softtoken,usb
+          - bluetooth,cable,cable-override-tunnel,ctap2-management,nfc,softpasskey,softtoken,usb,vendor-solokey
         os:
           - ubuntu-latest
           - windows-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tokio = { version = "1.22.0", features = [
     "sync",
     "test-util",
     "macros",
+    "net",
     "rt-multi-thread",
     "time",
 ] }

--- a/fido-key-manager/Cargo.toml
+++ b/fido-key-manager/Cargo.toml
@@ -23,6 +23,7 @@ test = false
 bluetooth = ["webauthn-authenticator-rs/bluetooth"]
 nfc = ["webauthn-authenticator-rs/nfc"]
 usb = ["webauthn-authenticator-rs/usb"]
+solokey = ["webauthn-authenticator-rs/vendor-solokey"]
 
 default = ["nfc", "usb"]
 

--- a/fido-key-manager/README.md
+++ b/fido-key-manager/README.md
@@ -80,6 +80,33 @@ Command | Description | Requirements
 [Enterprise Attestation]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-feature-descriptions-enterp-attstn
 [Minimum PIN Length]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-feature-descriptions-minPinLength
 
+## Vendor-specific commands
+
+**Warning:** for safety, ensure that you **only** have security key(s) from that
+vendor connected to your computer when using **any** vendor-specific command,
+**even benign ones**.
+
+In the CTAP 2 protocol, vendor-specific command IDs can (and do!) have different
+meanings on different vendors – one vendor may use a certain ID as a safe
+operation (such as "get info"), but another vendor might use the same ID to
+start firmware updates, change the key's operating mode or perform some
+potentially-destructive operation.
+
+For operations that require multiple commands be sent to a security key, this
+tool will attempt to stop early if a key reports that it does not support one
+of the commands, or returns an unexpected value.
+
+### SoloKey 2 / Trussed
+
+SoloKey 2 / Trussed commands are currently **only** supported over USB HID. NFC
+support may be added in future, but we have encountered many problems
+communicating with SoloKey / Trussed devices *at all* over NFC.
+
+Command | Description
+------- | -----------
+`solo-key-info` | get all connected SoloKeys' unique ID, firmware version and secure boot status
+`solo-key-random` | get some random bytes from a SoloKey
+
 ## Platform-specific notes
 
 Bluetooth is currently disabled by default, as it's not particularly reliable on
@@ -144,6 +171,10 @@ anything but macOS, and can easily accidentally select nearby devices.
 
 * NFC should "just work", provided you've installed a PC/SC initiator
   (driver) for your transciever (if it is not supported by `libccid`).
+
+  macOS tends to "butt in" on exclusive connections by selecting the PIV applet,
+  which can cause issues for some keys' firmware, especially if they support
+  PIV.
 
 * USB should "just work".
 

--- a/fido-key-manager/README.md
+++ b/fido-key-manager/README.md
@@ -38,6 +38,10 @@ Start-Process -FilePath "powershell" -Verb RunAs
 .\target\debug\fido-key-manager.exe --help
 ```
 
+By default, Cargo will build `fido-key-manager` with the `nfc` and `usb`
+[features][]. Additional features are described in `Cargo.toml` and in the
+remainder of this document.
+
 ## Commands
 
 Most `fido-key-manager` commands (except `info` and `factory-reset`) will
@@ -98,9 +102,13 @@ of the commands, or returns an unexpected value.
 
 ### SoloKey 2 / Trussed
 
+> **Tip:** this functionality is only available when `fido-key-manager` is
+> built with `--features solokey`.
+
 SoloKey 2 / Trussed commands are currently **only** supported over USB HID. NFC
 support may be added in future, but we have encountered many problems
-communicating with SoloKey / Trussed devices *at all* over NFC.
+communicating with SoloKey and Trussed devices *at all* over NFC, which has made
+things difficult.
 
 Command | Description
 ------- | -----------
@@ -110,7 +118,8 @@ Command | Description
 ## Platform-specific notes
 
 Bluetooth is currently disabled by default, as it's not particularly reliable on
-anything but macOS, and can easily accidentally select nearby devices.
+anything but macOS, and can easily accidentally select nearby devices. It can be
+enabled with `--features bluetooth`.
 
 ### Linux
 
@@ -218,3 +227,4 @@ As long as you're running `fido-key-manager` as Administrator:
 * USB support should "just work".
 
 [1]: https://learn.microsoft.com/en-us/previous-versions/bb756929(v=msdn.10)
+[features]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -50,6 +50,8 @@ ctap2 = [
     "dep:tokio-stream",
 ]
 ctap2-management = ["ctap2"]
+# Support for SoloKey's vendor commands
+vendor-solokey = []
 nfc = ["ctap2", "dep:pcsc"]
 # TODO: allow running softpasskey without softtoken
 softpasskey = ["crypto", "softtoken"]

--- a/webauthn-authenticator-rs/src/bluetooth/mod.rs
+++ b/webauthn-authenticator-rs/src/bluetooth/mod.rs
@@ -75,9 +75,9 @@ use crate::{
     transport::{
         types::{
             CBORResponse, KeepAliveStatus, Response, U2FError, BTLE_CANCEL, BTLE_KEEPALIVE,
-            TYPE_INIT, U2FHID_ERROR, U2FHID_MSG, U2FHID_PING,
+            U2FHID_ERROR, U2FHID_MSG, U2FHID_PING,
         },
-        Token, TokenEvent, Transport,
+        Token, TokenEvent, Transport, TYPE_INIT,
     },
     ui::UiCallback,
 };

--- a/webauthn-authenticator-rs/src/ctap2/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/mod.rs
@@ -128,6 +128,9 @@ mod ctap21_cred;
 mod ctap21pre;
 mod internal;
 mod pin_uv;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
+#[doc(hidden)]
+mod solokey;
 
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
@@ -158,6 +161,10 @@ pub use self::{
 pub use self::{
     ctap21_bio::BiometricAuthenticator, ctap21_cred::CredentialManagementAuthenticator,
 };
+
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
+#[doc(inline)]
+pub use self::solokey::SoloKeyAuthenticator;
 
 /// Abstraction for different versions of the CTAP2 protocol.
 ///

--- a/webauthn-authenticator-rs/src/ctap2/solokey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/solokey.rs
@@ -7,16 +7,36 @@ use crate::{
 
 use super::Ctap20Authenticator;
 
+/// SoloKey (Trussed) vendor-specific commands.
+///
+/// ## Warning
+///
+/// These commands currently operate on *any* [`Ctap20Authenticator`][], and do
+/// not filter to just SoloKey/Trussed devices. Due to the nature of CTAP
+/// vendor-specific commands, this may cause unexpected or undesirable behaviour
+/// on other vendors' keys.
+///
+/// Protocol notes are in [`crate::transport::solokey`].
 #[async_trait]
 pub trait SoloKeyAuthenticator {
-    async fn get_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
+    /// Gets the device-specific UUID of a SoloKey token.
+    async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
+
+    /// Gets the version of a SoloKey token.
+    async fn get_solokey_version(&mut self) -> Result<u32, WebauthnCError>;
 }
 
 #[async_trait]
 impl<'a, T: Token + SoloKeyToken, U: UiCallback> SoloKeyAuthenticator
     for Ctap20Authenticator<'a, T, U>
 {
-    async fn get_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
+    #[inline]
+    async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
         self.token.get_solokey_uuid().await
+    }
+
+    #[inline]
+    async fn get_solokey_version(&mut self) -> Result<u32, WebauthnCError> {
+        self.token.get_solokey_version().await
     }
 }

--- a/webauthn-authenticator-rs/src/ctap2/solokey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/solokey.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::{
+    prelude::WebauthnCError, transport::solokey::SoloKeyToken, transport::Token, ui::UiCallback,
+};
+
+use super::Ctap20Authenticator;
+
+#[async_trait]
+pub trait SoloKeyAuthenticator {
+    async fn get_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
+}
+
+#[async_trait]
+impl<'a, T: Token + SoloKeyToken, U: UiCallback> SoloKeyAuthenticator
+    for Ctap20Authenticator<'a, T, U>
+{
+    async fn get_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
+        self.token.get_solokey_uuid().await
+    }
+}

--- a/webauthn-authenticator-rs/src/ctap2/solokey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/solokey.rs
@@ -19,13 +19,16 @@ use super::Ctap20Authenticator;
 /// Protocol notes are in [`crate::transport::solokey`].
 #[async_trait]
 pub trait SoloKeyAuthenticator {
-    /// Gets the device's lock (secure boot) status.
+    /// Gets a SoloKey's lock (secure boot) status.
     async fn get_solokey_lock(&mut self) -> Result<bool, WebauthnCError>;
 
-    /// Gets the device-specific UUID of a SoloKey token.
+    /// Gets some random bytes from a SoloKey.
+    async fn get_solokey_random(&mut self) -> Result<[u8; 57], WebauthnCError>;
+
+    /// Gets a SoloKey's UUID.
     async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
 
-    /// Gets the version of a SoloKey token.
+    /// Gets a SoloKey's firmware version.
     async fn get_solokey_version(&mut self) -> Result<u32, WebauthnCError>;
 }
 
@@ -36,6 +39,11 @@ impl<'a, T: Token + SoloKeyToken, U: UiCallback> SoloKeyAuthenticator
     #[inline]
     async fn get_solokey_lock(&mut self) -> Result<bool, WebauthnCError> {
         self.token.get_solokey_lock().await
+    }
+
+    #[inline]
+    async fn get_solokey_random(&mut self) -> Result<[u8; 57], WebauthnCError> {
+        self.token.get_solokey_random().await
     }
 
     #[inline]

--- a/webauthn-authenticator-rs/src/ctap2/solokey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/solokey.rs
@@ -19,6 +19,9 @@ use super::Ctap20Authenticator;
 /// Protocol notes are in [`crate::transport::solokey`].
 #[async_trait]
 pub trait SoloKeyAuthenticator {
+    /// Gets the device's lock (secure boot) status.
+    async fn get_solokey_lock(&mut self) -> Result<bool, WebauthnCError>;
+
     /// Gets the device-specific UUID of a SoloKey token.
     async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
 
@@ -30,6 +33,11 @@ pub trait SoloKeyAuthenticator {
 impl<'a, T: Token + SoloKeyToken, U: UiCallback> SoloKeyAuthenticator
     for Ctap20Authenticator<'a, T, U>
 {
+    #[inline]
+    async fn get_solokey_lock(&mut self) -> Result<bool, WebauthnCError> {
+        self.token.get_solokey_lock().await
+    }
+
     #[inline]
     async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
         self.token.get_solokey_uuid().await

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -69,6 +69,8 @@ pub enum WebauthnCError {
     /// something has not been initialised correctly, or that the authenticator
     /// is sending unexpected messages.
     UnexpectedState,
+    #[cfg(feature = "usb")]
+    U2F(crate::transport::types::U2FError),
 }
 
 #[cfg(feature = "nfc")]
@@ -138,6 +140,13 @@ impl From<btleplug::Error> for WebauthnCError {
             PermissionDenied => WebauthnCError::PermissionDenied,
             _ => Self::BluetoothError(v.to_string()),
         }
+    }
+}
+
+#[cfg(feature = "usb")]
+impl From<crate::transport::types::U2FError> for WebauthnCError {
+    fn from(value: crate::transport::types::U2FError) -> Self {
+        Self::U2F(value)
     }
 }
 

--- a/webauthn-authenticator-rs/src/nfc/atr.rs
+++ b/webauthn-authenticator-rs/src/nfc/atr.rs
@@ -156,7 +156,6 @@ impl TryFrom<&[u8]> for Atr {
         let mut extended_lc = None;
         let mut card_issuers_data = None;
         if i + t1_len > atr.len() {
-            error!(?i, ?t1_len, "atr.len = {}", atr.len());
             return Err(WebauthnCError::MessageTooShort);
         }
         let t1 = &atr[i..i + t1_len];

--- a/webauthn-authenticator-rs/src/nfc/atr.rs
+++ b/webauthn-authenticator-rs/src/nfc/atr.rs
@@ -156,6 +156,7 @@ impl TryFrom<&[u8]> for Atr {
         let mut extended_lc = None;
         let mut card_issuers_data = None;
         if i + t1_len > atr.len() {
+            error!(?i, ?t1_len, "atr.len = {}", atr.len());
             return Err(WebauthnCError::MessageTooShort);
         }
         let t1 = &atr[i..i + t1_len];

--- a/webauthn-authenticator-rs/src/transport/mod.rs
+++ b/webauthn-authenticator-rs/src/transport/mod.rs
@@ -3,6 +3,8 @@
 //! See [crate::ctap2] for a higher-level abstraction over this API.
 mod any;
 pub mod iso7816;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
+pub(crate) mod solokey;
 #[cfg(any(doc, feature = "bluetooth", feature = "usb"))]
 pub(crate) mod types;
 
@@ -14,6 +16,9 @@ use std::fmt;
 use webauthn_rs_proto::AuthenticatorTransport;
 
 use crate::{ctap2::*, error::WebauthnCError, ui::UiCallback};
+
+#[cfg(any(doc, feature = "bluetooth", feature = "usb"))]
+pub(crate) const TYPE_INIT: u8 = 0x80;
 
 #[derive(Debug)]
 pub enum TokenEvent<T: Token> {

--- a/webauthn-authenticator-rs/src/transport/solokey.rs
+++ b/webauthn-authenticator-rs/src/transport/solokey.rs
@@ -1,3 +1,30 @@
+//! SoloKey (Trussed) vendor-specific commands.
+//!
+//! ## USB HID
+//!
+//! Commands are sent on a `U2FHIDFrame` level, and values are bitwise-OR'd
+//! with `transport::TYPE_INIT` (0x80).
+//!
+//! Command | Description | Request | Response
+//! ------- | ----------- | ------- | --------
+//! `0x51`  | Update      | _none_ to reboot into update mode, `01` to be "destructive" | _none_
+//! `0x53`  | Reboot      | _none_  | _none_
+//! `0x60`  | Get random bytes | _none_ | 57 bytes of randomness
+//! `0x61`  | Get version | _none_  | Version ID as `u32`
+//! `0x62`  | Get device UUID | _none_ | Big-endian UUID (16 bytes)
+//! `0x63`  | Get lock state | _none_ | `0` for unlocked "hacker edition" devices, `1` if locked
+//!
+//! ## NFC
+//!
+//! Admin app AID: `A0 00 00 08 47 00 00 00 01`
+//!
+//! ## References
+//!
+//! * [`solo2-cli` Admin commands][0]
+//! * [SoloKeys `admin-app` commands][1]
+//!
+//! [0]: https://github.com/solokeys/solo2-cli/blob/main/src/apps/admin.rs
+//! [1]: https://github.com/solokeys/admin-app/blob/main/src/admin.rs
 use async_trait::async_trait;
 use uuid::Uuid;
 
@@ -6,15 +33,38 @@ use crate::prelude::WebauthnCError;
 use super::AnyToken;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
+pub const CMD_RAND: u8 = super::TYPE_INIT | 0x60;
+
+#[cfg(all(feature = "usb", feature = "vendor-solokey"))]
+pub const CMD_VERSION: u8 = super::TYPE_INIT | 0x61;
+
+#[cfg(all(feature = "usb", feature = "vendor-solokey"))]
 pub const CMD_UUID: u8 = super::TYPE_INIT | 0x62;
 
+/// See [`SoloKeyAuthenticator`](crate::ctap2::SoloKeyAuthenticator).
 #[async_trait]
 pub trait SoloKeyToken {
+    /// See [`SoloKeyAuthenticator::get_solokey_version()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_version).
+    async fn get_solokey_version(&mut self) -> Result<u32, WebauthnCError>;
+
+    /// See [`SoloKeyAuthenticator::get_solokey_uuid()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_uuid).
     async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
 }
 
 #[async_trait]
 impl SoloKeyToken for AnyToken {
+    async fn get_solokey_version(&mut self) -> Result<u32, WebauthnCError> {
+        match self {
+            AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "nfc")]
+            AnyToken::Nfc(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "usb")]
+            AnyToken::Usb(u) => u.get_solokey_version().await,
+        }
+    }
+
     async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
         match self {
             AnyToken::Stub => unimplemented!(),

--- a/webauthn-authenticator-rs/src/transport/solokey.rs
+++ b/webauthn-authenticator-rs/src/transport/solokey.rs
@@ -61,6 +61,7 @@ pub trait SoloKeyToken {
 }
 
 #[async_trait]
+#[allow(clippy::unimplemented)]
 impl SoloKeyToken for AnyToken {
     async fn get_solokey_lock(&mut self) -> Result<bool, WebauthnCError> {
         match self {

--- a/webauthn-authenticator-rs/src/transport/solokey.rs
+++ b/webauthn-authenticator-rs/src/transport/solokey.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::prelude::WebauthnCError;
+
+use super::AnyToken;
+
+#[cfg(all(feature = "usb", feature = "vendor-solokey"))]
+pub const CMD_UUID: u8 = super::TYPE_INIT | 0x62;
+
+#[async_trait]
+pub trait SoloKeyToken {
+    async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError>;
+}
+
+#[async_trait]
+impl SoloKeyToken for AnyToken {
+    async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
+        match self {
+            AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "nfc")]
+            AnyToken::Nfc(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "usb")]
+            AnyToken::Usb(u) => u.get_solokey_uuid().await,
+        }
+    }
+}

--- a/webauthn-authenticator-rs/src/transport/solokey.rs
+++ b/webauthn-authenticator-rs/src/transport/solokey.rs
@@ -33,16 +33,16 @@ use crate::prelude::WebauthnCError;
 use super::AnyToken;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
-pub const CMD_RANDOM: u8 = super::TYPE_INIT | 0x60;
+pub(crate) const CMD_RANDOM: u8 = super::TYPE_INIT | 0x60;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
-pub const CMD_VERSION: u8 = super::TYPE_INIT | 0x61;
+pub(crate) const CMD_VERSION: u8 = super::TYPE_INIT | 0x61;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
-pub const CMD_UUID: u8 = super::TYPE_INIT | 0x62;
+pub(crate) const CMD_UUID: u8 = super::TYPE_INIT | 0x62;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
-pub const CMD_LOCK: u8 = super::TYPE_INIT | 0x63;
+pub(crate) const CMD_LOCK: u8 = super::TYPE_INIT | 0x63;
 
 /// See [`SoloKeyAuthenticator`](crate::ctap2::SoloKeyAuthenticator).
 #[async_trait]

--- a/webauthn-authenticator-rs/src/transport/solokey.rs
+++ b/webauthn-authenticator-rs/src/transport/solokey.rs
@@ -33,7 +33,7 @@ use crate::prelude::WebauthnCError;
 use super::AnyToken;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
-pub const CMD_RAND: u8 = super::TYPE_INIT | 0x60;
+pub const CMD_RANDOM: u8 = super::TYPE_INIT | 0x60;
 
 #[cfg(all(feature = "usb", feature = "vendor-solokey"))]
 pub const CMD_VERSION: u8 = super::TYPE_INIT | 0x61;
@@ -49,6 +49,9 @@ pub const CMD_LOCK: u8 = super::TYPE_INIT | 0x63;
 pub trait SoloKeyToken {
     /// See [`SoloKeyAuthenticator::get_solokey_lock()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_lock).
     async fn get_solokey_lock(&mut self) -> Result<bool, WebauthnCError>;
+
+    /// See [`SoloKeyAuthenticator::get_solokey_random()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_random).
+    async fn get_solokey_random(&mut self) -> Result<[u8; 57], WebauthnCError>;
 
     /// See [`SoloKeyAuthenticator::get_solokey_version()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_version).
     async fn get_solokey_version(&mut self) -> Result<u32, WebauthnCError>;
@@ -68,6 +71,18 @@ impl SoloKeyToken for AnyToken {
             AnyToken::Nfc(_) => Err(WebauthnCError::NotSupported),
             #[cfg(feature = "usb")]
             AnyToken::Usb(u) => u.get_solokey_lock().await,
+        }
+    }
+
+    async fn get_solokey_random(&mut self) -> Result<[u8; 57], WebauthnCError> {
+        match self {
+            AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "nfc")]
+            AnyToken::Nfc(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "usb")]
+            AnyToken::Usb(u) => u.get_solokey_random().await,
         }
     }
 

--- a/webauthn-authenticator-rs/src/transport/types.rs
+++ b/webauthn-authenticator-rs/src/transport/types.rs
@@ -1,3 +1,4 @@
+use super::TYPE_INIT;
 use crate::error::{CtapError, WebauthnCError};
 
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]

--- a/webauthn-authenticator-rs/src/transport/types.rs
+++ b/webauthn-authenticator-rs/src/transport/types.rs
@@ -3,7 +3,6 @@ use crate::error::{CtapError, WebauthnCError};
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 use super::iso7816::ISO7816ResponseAPDU;
 
-pub const TYPE_INIT: u8 = 0x80;
 pub const U2FHID_PING: u8 = TYPE_INIT | 0x01;
 #[cfg(any(doc, feature = "bluetooth"))]
 pub const BTLE_KEEPALIVE: u8 = TYPE_INIT | 0x02;

--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -13,6 +13,8 @@
 //! Windows instead.
 mod framing;
 mod responses;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
+mod solokey;
 
 use fido_hid_rs::{
     HidReportBytes, HidSendReportBytes, USBDevice, USBDeviceImpl, USBDeviceInfo, USBDeviceInfoImpl,

--- a/webauthn-authenticator-rs/src/usb/responses.rs
+++ b/webauthn-authenticator-rs/src/usb/responses.rs
@@ -1,9 +1,12 @@
 //! All [Response] frame types, used by FIDO tokens over USB HID.
 use crate::error::WebauthnCError;
-use crate::transport::iso7816::ISO7816ResponseAPDU;
-use crate::transport::types::{
-    CBORResponse, U2FError, TYPE_INIT, U2FHID_CBOR, U2FHID_ERROR, U2FHID_KEEPALIVE, U2FHID_MSG,
-    U2FHID_PING,
+use crate::transport::{
+    iso7816::ISO7816ResponseAPDU,
+    types::{
+        CBORResponse, U2FError, U2FHID_CBOR, U2FHID_ERROR, U2FHID_KEEPALIVE, U2FHID_MSG,
+        U2FHID_PING,
+    },
+    TYPE_INIT,
 };
 use crate::usb::framing::U2FHIDFrame;
 use crate::usb::*;

--- a/webauthn-authenticator-rs/src/usb/solokey.rs
+++ b/webauthn-authenticator-rs/src/usb/solokey.rs
@@ -1,10 +1,7 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-#[cfg(any(
-    all(doc, not(doctest)),
-    all(feature = "usb", feature = "vendor-solokey")
-))]
+#[cfg(all(feature = "usb", feature = "vendor-solokey"))]
 use crate::transport::solokey::{CMD_LOCK, CMD_RANDOM, CMD_UUID, CMD_VERSION};
 
 use crate::{

--- a/webauthn-authenticator-rs/src/usb/solokey.rs
+++ b/webauthn-authenticator-rs/src/usb/solokey.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::{
+    prelude::WebauthnCError,
+    transport::{
+        solokey::{SoloKeyToken, CMD_UUID},
+        types::{U2FError, U2FHID_ERROR},
+    },
+    usb::framing::U2FHIDFrame,
+};
+
+use super::{USBToken, USBTransport};
+
+#[async_trait]
+impl SoloKeyToken for USBToken {
+    async fn get_solokey_uuid(&mut self) -> Result<Uuid, WebauthnCError> {
+        let cmd = U2FHIDFrame {
+            cid: self.cid,
+            cmd: CMD_UUID,
+            len: 0,
+            data: vec![],
+        };
+        self.send_one(&cmd).await?;
+
+        let r = self.recv_one().await?;
+        match r.cmd {
+            CMD_UUID => {
+                if r.len != 16 || r.data.len() != 16 {
+                    return Err(WebauthnCError::InvalidMessageLength);
+                }
+
+                let u = Uuid::from_bytes(
+                    r.data
+                        .try_into()
+                        .map_err(|_| WebauthnCError::InvalidMessageLength)?,
+                );
+
+                Ok(u)
+            }
+
+            U2FHID_ERROR => Err(U2FError::from(r.data.as_slice()).into()),
+
+            _ => Err(WebauthnCError::UnexpectedState),
+        }
+    }
+}

--- a/webauthn-authenticator-rs/src/usb/solokey.rs
+++ b/webauthn-authenticator-rs/src/usb/solokey.rs
@@ -13,10 +13,8 @@ use crate::{
         solokey::SoloKeyToken,
         types::{U2FError, U2FHID_ERROR},
     },
-    usb::framing::U2FHIDFrame,
+    usb::{framing::U2FHIDFrame, USBToken},
 };
-
-use super::{USBToken, USBTransport};
 
 #[async_trait]
 impl SoloKeyToken for USBToken {

--- a/webauthn-authenticator-rs/src/usb/solokey.rs
+++ b/webauthn-authenticator-rs/src/usb/solokey.rs
@@ -1,10 +1,16 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
+#[cfg(any(
+    all(doc, not(doctest)),
+    all(feature = "usb", feature = "vendor-solokey")
+))]
+use crate::transport::solokey::{CMD_LOCK, CMD_RANDOM, CMD_UUID, CMD_VERSION};
+
 use crate::{
     prelude::WebauthnCError,
     transport::{
-        solokey::{SoloKeyToken, CMD_LOCK, CMD_RANDOM, CMD_UUID, CMD_VERSION},
+        solokey::SoloKeyToken,
         types::{U2FError, U2FHID_ERROR},
     },
     usb::framing::U2FHIDFrame,


### PR DESCRIPTION
This implements some vendor-specific SoloKeys 2 (Trussed) vendor-specific commands:

* get device UUID
* get firmware version
* get lock / secure boot status
* get random bytes

These commands all operate at a `U2FHidFrame` layer, so this also adds a bunch of plumbing to make that all work.

I've tested these with SoloKeys Solo 2 and NitroKey 3A over USB HID. I've tried a few other keys, and they appear to ignore these commands without any issues, but due to the nature of vendor commands this is all very difficult to manage.

I haven't implemented NFC support as that's been very unreliable.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
