### PR TITLE
20231215 264 cleanup

### DIFF
--- a/attestation-ca/src/lib.rs
+++ b/attestation-ca/src/lib.rs
@@ -125,7 +125,6 @@ impl AttestationCa {
         if self.blanket_allow || other.blanket_allow {
             self.blanket_allow = true;
             self.aaguids.clear();
-            return;
         } else {
             self.blanket_allow = false;
             for (o_aaguid, o_device) in other.aaguids.iter() {
@@ -142,7 +141,6 @@ impl AttestationCa {
         // more restrictive, or we also are a blanket allow
         if other.blanket_allow() {
             // Do nothing
-            return;
         } else if self.blanket_allow {
             // Just set our aaguids to other, and remove our blanket allow.
             self.blanket_allow = false;

--- a/compat_tester/webauthn-rs-demo/src/actors.rs
+++ b/compat_tester/webauthn-rs-demo/src/actors.rs
@@ -326,7 +326,7 @@ impl WebauthnActor {
 
         let user_unique_id = Uuid::new_v4();
 
-        let (ccr, rs) = self.wan.generate_challenge_register_options(
+        let (ccr, rs) = self.wan.generate_challenge_register(
             user_unique_id.as_bytes(),
             &username,
             &username,
@@ -360,7 +360,6 @@ impl WebauthnActor {
 
         // If use_cred_id is set, only allow this cred to be used. This also allows
         // some extra "stuff".
-
         let (acr, st) = match use_cred_id {
             Some(use_cred_id) => {
                 let cred = creds
@@ -369,9 +368,11 @@ impl WebauthnActor {
                     .ok_or(WebauthnError::CredentialNotFound)?;
 
                 self.wan
-                    .generate_challenge_authenticate_credential(cred, uv, extensions)
+                    .generate_challenge_authenticate(vec![cred], uv, extensions, None)
             }
-            None => self.wan.generate_challenge_authenticate(creds, extensions),
+            None => self
+                .wan
+                .generate_challenge_authenticate(creds, None, extensions, None),
         }?;
 
         debug!("complete ChallengeAuthenticate -> {:?}", acr);

--- a/compat_tester/webauthn-rs-demo/src/actors.rs
+++ b/compat_tester/webauthn-rs-demo/src/actors.rs
@@ -326,19 +326,18 @@ impl WebauthnActor {
 
         let user_unique_id = Uuid::new_v4();
 
-        let (ccr, rs) = self.wan.generate_challenge_register(
-            user_unique_id.as_bytes(),
-            &username,
-            &username,
-            attestation.unwrap_or(AttestationConveyancePreference::None),
-            uv,
-            None,
-            extensions,
-            algorithm.unwrap_or_else(|| vec![COSEAlgorithm::ES256, COSEAlgorithm::RS256]),
-            false,
-            attachment,
-            false,
-        )?;
+        let builder = self
+            .wan
+            .new_challenge_register_builder(user_unique_id.as_bytes(), &username, &username)?
+            .attestation(attestation.unwrap_or(AttestationConveyancePreference::None))
+            .user_verification_policy(uv.unwrap_or_default())
+            .extensions(extensions)
+            .authenticator_attachment(attachment)
+            .credential_algorithms(
+                algorithm.unwrap_or_else(|| vec![COSEAlgorithm::ES256, COSEAlgorithm::RS256]),
+            );
+
+        let (ccr, rs) = self.wan.generate_challenge_register(builder)?;
 
         debug!("complete ChallengeRegister -> {:?}", ccr);
         Ok((ccr, rs))

--- a/fido-key-manager/src/main.rs
+++ b/fido-key-manager/src/main.rs
@@ -22,7 +22,7 @@ use webauthn_authenticator_rs::{
     ui::Cli,
     SHA256Hash,
 };
-use webauthn_rs_core::interface::COSEKeyType;
+use webauthn_rs_core::proto::COSEKeyType;
 
 /// Parses a Base-16 encoded string.
 ///

--- a/sshkey-attest/src/lib.rs
+++ b/sshkey-attest/src/lib.rs
@@ -25,9 +25,10 @@ use uuid::Uuid;
 pub use webauthn_rs_core::error::WebauthnError;
 use webauthn_rs_core::{
     attestation::{
-        validate_extension, verify_attestation_ca_chain, AttestationFormat, FidoGenCeAaguid,
+        assert_packed_attest_req, validate_extension, verify_attestation_ca_chain,
+        AttestationFormat, FidoGenCeAaguid,
     },
-    crypto::{assert_packed_attest_req, compute_sha256, verify_signature},
+    crypto::{compute_sha256, verify_signature},
     internals::AuthenticatorData,
     proto::{
         AttestationCaList, AttestationMetadata, COSEAlgorithm, COSEKey, COSEKeyType,

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -248,7 +248,7 @@ async fn main() {
     let name = "william";
 
     let (chal, reg_state) = wan
-        .generate_challenge_register_options(
+        .generate_challenge_register(
             &unique_id,
             name,
             name,
@@ -290,11 +290,13 @@ async fn main() {
         let (chal, auth_state) = wan
             .generate_challenge_authenticate(
                 vec![cred.clone()],
+                None,
                 Some(RequestAuthenticationExtensions {
                     appid: Some("example.app.id".to_string()),
                     uvm: None,
                     hmac_get_secret: None,
                 }),
+                None,
             )
             .unwrap();
 

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -247,21 +247,13 @@ async fn main() {
     ];
     let name = "william";
 
-    let (chal, reg_state) = wan
-        .generate_challenge_register(
-            &unique_id,
-            name,
-            name,
-            AttestationConveyancePreference::None,
-            Some(opt.verification_policy.into()),
-            None,
-            None,
-            COSEAlgorithm::secure_algs(),
-            false,
-            None,
-            false,
-        )
-        .unwrap();
+    let builder = wan
+        .new_challenge_register_builder(&unique_id, name, name)
+        .unwrap()
+        .attestation(AttestationConveyancePreference::None)
+        .user_verification_policy(opt.verification_policy.into());
+
+    let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
     info!("🍿 challenge -> {:x?}", chal);
 

--- a/webauthn-authenticator-rs/src/softpasskey.rs
+++ b/webauthn-authenticator-rs/src/softpasskey.rs
@@ -549,7 +549,7 @@ mod tests {
         let name = "william";
 
         let (chal, reg_state) = wan
-            .generate_challenge_register_options(
+            .generate_challenge_register(
                 &unique_id,
                 name,
                 name,
@@ -578,7 +578,7 @@ mod tests {
         let cred = wan.register_credential(&r, &reg_state, None).unwrap();
 
         let (chal, auth_state) = wan
-            .generate_challenge_authenticate(vec![cred], None)
+            .generate_challenge_authenticate(vec![cred], None, None, None)
             .unwrap();
 
         let r = wa

--- a/webauthn-authenticator-rs/src/softpasskey.rs
+++ b/webauthn-authenticator-rs/src/softpasskey.rs
@@ -548,21 +548,13 @@ mod tests {
         ];
         let name = "william";
 
-        let (chal, reg_state) = wan
-            .generate_challenge_register(
-                &unique_id,
-                name,
-                name,
-                AttestationConveyancePreference::Direct,
-                Some(UserVerificationPolicy::Preferred),
-                None,
-                None,
-                COSEAlgorithm::secure_algs(),
-                false,
-                None,
-                false,
-            )
-            .unwrap();
+        let builder = wan
+            .new_challenge_register_builder(&unique_id, name, name)
+            .unwrap()
+            .attestation(AttestationConveyancePreference::Direct)
+            .user_verification_policy(UserVerificationPolicy::Preferred);
+
+        let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
         info!("🍿 challenge -> {:x?}", chal);
 

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -900,7 +900,7 @@ mod tests {
         let name = "william";
 
         let (chal, reg_state) = wan
-            .generate_challenge_register_options(
+            .generate_challenge_register(
                 &unique_id,
                 name,
                 name,
@@ -938,7 +938,7 @@ mod tests {
         info!("Credential -> {:?}", cred);
 
         let (chal, auth_state) = wan
-            .generate_challenge_authenticate(vec![cred], None)
+            .generate_challenge_authenticate(vec![cred], None, None, None)
             .unwrap();
 
         let r = wa
@@ -980,7 +980,7 @@ mod tests {
         let name = "william";
 
         let (chal, reg_state) = wan
-            .generate_challenge_register_options(
+            .generate_challenge_register(
                 &unique_id,
                 name,
                 name,
@@ -1032,7 +1032,7 @@ mod tests {
         let mut wa = WebauthnAuthenticator::new(soft_token);
 
         let (chal, auth_state) = wan
-            .generate_challenge_authenticate(vec![cred], None)
+            .generate_challenge_authenticate(vec![cred], None, None, None)
             .unwrap();
 
         let r = wa

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -899,21 +899,13 @@ mod tests {
         ];
         let name = "william";
 
-        let (chal, reg_state) = wan
-            .generate_challenge_register(
-                &unique_id,
-                name,
-                name,
-                AttestationConveyancePreference::Direct,
-                Some(UserVerificationPolicy::Preferred),
-                None,
-                None,
-                COSEAlgorithm::secure_algs(),
-                false,
-                None,
-                false,
-            )
-            .unwrap();
+        let builder = wan
+            .new_challenge_register_builder(&unique_id, name, name)
+            .unwrap()
+            .attestation(AttestationConveyancePreference::Direct)
+            .user_verification_policy(UserVerificationPolicy::Preferred);
+
+        let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
         info!("🍿 challenge -> {:x?}", chal);
 
@@ -979,21 +971,13 @@ mod tests {
         ];
         let name = "william";
 
-        let (chal, reg_state) = wan
-            .generate_challenge_register(
-                &unique_id,
-                name,
-                name,
-                AttestationConveyancePreference::Direct,
-                Some(UserVerificationPolicy::Preferred),
-                None,
-                None,
-                COSEAlgorithm::secure_algs(),
-                false,
-                None,
-                false,
-            )
-            .unwrap();
+        let builder = wan
+            .new_challenge_register_builder(&unique_id, name, name)
+            .unwrap()
+            .attestation(AttestationConveyancePreference::Direct)
+            .user_verification_policy(UserVerificationPolicy::Preferred);
+
+        let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
         info!("🍿 challenge -> {:x?}", chal);
 

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -1,16 +1,15 @@
-//! Attestation information and verifications procedures.
+//! Attestation information and verification procedures.
 //! This contains a transparent type allowing callbacks to
-//! make attestation decisions. See the WebauthnConfig trait
-//! for more details.
+//! make attestation decisions.
 
 use std::convert::TryFrom;
 
 use crate::crypto::{
-    assert_packed_attest_req, assert_tpm_attest_req, compute_sha256, only_hash_from_type,
-    verify_signature,
+    check_extension, compute_sha256, only_hash_from_type, verify_signature, TpmSanData,
 };
 use crate::error::WebauthnError;
 use crate::internals::*;
+use crate::internals::{tpm_device_attribute_parser, TpmVendor};
 use crate::proto::*;
 use base64urlsafedata::Base64UrlSafeData;
 use openssl::hash::MessageDigest;
@@ -21,6 +20,8 @@ use openssl::x509::store;
 use openssl::x509::verify;
 use uuid::Uuid;
 use x509_parser::oid_registry::Oid;
+use x509_parser::prelude::GeneralName;
+use x509_parser::x509::X509Version;
 
 /// x509 certificate extensions are validated in the webauthn spec by checking
 /// that the value of the extension is equal to some other value
@@ -536,6 +537,93 @@ pub(crate) fn verify_packed_attestation(
     }
 }
 
+/// Verify that attestnCert meets the requirements in
+/// [§ 8.2.1 Packed Attestation Statement Certificate Requirements][0]
+///
+/// [0]: https://www.w3.org/TR/webauthn-2/#sctn-packed-attestation-cert-requirements
+pub fn assert_packed_attest_req(pubk: &x509::X509) -> Result<(), WebauthnError> {
+    // https://w3c.github.io/webauthn/#sctn-packed-attestation-cert-requirements
+    let der_bytes = pubk.to_der()?;
+    let x509_cert = x509_parser::parse_x509_certificate(&der_bytes)
+        .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)?
+        .1;
+
+    // The attestation certificate MUST have the following fields/extensions:
+    // Version MUST be set to 3 (which is indicated by an ASN.1 INTEGER with value 2).
+    if x509_cert.version != X509Version::V3 {
+        trace!("X509 Version != v3");
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
+
+    // Subject field MUST be set to:
+    //
+    // Subject-C
+    //  ISO 3166 code specifying the country where the Authenticator vendor is incorporated (PrintableString)
+    // Subject-O
+    //  Legal name of the Authenticator vendor (UTF8String)
+    // Subject-OU
+    //  Literal string “Authenticator Attestation” (UTF8String)
+    // Subject-CN
+    //  A UTF8String of the vendor’s choosing
+    let subject = &x509_cert.subject;
+
+    let subject_c = subject.iter_country().take(1).next();
+    let subject_o = subject.iter_organization().take(1).next();
+    let subject_ou = subject.iter_organizational_unit().take(1).next();
+    let subject_cn = subject.iter_common_name().take(1).next();
+
+    if subject_c.is_none() || subject_o.is_none() || subject_cn.is_none() {
+        trace!("Invalid subject details");
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
+
+    match subject_ou {
+        Some(ou) => match ou.attr_value().as_str() {
+            Ok(ou_d) => {
+                if ou_d != "Authenticator Attestation" {
+                    trace!("ou != Authenticator Attestation");
+                    return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+                }
+            }
+            Err(_) => {
+                trace!("ou invalid");
+                return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+            }
+        },
+        None => {
+            trace!("ou not found");
+            return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+        }
+    }
+
+    // If the related attestation root certificate is used for multiple authenticator models,
+    // the Extension OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) MUST be present,
+    // containing the AAGUID as a 16-byte OCTET STRING. The extension MUST NOT be marked as critical.
+    //
+    // We already check that the value matches the AAGUID in attestation
+    // verification, so we only have to check the critical requirement here.
+    //
+    // The problem with this check, is that it's not actually required that this
+    // oid be present at all ...
+    check_extension(
+        &x509_cert.get_extension_unique(&FidoGenCeAaguid::OID),
+        false,
+        |fido_gen_ce_aaguid| !fido_gen_ce_aaguid.critical,
+    )?;
+
+    // The Basic Constraints extension MUST have the CA component set to false.
+    check_extension(&x509_cert.basic_constraints(), true, |basic_constraints| {
+        !basic_constraints.value.ca
+    })?;
+
+    // An Authority Information Access (AIA) extension with entry id-ad-ocsp and a CRL
+    // Distribution Point extension [RFC5280] are both OPTIONAL as the status of many
+    // attestation certificates is available through authenticator metadata services. See, for
+    // example, the FIDO Metadata Service [FIDOMetadataService].
+
+    Ok(())
+}
+
 // https://w3c.github.io/webauthn/#fido-u2f-attestation
 // https://medium.com/@herrjemand/verifying-fido-u2f-attestations-in-fido2-f83fab80c355
 pub(crate) fn verify_fidou2f_attestation(
@@ -898,6 +986,90 @@ pub(crate) fn verify_tpm_attestation(
             firmware_version: certinfo.firmware_version,
         },
     ))
+}
+
+pub(crate) fn assert_tpm_attest_req(x509: &x509::X509) -> Result<(), WebauthnError> {
+    let der_bytes = x509.to_der()?;
+    let x509_cert = x509_parser::parse_x509_certificate(&der_bytes)
+        .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)?
+        .1;
+
+    // TPM attestation certificate MUST have the following fields/extensions:
+
+    // Version MUST be set to 3.
+    if x509_cert.version != X509Version::V3 {
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
+
+    // Subject field MUST be set to empty.
+    let subject_name_ref = x509.subject_name();
+    if subject_name_ref.entries().count() != 0 {
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
+
+    // The Subject Alternative Name extension MUST be set as defined in [TPMv2-EK-Profile] section 3.2.9.
+    // https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
+    check_extension(
+        &x509_cert.subject_alternative_name(),
+        true,
+        |subject_alternative_name| {
+            // From [TPMv2-EK-Profile]:
+            // In accordance with RFC 5280[11], this extension MUST be critical if
+            // subject is empty and SHOULD be non-critical if subject is non-empty.
+            //
+            // We've already returned if the subject is non-empty, so we can just
+            // check that the extension is critical.
+            if !subject_alternative_name.critical {
+                return false;
+            };
+
+            // The issuer MUST include TPM manufacturer, TPM part number and TPM
+            // firmware version, using the directoryName form within the GeneralName
+            // structure.
+            subject_alternative_name
+                .value
+                .general_names
+                .iter()
+                .any(|general_name| {
+                    if let GeneralName::DirectoryName(x509_name) = general_name {
+                        TpmSanData::try_from(x509_name)
+                            .and_then(|san_data| {
+                                tpm_device_attribute_parser(san_data.manufacturer.as_bytes())
+                                    .map_err(|_| WebauthnError::ParseNOMFailure)
+                            })
+                            .and_then(|(_, manufacturer_bytes)| {
+                                TpmVendor::try_from(manufacturer_bytes)
+                            })
+                            .is_ok()
+                    } else {
+                        false
+                    }
+                })
+        },
+    )?;
+
+    // The Extended Key Usage extension MUST contain the "joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)" OID.
+    check_extension(
+        &x509_cert.extended_key_usage(),
+        true,
+        |extended_key_usage| {
+            extended_key_usage
+                .value
+                .other
+                .contains(&der_parser::oid!(2.23.133 .8 .3))
+        },
+    )?;
+
+    // The Basic Constraints extension MUST have the CA component set to false.
+    check_extension(&x509_cert.basic_constraints(), true, |basic_constraints| {
+        !basic_constraints.value.ca
+    })?;
+
+    // An Authority Information Access (AIA) extension with entry id-ad-ocsp and a CRL Distribution
+    // Point extension [RFC5280] are both OPTIONAL as the status of many attestation certificates is
+    // available through metadata services. See, for example, the FIDO Metadata Service [FIDOMetadataService].
+
+    Ok(())
 }
 
 pub(crate) fn verify_apple_anonymous_attestation(

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -1338,11 +1338,12 @@ pub trait WebauthnConfig {
 mod tests {
     #![allow(clippy::panic)]
 
+    use crate::attestation::AttestationFormat;
     use crate::constants::CHALLENGE_SIZE_BYTES;
     use crate::core::{CreationChallengeResponse, RegistrationState, WebauthnError};
+    use crate::internals::*;
     use crate::proto::*;
     use crate::WebauthnCore as Webauthn;
-    use crate::{internals::*, AttestationFormat};
     use base64::{engine::general_purpose::STANDARD, Engine};
     use base64urlsafedata::Base64UrlSafeData;
     use std::time::Duration;

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -38,7 +38,7 @@ pub struct RegistrationState {
     pub(crate) require_resident_key: bool,
     pub(crate) authenticator_attachment: Option<AuthenticatorAttachment>,
     pub(crate) extensions: RequestRegistrationExtensions,
-    pub(crate) experimental_allow_synchronised_authenticators: bool,
+    pub(crate) allow_synchronised_authenticators: bool,
 }
 
 /// The in progress state of an authentication attempt. You must persist this associated to the UserID

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -38,7 +38,7 @@ pub struct RegistrationState {
     pub(crate) require_resident_key: bool,
     pub(crate) authenticator_attachment: Option<AuthenticatorAttachment>,
     pub(crate) extensions: RequestRegistrationExtensions,
-    pub(crate) experimental_allow_passkeys: bool,
+    pub(crate) experimental_allow_synchronised_authenticators: bool,
 }
 
 /// The in progress state of an authentication attempt. You must persist this associated to the UserID

--- a/webauthn-rs-core/src/lib.rs
+++ b/webauthn-rs-core/src/lib.rs
@@ -37,9 +37,9 @@ mod constants;
 pub mod attestation;
 pub mod crypto;
 
-pub mod core;
+mod core;
 pub mod error;
-pub mod interface;
+mod interface;
 pub mod internals;
 
 /// Protocol bindings
@@ -48,8 +48,5 @@ pub mod proto {
     pub use base64urlsafedata::Base64UrlSafeData;
     pub use webauthn_rs_proto::*;
 }
-
-pub use attestation::verify_attestation_ca_chain;
-pub use attestation::AttestationFormat;
 
 pub use crate::core::*;

--- a/webauthn-rs-core/src/lib.rs
+++ b/webauthn-rs-core/src/lib.rs
@@ -4,12 +4,14 @@
 //! to allow strong, passwordless, cryptographic authentication to be performed. Webauthn
 //! is able to operate with many authenticator types, such as U2F.
 //!
-//! This library aims to provide a secure Webauthn implementation that you can
-//! plug into your application, so that you can provide Webauthn to your users.
+//! ⚠️  ⚠️  ⚠️  THIS IS UNSAFE. AVOID USING THIS DIRECTLY ⚠️  ⚠️  ⚠️
 //!
-//! To use this library yourself, you will want to reference the `WebauthnConfig` trait to
-//! develop site specific policy and configuration, and the `Webauthn` struct for Webauthn
-//! interactions.
+//! If possible, use the `webauthn-rs` crate, and it's safe wrapper instead!
+//!
+//! Webauthn as a standard has many traps that in the worst cases, may lead to
+//! bypasses and full account compromises. Many of the features of webauthn are
+//! NOT security policy, but user interface hints. Many options can NOT be
+//! enforced. `webauthn-rs` handles these correctly. USE `webauthn-rs` INSTEAD.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -107,11 +107,12 @@ pub struct PubKeyCredParams {
 }
 
 /// <https://www.w3.org/TR/webauthn/#enumdef-attestationconveyancepreference>
-#[derive(Debug, Serialize, Clone, Deserialize)]
+#[derive(Debug, Serialize, Clone, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum AttestationConveyancePreference {
     /// Do not request attestation.
     /// <https://www.w3.org/TR/webauthn/#dom-attestationconveyancepreference-none>
+    #[default]
     None,
 
     /// Request attestation in a semi-anonymized form.

--- a/webauthn-rs/Cargo.toml
+++ b/webauthn-rs/Cargo.toml
@@ -16,7 +16,9 @@ features = ["danger-allow-state-serialisation", "danger-user-presence-only-secur
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-preview-features = ["conditional-ui", "attestation"]
+default = ["attestation"]
+
+preview-features = ["conditional-ui"]
 resident-key-support = []
 conditional-ui = []
 attestation = []

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -3,11 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 use webauthn_rs_core::error::WebauthnError;
-use webauthn_rs_core::interface::{
-    AttestationCaList, AuthenticationResult, AuthenticationState, RegistrationState,
-};
 use webauthn_rs_core::proto::{
-    AttestationCa, COSEAlgorithm, COSEKey, Credential, CredentialID, ParsedAttestation,
+    AttestationCa, AttestationCaList, AuthenticationResult, AuthenticationState, COSEAlgorithm,
+    COSEKey, Credential, CredentialID, ParsedAttestation, RegistrationState,
 };
 
 /// An in progress registration session for a [Passkey].

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -201,6 +201,7 @@ pub mod prelude {
     pub use base64urlsafedata::Base64UrlSafeData;
     pub use url::Url;
     pub use uuid::Uuid;
+    pub use webauthn_rs_core::attestation::AttestationFormat;
     pub use webauthn_rs_core::error::{WebauthnError, WebauthnResult};
     #[cfg(feature = "danger-credential-internals")]
     pub use webauthn_rs_core::proto::Credential;
@@ -216,7 +217,6 @@ pub mod prelude {
         COSEAlgorithm, COSEEC2Key, COSEKey, COSEKeyType, COSEKeyTypeId, COSEOKPKey, COSERSAKey,
         ECDSACurve, EDDSACurve,
     };
-    pub use webauthn_rs_core::AttestationFormat;
 }
 
 /// The [Webauthn recommended authenticator interaction timeout][0].


### PR DESCRIPTION
Fixes #264 - this cleans up some of the older "safe" interfaces in core since they now all belong in webauthn-rs. This removes some old comments and also hides some modules. Finally some other functions are moved to more contextually relevant places. 

- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
