### PR TITLE
One line fix - missing cfg

### DIFF
--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -268,6 +268,7 @@ impl PartialEq for AttestedPasskey {
     }
 }
 
+#[cfg(feature = "attestation")]
 impl Eq for AttestedPasskey {}
 
 #[cfg(feature = "attestation")]


### PR DESCRIPTION
Missing cfg in interface.

- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
