### PR TITLE
394 - set axum cookie 'secure' to false

### DIFF
--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -1,0 +1,12 @@
+.DEFAULT: help
+.PHONY: help
+help:
+	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+wasm: ## build the WASM parts
+wasm:
+	cd wasm && ./build.sh
+
+actix: ## Build the WASM parts and run the actix server
+actix: wasm
+	cd server/actix_web && cargo run

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -6,4 +6,3 @@ This is a tutorial / example of how to use the webauthn-rs library in a minimal 
 
 There are two halves to this tutorial - a backend server (`site`) and the front end
 that contains a single-page html/wasm application (`wasm`).
-

--- a/tutorial/server/actix_web/src/handler/serve_wasm.rs
+++ b/tutorial/server/actix_web/src/handler/serve_wasm.rs
@@ -3,8 +3,10 @@ use std::path::PathBuf;
 use actix_files::NamedFile;
 use actix_web::HttpRequest;
 
+pub const WASM_DIR: &str = "../../wasm/pkg";
+
 pub(crate) async fn serve_wasm(req: HttpRequest) -> actix_web::Result<NamedFile> {
     let fp: PathBuf = req.match_info().query("filename").parse().unwrap();
-    let path = PathBuf::new().join("../../wasm/pkg").join(fp);
+    let path = PathBuf::new().join(WASM_DIR).join(fp);
     Ok(NamedFile::open(path)?)
 }


### PR DESCRIPTION
Fixes #394 - axum cookie storage wasn't working on localhost http because the [default is true](https://docs.rs/actix-session/0.8.0/actix_session/config/struct.SessionMiddlewareBuilder.html#method.cookie_secure) which blocks the cookies on `http`

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
