### PR TITLE
20231129 attestation finalisation

### DIFF
--- a/attestation-ca/src/lib.rs
+++ b/attestation-ca/src/lib.rs
@@ -125,7 +125,7 @@ impl AttestationCa {
         if self.blanket_allow || other.blanket_allow {
             self.blanket_allow = true;
             self.aaguids.clear();
-            return
+            return;
         } else {
             self.blanket_allow = false;
             for (o_aaguid, o_device) in other.aaguids.iter() {
@@ -142,7 +142,7 @@ impl AttestationCa {
         // more restrictive, or we also are a blanket allow
         if other.blanket_allow() {
             // Do nothing
-            return
+            return;
         } else if self.blanket_allow {
             // Just set our aaguids to other, and remove our blanket allow.
             self.blanket_allow = false;

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -39,7 +39,7 @@ pub struct SoftToken {
     #[serde(with = "PKeyPrivateDef")]
     _ca_key: pkey::PKey<pkey::Private>,
     #[serde(with = "X509Def")]
-    _ca_cert: X509,
+    ca_cert: X509,
     #[serde(with = "PKeyPrivateDef")]
     intermediate_key: pkey::PKey<pkey::Private>,
     #[serde(with = "X509Def")]
@@ -246,7 +246,7 @@ impl SoftToken {
             SoftToken {
                 // We could consider throwing these away?
                 _ca_key: ca_key,
-                _ca_cert: ca_cert,
+                ca_cert,
                 intermediate_key,
                 intermediate_cert,
                 tokens: HashMap::new(),

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -27,8 +27,8 @@ use base64urlsafedata::Base64UrlSafeData;
 
 use webauthn_rs_proto::{
     AllowCredentials, AuthenticationExtensionsClientOutputs, AuthenticatorAssertionResponseRaw,
-    AuthenticatorAttachment, AuthenticatorAttestationResponseRaw, PublicKeyCredential,
-    PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
+    AuthenticatorAttachment, AuthenticatorAttestationResponseRaw, AuthenticatorTransport,
+    PublicKeyCredential, PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
     RegisterPublicKeyCredential, RegistrationExtensionsClientOutputs, UserVerificationPolicy,
 };
 
@@ -596,7 +596,7 @@ impl AuthenticatorBackendHashedClientData for SoftToken {
             response: AuthenticatorAttestationResponseRaw {
                 attestation_object: Base64UrlSafeData(ao_bytes),
                 client_data_json: Base64UrlSafeData(vec![]),
-                transports: None,
+                transports: Some(vec![AuthenticatorTransport::Internal]),
             },
             type_: "public-key".to_string(),
             extensions: RegistrationExtensionsClientOutputs::default(),

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -1242,7 +1242,7 @@ pub fn verify_attestation_ca_chain<'a>(
     danger_disable_certificate_time_checks: bool,
 ) -> Result<Option<&'a AttestationCa>, WebauthnError> {
     // If the ca_list is empty, Immediately fail since no valid attestation can be created.
-    if ca_list.cas.is_empty() {
+    if ca_list.cas().is_empty() {
         return Err(WebauthnError::AttestationCertificateTrustStoreEmpty);
     }
 
@@ -1288,7 +1288,7 @@ pub fn verify_attestation_ca_chain<'a>(
             .map_err(WebauthnError::OpenSSLError)?;
     }
 
-    for ca_crt in ca_list.cas.values() {
+    for ca_crt in ca_list.cas().values() {
         ca_store
             .add_cert(ca_crt.ca().clone())
             .map_err(WebauthnError::OpenSSLError)?;
@@ -1342,7 +1342,7 @@ pub fn verify_attestation_ca_chain<'a>(
     // attestation CA.
     res.and_then(|dgst| {
         ca_list
-            .cas
+            .cas()
             .get(dgst.as_ref())
             .ok_or_else(|| {
                 WebauthnError::AttestationChainNotTrusted("Invalid CA digest maps".to_string())

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -362,6 +362,19 @@ pub enum AttestationFormat {
     None,
 }
 
+impl AttestationFormat {
+    /// Only a small number of devices correctly report their transports. These are
+    /// limited to attested devices, and exclusively packed (fido2) and tpms. Most
+    /// other devices/browsers will get this wrong, meaning that authentication will
+    /// fail or not offer the correct transports to the user.
+    pub(crate) fn transports_valid(&self) -> bool {
+        match self {
+            AttestationFormat::Packed | AttestationFormat::Tpm => true,
+            _ => false,
+        }
+    }
+}
+
 impl TryFrom<&str> for AttestationFormat {
     type Error = WebauthnError;
 

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -368,10 +368,7 @@ impl AttestationFormat {
     /// other devices/browsers will get this wrong, meaning that authentication will
     /// fail or not offer the correct transports to the user.
     pub(crate) fn transports_valid(&self) -> bool {
-        match self {
-            AttestationFormat::Packed | AttestationFormat::Tpm => true,
-            _ => false,
-        }
+        matches!(self, AttestationFormat::Packed | AttestationFormat::Tpm)
     }
 }
 

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -602,10 +602,10 @@ impl WebauthnCore {
         debug!("attested_ca_crt = {:?}", attested_ca_crt);
 
         // Assert that the aaguid of the device, is within the authority of this CA (if
-        // a list of aaguids was provided).
+        // a list of aaguids was provided, and the ca blanket allows verification).
         if let Some(att_ca_crt) = attested_ca_crt {
-            if att_ca_crt.aaguids().is_empty() {
-                trace!("No aaguids set present, allowing all associated keys.");
+            if att_ca_crt.blanket_allow() {
+                trace!("CA allows all associated keys.");
             } else {
                 match &credential.attestation.metadata {
                     AttestationMetadata::Packed { aaguid }

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -284,20 +284,19 @@ impl Credential {
     /// be useful if you want to re-assert your credentials match an updated or changed
     /// ca_list from the time that registration occured. This can also be useful to
     /// re-determine certain properties of your device that may exist.
-    ///
-    /// # Safety
-    /// Due to the design of CA infrastructure by certain providers, it is NOT possible
-    /// to verify the CA expiry time. Certain vendors use CA intermediates that have
-    /// expiries that are only valid for approximately 10 minutes, meaning that if we
-    /// enforced time validity, these would false negative for their validity.
+    // ///
+    // /// # Safety
+    // /// Due to the design of CA infrastructure by certain providers, it is NOT possible
+    // /// to verify the CA expiry time. Certain vendors use CA intermediates that have
+    // /// expiries that are only valid for approximately 10 minutes, meaning that if we
+    // /// enforced time validity, these would false negative for their validity.
     pub fn verify_attestation<'a>(
         &'_ self,
         ca_list: &'a AttestationCaList,
     ) -> Result<Option<&'a AttestationCa>, WebauthnError> {
-        // Why do we disable this? Because of Apple. They issue dynamic short lived
-        // attestation certs, that last for about 5 minutes. This means that
-        // post-registration validation will always fail if we validate time.
-        let danger_disable_certificate_time_checks = true;
+        // Formerly we disabled this due to apple, but they no longer provide
+        // meaningful attesation so we can re-enable it.
+        let danger_disable_certificate_time_checks = false;
         verify_attestation_ca_chain(
             &self.attestation.data,
             ca_list,

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -284,12 +284,6 @@ impl Credential {
     /// be useful if you want to re-assert your credentials match an updated or changed
     /// ca_list from the time that registration occured. This can also be useful to
     /// re-determine certain properties of your device that may exist.
-    // ///
-    // /// # Safety
-    // /// Due to the design of CA infrastructure by certain providers, it is NOT possible
-    // /// to verify the CA expiry time. Certain vendors use CA intermediates that have
-    // /// expiries that are only valid for approximately 10 minutes, meaning that if we
-    // /// enforced time validity, these would false negative for their validity.
     pub fn verify_attestation<'a>(
         &'_ self,
         ca_list: &'a AttestationCaList,

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -126,7 +126,7 @@ impl Credential {
         req_extn: &RequestRegistrationExtensions,
         client_extn: &RegistrationExtensionsClientOutputs,
         attestation_format: AttestationFormat,
-        _transports: &Option<Vec<AuthenticatorTransport>>,
+        transports: &Option<Vec<AuthenticatorTransport>>,
     ) -> Self {
         let cred_protect = match (
             auth_data.extensions.cred_protect.as_ref(),
@@ -182,8 +182,11 @@ impl Credential {
         let backup_eligible = auth_data.backup_eligible;
         let backup_state = auth_data.backup_state;
 
-        // due to bugs in chrome, we have to disable transports because lol.
-        let transports = None;
+        let transports = if attestation_format.transports_valid() {
+            transports.clone()
+        } else {
+            None
+        };
 
         Credential {
             cred_id: acd.credential_id.clone(),

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -204,7 +204,9 @@ pub mod prelude {
     pub use webauthn_rs_core::error::{WebauthnError, WebauthnResult};
     #[cfg(feature = "danger-credential-internals")]
     pub use webauthn_rs_core::proto::Credential;
-    pub use webauthn_rs_core::proto::{AttestationCa, AttestationCaList, AttestationCaListBuilder, AuthenticatorAttachment};
+    pub use webauthn_rs_core::proto::{
+        AttestationCa, AttestationCaList, AttestationCaListBuilder, AuthenticatorAttachment,
+    };
     pub use webauthn_rs_core::proto::{
         AttestationMetadata, AuthenticationResult, AuthenticationState, CreationChallengeResponse,
         CredentialID, ParsedAttestation, ParsedAttestationData, PublicKeyCredential,

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -204,7 +204,7 @@ pub mod prelude {
     pub use webauthn_rs_core::error::{WebauthnError, WebauthnResult};
     #[cfg(feature = "danger-credential-internals")]
     pub use webauthn_rs_core::proto::Credential;
-    pub use webauthn_rs_core::proto::{AttestationCa, AttestationCaList, AuthenticatorAttachment};
+    pub use webauthn_rs_core::proto::{AttestationCa, AttestationCaList, AttestationCaListBuilder, AuthenticatorAttachment};
     pub use webauthn_rs_core::proto::{
         AttestationMetadata, AuthenticationResult, AuthenticationState, CreationChallengeResponse,
         CredentialID, ParsedAttestation, ParsedAttestationData, PublicKeyCredential,


### PR DESCRIPTION
This finalises what is required for Kanidm for Webauthn attestation. Being used in "anger" showed a number of smaller issues around the attestation paths and code base. 

- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
