### PR TITLE
Revert "Feature/configurable timeout"

### DIFF
--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -4,7 +4,6 @@ extern crate tracing;
 #[cfg(feature = "softtoken")]
 use std::fs::OpenOptions;
 use std::io::{stdin, stdout, Write};
-use std::time::Duration;
 
 use clap::clap_derive::ValueEnum;
 #[cfg(any(feature = "cable", feature = "softtoken"))]
@@ -237,7 +236,7 @@ async fn main() {
         "https://localhost:8080/auth",
         "localhost",
         vec![url::Url::parse("https://localhost:8080").unwrap()],
-        Some(Duration::from_millis(1)),
+        Some(1),
         None,
         None,
     );

--- a/webauthn-rs-core/src/constants.rs
+++ b/webauthn-rs-core/src/constants.rs
@@ -1,5 +1,4 @@
-use std::time::Duration;
-
 // Can this ever change?
 pub const CHALLENGE_SIZE_BYTES: usize = 32;
-pub const DEFAULT_AUTHENTICATOR_TIMEOUT: Duration = Duration::from_millis(60000);
+// Allegedly this is milliseconds?
+pub const AUTHENTICATOR_TIMEOUT: u32 = 60000;

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -18,7 +18,6 @@
 use rand::prelude::*;
 use std::collections::BTreeSet;
 use std::convert::TryFrom;
-use std::time::Duration;
 use url::Url;
 
 use crate::attestation::{
@@ -26,7 +25,7 @@ use crate::attestation::{
     verify_apple_anonymous_attestation, verify_attestation_ca_chain, verify_fidou2f_attestation,
     verify_packed_attestation, verify_tpm_attestation, AttestationFormat,
 };
-use crate::constants::{CHALLENGE_SIZE_BYTES, DEFAULT_AUTHENTICATOR_TIMEOUT};
+use crate::constants::{AUTHENTICATOR_TIMEOUT, CHALLENGE_SIZE_BYTES};
 use crate::crypto::compute_sha256;
 use crate::error::WebauthnError;
 use crate::internals::*;
@@ -55,7 +54,7 @@ pub struct WebauthnCore {
     rp_id: String,
     rp_id_hash: [u8; 32],
     allowed_origins: Vec<Url>,
-    authenticator_timeout: Duration,
+    authenticator_timeout: u32,
     require_valid_counter_value: bool,
     #[allow(unused)]
     ignore_unsupported_attestation_formats: bool,
@@ -85,7 +84,7 @@ impl WebauthnCore {
         rp_name: &str,
         rp_id: &str,
         allowed_origins: Vec<Url>,
-        authenticator_timeout: Option<Duration>,
+        authenticator_timeout: Option<u32>,
         allow_subdomains_origin: Option<bool>,
         allow_any_port: Option<bool>,
     ) -> Self {
@@ -95,7 +94,7 @@ impl WebauthnCore {
             rp_id: rp_id.to_string(),
             rp_id_hash,
             allowed_origins,
-            authenticator_timeout: authenticator_timeout.unwrap_or(DEFAULT_AUTHENTICATOR_TIMEOUT),
+            authenticator_timeout: authenticator_timeout.unwrap_or(AUTHENTICATOR_TIMEOUT),
             require_valid_counter_value: true,
             ignore_unsupported_attestation_formats: true,
             allow_cross_origin: false,
@@ -214,9 +213,6 @@ impl WebauthnCore {
             Some(ResidentKeyRequirement::Discouraged)
         };
 
-        let timeout_millis =
-            u32::try_from(self.authenticator_timeout.as_millis()).expect("Timeout too large");
-
         let c = CreationChallengeResponse {
             public_key: PublicKeyCredentialCreationOptions {
                 rp: RelyingParty {
@@ -236,7 +232,7 @@ impl WebauthnCore {
                         alg: *alg as i64,
                     })
                     .collect(),
-                timeout: Some(timeout_millis),
+                timeout: Some(self.authenticator_timeout),
                 attestation: Some(attestation),
                 exclude_credentials: exclude_credentials.as_ref().map(|creds| {
                     creds
@@ -939,15 +935,12 @@ impl WebauthnCore {
         // Extract the appid from the extensions to store it in the AuthenticationState
         let appid = extensions.as_ref().and_then(|e| e.appid.clone());
 
-        let timeout_millis =
-            u32::try_from(self.authenticator_timeout.as_millis()).expect("Timeout too large");
-
         // Store the chal associated to the user.
         // Now put that into the correct challenge format
         let r = RequestChallengeResponse {
             public_key: PublicKeyCredentialRequestOptions {
                 challenge: chal.clone().into(),
-                timeout: Some(timeout_millis),
+                timeout: Some(self.authenticator_timeout),
                 rp_id: self.rp_id.clone(),
                 allow_credentials: ac,
                 user_verification: policy,

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -185,7 +185,6 @@ extern crate tracing;
 
 mod interface;
 
-use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
 use webauthn_rs_core::error::{WebauthnError, WebauthnResult};
@@ -226,7 +225,6 @@ pub struct WebauthnBuilder<'a> {
     allowed_origins: Vec<Url>,
     allow_subdomains: bool,
     allow_any_port: bool,
-    timeout: Option<Duration>,
     algorithms: Vec<COSEAlgorithm>,
     user_presence_only_security_keys: bool,
 }
@@ -282,7 +280,6 @@ impl<'a> WebauthnBuilder<'a> {
                 allowed_origins: vec![rp_origin.to_owned()],
                 allow_subdomains: false,
                 allow_any_port: false,
-                timeout: None,
                 algorithms: COSEAlgorithm::secure_algs(),
                 user_presence_only_security_keys: false,
             })
@@ -315,14 +312,6 @@ impl<'a> WebauthnBuilder<'a> {
     /// app-specific origins than a web browser would.
     pub fn append_allowed_origin(mut self, origin: &Url) -> Self {
         self.allowed_origins.push(origin.to_owned());
-        self
-    }
-
-    /// Set the timeout value to use for credential creation and authentication challenges.
-    ///
-    /// If not set, defaults to [webauthn_rs_core::constants::DEFAULT_AUTHENTICATOR_TIMEOUT].
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = Some(timeout);
         self
     }
 
@@ -367,7 +356,7 @@ impl<'a> WebauthnBuilder<'a> {
                 self.rp_name.unwrap_or(self.rp_id),
                 self.rp_id,
                 self.allowed_origins,
-                self.timeout,
+                None,
                 Some(self.allow_subdomains),
                 Some(self.allow_any_port),
             ),


### PR DESCRIPTION
Reverts kanidm/webauthn-rs#385

This broke the documentation build on Rust `stable`:

```
  Documenting webauthn-attestation-ca v0.1.0 (/home/runner/work/webauthn-rs/webauthn-rs/attestation-ca)
error: unresolved link to `webauthn_rs_core::constants::DEFAULT_AUTHENTICATOR_TIMEOUT`
   --> webauthn-rs/src/lib.rs:323:34
    |
323 |     /// If not set, defaults to [webauthn_rs_core::constants::DEFAULT_AUTHENTICATOR_TIMEOUT].
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `constants` in module `webauthn_rs_core`
    |
note: the lint level is defined here
   --> webauthn-rs/src/lib.rs:170:9
    |
170 | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`

error: could not document `webauthn-rs`
```

`webauthn_rs_core::constants` is not public, so you can't reference it in `webauthn-rs`.

`nightly` issues will be addressed in a follow-up, they're related to a change a made a while ago.