### PR TITLE
YubiKey 5 vendor commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,15 @@ jobs:
       # --help should be enough to find an issue.
       - run: cargo run --bin cable-tunnel-server-backend -- --help
       - run: cargo run --bin cable-tunnel-server-frontend -- --help
+      - run: cargo run --bin fido-mds-tool -- --help
       # fido-key-manager requires elevation on Windows, which cargo can't
       # handle.
       - if: runner.os != 'windows'
         run: cargo run --bin fido-key-manager -- --help
       - if: runner.os != 'windows'
         run: cargo run --bin fido-key-manager --features solokey -- --help
-      - run: cargo run --bin fido-mds-tool -- --help
+      - if: runner.os != 'windows'
+        run: cargo run --bin fido-key-manager --features yubikey -- --help
 
   authenticator:
     name: webauthn-authenticator-rs test
@@ -90,7 +92,7 @@ jobs:
           - softtoken
           - usb
           - bluetooth,nfc,usb,ctap2-management
-          - bluetooth,cable,cable-override-tunnel,ctap2-management,nfc,softpasskey,softtoken,usb,vendor-solokey
+          - bluetooth,cable,cable-override-tunnel,ctap2-management,nfc,softpasskey,softtoken,usb,vendor-solokey,vendor-yubikey
         os:
           - ubuntu-latest
           - windows-latest

--- a/fido-key-manager/Cargo.toml
+++ b/fido-key-manager/Cargo.toml
@@ -24,6 +24,7 @@ bluetooth = ["webauthn-authenticator-rs/bluetooth"]
 nfc = ["webauthn-authenticator-rs/nfc"]
 usb = ["webauthn-authenticator-rs/usb"]
 solokey = ["webauthn-authenticator-rs/vendor-solokey"]
+yubikey = ["webauthn-authenticator-rs/vendor-yubikey"]
 
 default = ["nfc", "usb"]
 

--- a/fido-key-manager/README.md
+++ b/fido-key-manager/README.md
@@ -115,6 +115,26 @@ Command | Description
 `solo-key-info` | get all connected SoloKeys' unique ID, firmware version and secure boot status
 `solo-key-random` | get some random bytes from a SoloKey
 
+### YubiKey
+
+> **Tip:** this functionality is only available when `fido-key-manager` is built
+> with `--features yubikey`.
+
+This only supports [YubiKey 5 series][yk5] and [Security Key by Yubico][sky]
+devices via USB HID with the CTAP 2.0 interface (FIDO2) enabled. NFC support may
+be added in future.
+
+YubiKey 4 and earlier support is not planned - they do not support CTAP 2.0,
+they use a different config format and protocol, and some firmware versions
+report bogus data.
+
+Command | Description
+------- | -----------
+`yubikey-get-config` | gets a connected YubiKey's device info, firmware version and interface configuration
+
+[yk5]: https://www.yubico.com/products/yubikey-5-overview/
+[sky]: https://www.yubico.com/products/security-key/
+
 ## Platform-specific notes
 
 Bluetooth is currently disabled by default, as it's not particularly reliable on

--- a/fido-key-manager/src/main.rs
+++ b/fido-key-manager/src/main.rs
@@ -11,10 +11,10 @@ use hex::{FromHex, FromHexError};
 use std::io::{stdin, stdout, Write};
 use std::time::Duration;
 use tokio_stream::StreamExt;
-#[cfg(feature = "solokey")]
-use webauthn_authenticator_rs::{ctap2::SoloKeyAuthenticator, prelude::WebauthnCError};
 #[cfg(feature = "yubikey")]
 use webauthn_authenticator_rs::ctap2::YubiKeyAuthenticator;
+#[cfg(feature = "solokey")]
+use webauthn_authenticator_rs::{ctap2::SoloKeyAuthenticator, prelude::WebauthnCError};
 use webauthn_authenticator_rs::{
     ctap2::{
         commands::UserCM, select_one_device, select_one_device_predicate,

--- a/fido-key-manager/src/main.rs
+++ b/fido-key-manager/src/main.rs
@@ -12,11 +12,9 @@ use std::io::{stdin, stdout, Write};
 use std::time::Duration;
 use tokio_stream::StreamExt;
 #[cfg(feature = "solokey")]
-use webauthn_authenticator_rs::ctap2::SoloKeyAuthenticator;
+use webauthn_authenticator_rs::{ctap2::SoloKeyAuthenticator, prelude::WebauthnCError};
 #[cfg(feature = "yubikey")]
 use webauthn_authenticator_rs::ctap2::YubiKeyAuthenticator;
-#[cfg(any(feature = "solokey", feature = "yubikey"))]
-use webauthn_authenticator_rs::prelude::WebauthnCError;
 use webauthn_authenticator_rs::{
     ctap2::{
         commands::UserCM, select_one_device, select_one_device_predicate,

--- a/fido-key-manager/src/main.rs
+++ b/fido-key-manager/src/main.rs
@@ -768,11 +768,13 @@ async fn main() {
             let mut token: CtapAuthenticator<AnyToken, Cli> =
                 select_one_device(stream, &ui).await.unwrap();
 
-            let r = token
+            let cfg = token
                 .get_yubikey_config()
                 .await
-                .expect("Error getting random data");
-            todo!()
+                .expect("Error getting YubiKey config");
+
+            println!("YubiKey config:");
+            println!("{cfg}")
         }
     }
 }

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -52,6 +52,8 @@ ctap2 = [
 ctap2-management = ["ctap2"]
 # Support for SoloKey's vendor commands
 vendor-solokey = []
+# Support for YubiKey's vendor commands
+vendor-yubikey = []
 nfc = ["ctap2", "dep:pcsc"]
 # TODO: allow running softpasskey without softtoken
 softpasskey = ["crypto", "softtoken"]

--- a/webauthn-authenticator-rs/src/ctap2/ctap20.rs
+++ b/webauthn-authenticator-rs/src/ctap2/ctap20.rs
@@ -533,7 +533,10 @@ impl<'a, T: Token, U: UiCallback> Ctap20Authenticator<'a, T, U> {
         let ret = self.token.transmit(mc, self.ui_callback).await;
 
         if let Err(WebauthnCError::Ctap(e)) = ret {
-            if e == CtapError::Ctap2PinAuthInvalid || e == CtapError::Ctap2PinNotSet {
+            if e == CtapError::Ctap2PinAuthInvalid
+                || e == CtapError::Ctap2PinNotSet
+                || e == CtapError::Ctap2PinInvalid
+            {
                 // User pressed the button
                 return Ok(());
             }

--- a/webauthn-authenticator-rs/src/ctap2/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/mod.rs
@@ -131,6 +131,9 @@ mod pin_uv;
 #[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
 #[doc(hidden)]
 mod solokey;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-yubikey"))]
+#[doc(hidden)]
+mod yubikey;
 
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
@@ -165,6 +168,10 @@ pub use self::{
 #[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
 #[doc(inline)]
 pub use self::solokey::SoloKeyAuthenticator;
+
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-yubikey"))]
+#[doc(inline)]
+pub use self::yubikey::YubiKeyAuthenticator;
 
 /// Abstraction for different versions of the CTAP2 protocol.
 ///

--- a/webauthn-authenticator-rs/src/ctap2/yubikey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/yubikey.rs
@@ -20,7 +20,7 @@ use super::Ctap20Authenticator;
 /// vendor-specific commands, this may cause unexpected or undesirable behaviour
 /// on other vendors' keys.
 ///
-/// Protocol notes are in TODO
+/// Protocol notes are in [`crate::transport::yubikey`].
 #[async_trait]
 pub trait YubiKeyAuthenticator {
     async fn get_yubikey_config(&mut self) -> Result<YubiKeyConfig, WebauthnCError>;

--- a/webauthn-authenticator-rs/src/ctap2/yubikey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/yubikey.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 
 use crate::{
     prelude::WebauthnCError,
-    transport::{yubikey::YubiKeyToken, Token},
+    transport::{
+        yubikey::{YubiKeyConfig, YubiKeyToken},
+        Token,
+    },
     ui::UiCallback,
 };
 
@@ -20,7 +23,7 @@ use super::Ctap20Authenticator;
 /// Protocol notes are in TODO
 #[async_trait]
 pub trait YubiKeyAuthenticator {
-    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError>;
+    async fn get_yubikey_config(&mut self) -> Result<YubiKeyConfig, WebauthnCError>;
 }
 
 #[async_trait]
@@ -28,7 +31,7 @@ impl<'a, T: Token + YubiKeyToken, U: UiCallback> YubiKeyAuthenticator
     for Ctap20Authenticator<'a, T, U>
 {
     #[inline]
-    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError> {
+    async fn get_yubikey_config(&mut self) -> Result<YubiKeyConfig, WebauthnCError> {
         self.token.get_yubikey_config().await
     }
 }

--- a/webauthn-authenticator-rs/src/ctap2/yubikey.rs
+++ b/webauthn-authenticator-rs/src/ctap2/yubikey.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+
+use crate::{
+    prelude::WebauthnCError,
+    transport::{yubikey::YubiKeyToken, Token},
+    ui::UiCallback,
+};
+
+use super::Ctap20Authenticator;
+
+/// YubiKey vendor-specific commands.
+///
+/// ## Warning
+///
+/// These commands currently operate on *any* [`Ctap20Authenticator`][], and do
+/// not filter to just YubiKey devices. Due to the nature of CTAP
+/// vendor-specific commands, this may cause unexpected or undesirable behaviour
+/// on other vendors' keys.
+///
+/// Protocol notes are in TODO
+#[async_trait]
+pub trait YubiKeyAuthenticator {
+    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError>;
+}
+
+#[async_trait]
+impl<'a, T: Token + YubiKeyToken, U: UiCallback> YubiKeyAuthenticator
+    for Ctap20Authenticator<'a, T, U>
+{
+    #[inline]
+    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError> {
+        self.token.get_yubikey_config().await
+    }
+}

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -129,6 +129,7 @@ mod crypto;
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2"))]
 pub mod ctap2;
 pub mod error;
+mod tlv;
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2"))]
 pub mod transport;
 pub mod types;

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -129,6 +129,7 @@ mod crypto;
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2"))]
 pub mod ctap2;
 pub mod error;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-yubikey"))]
 mod tlv;
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2"))]
 pub mod transport;

--- a/webauthn-authenticator-rs/src/tlv/ber.rs
+++ b/webauthn-authenticator-rs/src/tlv/ber.rs
@@ -20,11 +20,14 @@ impl BerTlvParser<'_> {
         BerTlvParser { b: &tlv[i..] }
     }
 
+    /// Sets the internal buffer to an empty range, effectively "bricking" the
+    /// iterator.
     #[inline]
     fn brick(&mut self) {
         self.b = &self.b[0..0];
     }
 
+    /// Returns `None` if the internal buffer is empty.
     fn stop_if_empty(&self) -> Option<()> {
         if self.b.is_empty() {
             None
@@ -33,6 +36,10 @@ impl BerTlvParser<'_> {
         }
     }
 
+    /// Returns `None` and [bricks][0] the buffer if it contains less than
+    /// `bytes` bytes.
+    ///
+    /// [0]: BerTlvParser::brick
     fn stop_and_brick_if_less_than(&mut self, bytes: usize) -> Option<()> {
         if self.b.len() < bytes {
             error!("bricked: less than {bytes} bytes: {}", self.b.len());

--- a/webauthn-authenticator-rs/src/tlv/ber.rs
+++ b/webauthn-authenticator-rs/src/tlv/ber.rs
@@ -1,0 +1,244 @@
+//! [BerTlvParser] is an [Iterator]-based BER-TLV parser.
+
+/// An [Iterator]-based Compact-TLV parser.
+pub(crate) struct BerTlvParser<'a> {
+    b: &'a [u8],
+}
+
+impl BerTlvParser<'_> {
+    /// Parses a BER-TLV structure in the given slice.
+    pub fn new(tlv: &[u8]) -> BerTlvParser {
+        // Skip null bytes at the start
+        let mut i = 0;
+        loop {
+            if i >= tlv.len() || tlv[i] != 0 {
+                break;
+            }
+            i += 1;
+        }
+
+        BerTlvParser { b: &tlv[i..] }
+    }
+
+    #[inline]
+    fn brick(&mut self) {
+        self.b = &self.b[0..0];
+    }
+
+    fn stop_if_empty(&self) -> Option<()> {
+        if self.b.is_empty() {
+            None
+        } else {
+            Some(())
+        }
+    }
+
+    fn stop_and_brick_if_less_than(&mut self, bytes: usize) -> Option<()> {
+        if self.b.len() < bytes {
+            error!("bricked: less than {bytes} bytes: {}", self.b.len());
+            self.brick();
+            None
+        } else {
+            Some(())
+        }
+    }
+}
+
+impl<'a> Iterator for BerTlvParser<'a> {
+    /// A BER-TLV item, a tuple of `class, tag, value`.
+    type Item = (u8, u16, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stop_if_empty()?;
+
+        // 5.2.2.1: BER-TLV tag fields
+        let class = self.b[0] >> 5;
+        let mut tag = u16::from(self.b[0] & 0x1f);
+        // trace!(?class, ?tag);
+        self.b = &self.b[1..];
+        if tag == 0x1f {
+            self.stop_if_empty()?;
+            // 0b???1_1111 = 2 or 3 byte tag value
+            tag = u16::from(self.b[0]);
+            self.b = &self.b[1..];
+
+            // 2 byte tag value as 0b0???_???? (31..=127)
+            // 3 byte tag value as 0b1???_???? 0b0???_???? (128..=16383)
+            if tag & 0x80 == 0x80 {
+                self.stop_if_empty()?;
+
+                tag = (tag & 0x7f) << 7;
+                tag |= u16::from(self.b[0]) & 0x7f;
+                self.b = &self.b[1..];
+            }
+        }
+
+        // 5.2.2.2 BER-TLV length fields
+        self.stop_if_empty()?;
+        let len = self.b[0];
+        self.b = &self.b[1..];
+
+        let len = match len {
+            0..=0x7f => u32::from(len),
+
+            0x80 => {
+                error!("indefinite length not supported");
+                self.brick();
+                return None;
+            }
+
+            0x81 => {
+                self.stop_if_empty()?;
+                let len = u32::from(self.b[0]);
+                self.b = &self.b[1..];
+                len
+            }
+
+            0x82 => {
+                self.stop_and_brick_if_less_than(2);
+                let len = u32::from(u16::from_be_bytes(self.b[..2].try_into().ok()?));
+                self.b = &self.b[2..];
+                len
+            }
+
+            0x83 => {
+                self.stop_and_brick_if_less_than(3)?;
+                let mut buf = [0; 4];
+                buf[1..].copy_from_slice(&self.b[..3]);
+                let len = u32::from_be_bytes(buf);
+                self.b = &self.b[3..];
+                len
+            }
+
+            0x84 => {
+                self.stop_and_brick_if_less_than(4)?;
+                let len = u32::from_be_bytes(self.b[..4].try_into().ok()?);
+                self.b = &self.b[4..];
+                len
+            }
+
+            0x85..=0xff => {
+                error!("invalid BER-TLV length field length: {len:#x}");
+                self.brick();
+                return None;
+            }
+        };
+        // info!(?len);
+
+        let len = len as usize;
+        self.stop_and_brick_if_less_than(len)?;
+        let v = &self.b[..len];
+        self.b = &self.b[len..];
+        Some((class, tag, v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_tlv_parser(expected: &[(u8, u16, &[u8])], p: BerTlvParser<'_>) {
+        let mut i = 0;
+        for (actual_cls, actual_tag, actual_val) in p {
+            let (expected_cls, expected_tag, expected_val) = expected[i];
+            assert_eq!(expected_cls, actual_cls, "cls mismatch at {i}");
+            assert_eq!(expected_tag, actual_tag, "tag mismatch at {i}");
+            assert_eq!(
+                expected_val, actual_val,
+                "val mismatch at {i} (tag={expected_tag})"
+            );
+            i += 1;
+        }
+        assert_eq!(expected.len(), i);
+    }
+
+    #[test]
+    fn yubico_security_key_c_nfc() {
+        let _ = tracing_subscriber::fmt().try_init();
+
+        let v = hex::decode(concat!(
+            "28",     // length byte, not TLV
+            "0102",   // cls=0, tag=1, len=2
+            "0202",   //
+            "0302",   // cls=0, tag=3, len=2
+            "0200",   //
+            "0401",   // cls=0, tag=4, len=1
+            "43",     //
+            "0503",   // cls=0, tag=5, len=3
+            "050403", //
+            "0602",   // cls=0, tag=6, len=2
+            "0000",   //
+            "0701",   // cls=0, tag=7, len=1
+            "0f",     //
+            "0801",   // cls=0, tag=8, len=1
+            "00",     //
+            "0d02",   // cls=0, tag=13, len=2
+            "0206",   //
+            "0e02",   // cls=0, tag=14, len=2
+            "0200",   //
+            "0a01",   // cls=0, tag=10, len=1
+            "00",     //
+            "0f01",   // cls=0, tag=15, len=1
+            "00",     //
+        ))
+        .unwrap();
+        let expected: [(u8, u16, &[u8]); 11] = [
+            (0, 1, b"\x02\x02"),
+            (0, 3, b"\x02\0"),
+            (0, 4, b"\x43"),
+            (0, 5, b"\x05\x04\x03"),
+            (0, 6, b"\0\0"),
+            (0, 7, b"\x0f"),
+            (0, 8, b"\0"),
+            (0, 13, b"\x02\x06"),
+            (0, 14, b"\x02\0"),
+            (0, 10, b"\0"),
+            (0, 15, b"\0"),
+        ];
+
+        let p = BerTlvParser::new(&v[1..]);
+        assert_tlv_parser(expected.as_slice(), p);
+    }
+
+    #[test]
+    fn yubikey_5c() {
+        let _ = tracing_subscriber::fmt().try_init();
+
+        let v = hex::decode(concat!(
+            "23",       // length byte, not TLV
+            "0102",     // cls=0, tag=1, len=2
+            "023f",     //
+            "0302",     // cls=0, tag=3, len=2
+            "0218",     //
+            "0204",     // cls=0, tag=2, len=4
+            "cafe1234", //
+            "0401",     // cls=0, tag=4, len=1
+            "03",       //
+            "0503",     // cls=0, tag=5, len=3
+            "050102",   //
+            "0602",     // cls=0, tag=6, len=2
+            "0000",     //
+            "0701",     // cls=0, tag=7, len=1
+            "0f",       //
+            "0801",     // cls=0, tag=8, len=1
+            "00",       //
+            "0a01",     // cls=0, tag=10, len=1
+            "00",       //
+        ))
+        .unwrap();
+        let expected: [(u8, u16, &[u8]); 9] = [
+            (0, 1, b"\x02\x3f"),
+            (0, 3, b"\x02\x18"),
+            (0, 2, b"\xca\xfe\x12\x34"),
+            (0, 4, b"\x03"),
+            (0, 5, b"\x05\x01\x02"),
+            (0, 6, b"\0\0"),
+            (0, 7, b"\x0f"),
+            (0, 8, b"\0"),
+            (0, 10, b"\0"),
+        ];
+
+        let p = BerTlvParser::new(&v[1..]);
+        assert_tlv_parser(expected.as_slice(), p);
+    }
+}

--- a/webauthn-authenticator-rs/src/tlv/ber.rs
+++ b/webauthn-authenticator-rs/src/tlv/ber.rs
@@ -61,7 +61,6 @@ impl<'a> Iterator for BerTlvParser<'a> {
         // 5.2.2.1: BER-TLV tag fields
         let class = self.b[0] >> 5;
         let mut tag = u16::from(self.b[0] & 0x1f);
-        // trace!(?class, ?tag);
         self.b = &self.b[1..];
         if tag == 0x1f {
             self.stop_if_empty()?;
@@ -130,7 +129,6 @@ impl<'a> Iterator for BerTlvParser<'a> {
                 return None;
             }
         };
-        // info!(?len);
 
         let len = len as usize;
         self.stop_and_brick_if_less_than(len)?;

--- a/webauthn-authenticator-rs/src/tlv/mod.rs
+++ b/webauthn-authenticator-rs/src/tlv/mod.rs
@@ -1,0 +1,1 @@
+pub mod ber;

--- a/webauthn-authenticator-rs/src/transport/mod.rs
+++ b/webauthn-authenticator-rs/src/transport/mod.rs
@@ -7,6 +7,8 @@ pub mod iso7816;
 pub(crate) mod solokey;
 #[cfg(any(doc, feature = "bluetooth", feature = "usb"))]
 pub(crate) mod types;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-yubikey"))]
+pub(crate) mod yubikey;
 
 pub use crate::transport::any::{AnyToken, AnyTransport};
 

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -118,12 +118,9 @@ pub enum FormFactor {
 ///
 /// The payload is BER-TLV-like, with some differences:
 ///
-/// * all tags (incorrectly) use the universal class (0x00)
+/// * all tags use the universal class (0x00)
 /// * tag numbers are one of the values in [`ConfigKey`]
 /// * values are encoded directly
-///
-/// BER-TLV tag values are one of the values in [`ConfigKey`], which are all in
-/// the universal class (0x00).
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct YubiKeyConfig {
     /// Device serial number. This isn't available on all devices.

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -16,15 +16,17 @@
 //!
 //! ## NFC
 //!
+//! **NFC support is not yet implemented.**
+//!
 //! Management app AID: `a000000527471117`
+//!
+//! All commands sent with CLA = `0x00`, P2 = `0x00`.
 //!
 //! INS    | P1     | Description | Request | Response
 //! ------ | ------ | ----------- | ------- | --------
 //! `0x16` | `0x11` | Set legacy device config | ... | ...
 //! `0x1D` | `0x00` | Get device config | _none_ | [`YubiKeyConfig`]
 //! `0x1C` | `0x00` | Set device config | [`YubiKeyConfig`] | none?
-//!
-//! All commands sent with CLA = `0x00`, P2 = `0x00`.
 //!
 //! ## References
 //!
@@ -33,7 +35,7 @@
 //! [0]: https://github.com/Yubico/yubikey-manager/blob/51a7ae438c923189788a1e31d3de18d452131942/yubikit/management.py#L223
 use async_trait::async_trait;
 use bitflags::bitflags;
-use num_traits::cast::{FromPrimitive, ToPrimitive};
+use num_traits::cast::FromPrimitive;
 
 use crate::{prelude::WebauthnCError, tlv::ber::BerTlvParser};
 

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -1,5 +1,8 @@
 //! YubiKey vendor-specific commands.
 //!
+//! This currently only supports YubiKey 5 and later. Older keys have different
+//! config formats and protocols, some firmwares give bogus data.
+//!
 //! ## USB HID
 //!
 //! Commands are sent on a `U2FHIDFrame` level, and values are bitwise-OR'd
@@ -7,10 +10,21 @@
 //!
 //! Command | Description | Request | Response
 //! ------- | ----------- | ------- | --------
+//! `0x40`  | Set legacy device config | ... | ...
 //! `0x42`  | Get device config | _none_ | [`YubiKeyConfig`]
-//!
+//! `0x43`  | Set device config | [`YubiKeyConfig`] | none?
 //!
 //! ## NFC
+//!
+//! Management app AID: `a000000527471117`
+//!
+//! INS    | P1     | Description | Request | Response
+//! ------ | ------ | ----------- | ------- | --------
+//! `0x16` | `0x11` | Set legacy device config | ... | ...
+//! `0x1D` | `0x00` | Get device config | _none_ | [`YubiKeyConfig`]
+//! `0x1C` | `0x00` | Set device config | [`YubiKeyConfig`] | none?
+//!
+//! All commands sent with CLA = `0x00`, P2 = `0x00`.
 //!
 //! ## References
 //!
@@ -60,7 +74,9 @@ enum ConfigKey {
     ChallengeResponseTimeout = 0x7,
     DeviceFlags = 0x8,
     AppVersions = 0x9,
+    /// 16 bytes lock code, or indicates when a device is locked
     ConfigLock = 0xa,
+    /// 16 bytes unlock code, to unlock a locked device
     Unlock = 0xb,
     Reboot = 0xc,
     SupportedNfcInterfaces = 0xd,

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -7,7 +7,8 @@
 //!
 //! Command | Description | Request | Response
 //! ------- | ----------- | ------- | --------
-//! `0x42`  | Get device config | _none_ | `DeviceInfo` BER-TLV
+//! `0x42`  | Get device config | _none_ | [`YubiKeyConfig`]
+//!
 //!
 //! ## NFC
 //!
@@ -66,35 +67,63 @@ enum ConfigKey {
     EnabledNfcInterfaces = 0xe,
 }
 
+/// YubiKey device form factor.
+///
+/// Only the lower 3 bits of the `u8` are used.
 #[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 pub enum FormFactor {
     #[default]
     Unknown = 0x0,
+    /// USB-A keychain-size device
     UsbAKeychain = 0x1,
+    /// USB-A nano-size device
     UsbANano = 0x2,
+    /// USB-C keychain-size device
     UsbCKeychain = 0x3,
+    /// USB-C nano-size device
     UsbCNano = 0x4,
+    /// USB-C + Lightning device
     UsbCLightning = 0x5,
+    /// USB-A + biometric device
     UsbABio = 0x6,
+    /// USB-C + biometric device
     UsbCBio = 0x7,
 }
 
+/// YubiKey device info / configuration structure
+///
+/// ## Payload format
+///
+/// * `u8`: length
+/// * BER-TLV payload
+///
+/// BER-TLV tag values are one of the values in [`ConfigKey`].
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct YubiKeyConfig {
+    /// Device serial number. This isn't available on all devices.
     pub serial: Option<u32>,
+    /// Form factor of the device.
     pub form_factor: FormFactor,
+    /// Firmware version of the device.
     pub version: [u8; 3],
+    /// `true` if a configuration lock has been set on the device.
     pub is_locked: bool,
+    /// `true` if the device is FIPS-certified.
     pub is_fips: bool,
     /// `true` if the device is a "Security Key" (CTAP-only), `false` if it is a
     /// "YubiKey".
     pub is_security_key: bool,
     pub supports_remote_wakeup: bool,
     pub supports_eject: bool,
+    /// Interfaces which are supported over USB.
     pub supported_usb_interfaces: Interface,
+    /// Interfaces which are enabled over USB.
     pub enabled_usb_interfaces: Interface,
+    /// Interfaces which are supported over NFC. Non-NFC devices don't set any
+    /// values here.
     pub supported_nfc_interfaces: Interface,
+    /// Interfaces which are enabled over NFC.
     pub enabled_nfc_interfaces: Interface,
     pub auto_eject_timeout: u16,
     pub challenge_response_timeout: u16,

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -163,7 +163,6 @@ impl YubiKeyConfig {
         let parser = BerTlvParser::new(&b[1..]);
 
         for (cls, tag, val) in parser {
-            // trace!(?cls, ?tag, ?val);
             if cls != 0 {
                 continue;
             }
@@ -427,6 +426,33 @@ mod tests {
         };
         let v =
             hex::decode("230102023f030202180204cafe123404010305030501020602000007010f0801000a0100")
+                .unwrap();
+        let cfg = YubiKeyConfig::from_bytes(v.as_slice()).unwrap();
+        assert_eq!(expected, cfg);
+    }
+
+    #[test]
+    fn yubikey_5c_nano() {
+        let _ = tracing_subscriber::fmt().try_init();
+        let expected = YubiKeyConfig {
+            serial: Some(0xcafe1234),
+            form_factor: FormFactor::UsbCNano,
+            version: [5, 2, 4],
+            supported_usb_interfaces: Interface::OTP
+                | Interface::CTAP1
+                | Interface::CTAP2
+                | Interface::OPENPGP
+                | Interface::PIV
+                | Interface::OATH,
+            enabled_usb_interfaces: Interface::CTAP1 | Interface::CTAP2,
+            supported_nfc_interfaces: Interface::empty(),
+            enabled_nfc_interfaces: Interface::empty(),
+            auto_eject_timeout: 0,
+            challenge_response_timeout: 15,
+            ..Default::default()
+        };
+        let v =
+            hex::decode("260102023f030202020204cafe123404010405030502040602000007010f0801000a01000f0100")
                 .unwrap();
         let cfg = YubiKeyConfig::from_bytes(v.as_slice()).unwrap();
         assert_eq!(expected, cfg);

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -451,9 +451,10 @@ mod tests {
             challenge_response_timeout: 15,
             ..Default::default()
         };
-        let v =
-            hex::decode("260102023f030202020204cafe123404010405030502040602000007010f0801000a01000f0100")
-                .unwrap();
+        let v = hex::decode(
+            "260102023f030202020204cafe123404010405030502040602000007010f0801000a01000f0100",
+        )
+        .unwrap();
         let cfg = YubiKeyConfig::from_bytes(v.as_slice()).unwrap();
         assert_eq!(expected, cfg);
     }

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -7,31 +7,331 @@
 //!
 //! Command | Description | Request | Response
 //! ------- | ----------- | ------- | --------
+//! `0x42`  | Get device config | _none_ | `DeviceInfo` BER-TLV
 //!
 //! ## NFC
 //!
 //! ## References
 //!
+//! * [DeviceInfo structure][0] (includes config)
+//!
+//! [0]: https://github.com/Yubico/yubikey-manager/blob/51a7ae438c923189788a1e31d3de18d452131942/yubikit/management.py#L223
 use async_trait::async_trait;
+use bitflags::bitflags;
+use num_traits::cast::{FromPrimitive, ToPrimitive};
 
-use crate::prelude::WebauthnCError;
+use crate::{prelude::WebauthnCError, tlv::ber::BerTlvParser};
 
 use super::AnyToken;
 
 #[cfg(all(feature = "usb", feature = "vendor-yubikey"))]
 pub(crate) const CMD_GET_CONFIG: u8 = super::TYPE_INIT | 0x42;
 
+bitflags! {
+    /// Bitmask of enabled / available interfaces.
+    ///
+    /// `ykman` calls these "Capabilities".
+    ///
+    /// Reference: <https://github.com/Yubico/yubikey-manager/blob/51a7ae438c923189788a1e31d3de18d452131942/yubikit/management.py#L62>
+    #[derive(Default)]
+    pub struct Interface: u16 {
+        const OTP = 0x01;
+        const CTAP1 = 0x02;
+        const OPENPGP = 0x08;
+        const PIV = 0x10;
+        const OATH = 0x20;
+        const YUBIHSM = 0x100;
+        const CTAP2 = 0x200;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive, ToPrimitive)]
+#[repr(u16)]
+enum ConfigKey {
+    #[default]
+    Unknown = 0x0,
+    SupportedUsbInterfaces = 0x1,
+    Serial = 0x2,
+    EnabledUsbInterfaces = 0x3,
+    FormFactor = 0x4,
+    Version = 0x5,
+    AutoEjectTimeout = 0x6,
+    ChallengeResponseTimeout = 0x7,
+    DeviceFlags = 0x8,
+    AppVersions = 0x9,
+    ConfigLock = 0xa,
+    Unlock = 0xb,
+    Reboot = 0xc,
+    SupportedNfcInterfaces = 0xd,
+    EnabledNfcInterfaces = 0xe,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive, ToPrimitive)]
+#[repr(u8)]
+pub enum FormFactor {
+    #[default]
+    Unknown = 0x0,
+    UsbAKeychain = 0x1,
+    UsbANano = 0x2,
+    UsbCKeychain = 0x3,
+    UsbCNano = 0x4,
+    UsbCLightning = 0x5,
+    UsbABio = 0x6,
+    UsbCBio = 0x7,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct YubiKeyConfig {
+    pub serial: Option<u32>,
+    pub form_factor: FormFactor,
+    pub version: [u8; 3],
+    pub is_locked: bool,
+    pub is_fips: bool,
+    /// `true` if the device is a "Security Key" (CTAP-only), `false` if it is a
+    /// "YubiKey".
+    pub is_security_key: bool,
+    pub supports_remote_wakeup: bool,
+    pub supports_eject: bool,
+    pub supported_usb_interfaces: Interface,
+    pub enabled_usb_interfaces: Interface,
+    pub supported_nfc_interfaces: Interface,
+    pub enabled_nfc_interfaces: Interface,
+    pub auto_eject_timeout: u16,
+    pub challenge_response_timeout: u16,
+}
+
+impl YubiKeyConfig {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, WebauthnCError> {
+        if b.is_empty() {
+            return Err(WebauthnCError::InvalidMessageLength);
+        }
+        let len = b[0];
+        if b.len() - 1 != usize::from(len) {
+            return Err(WebauthnCError::InvalidMessageLength);
+        }
+
+        let mut o = YubiKeyConfig {
+            ..Default::default()
+        };
+        let parser = BerTlvParser::new(&b[1..]);
+
+        for (cls, tag, val) in parser {
+            // trace!(?cls, ?tag, ?val);
+            if cls != 0 {
+                continue;
+            }
+            let Some(key) = ConfigKey::from_u16(tag) else {
+                continue;
+            };
+
+            match key {
+                ConfigKey::Unknown => continue,
+                ConfigKey::SupportedUsbInterfaces => {
+                    if val.len() != 2 {
+                        continue;
+                    }
+                    let v = u16::from_be_bytes(
+                        val.try_into()
+                            .map_err(|_| WebauthnCError::InvalidMessageLength)?,
+                    );
+                    if let Some(i) = Interface::from_bits(v & Interface::all().bits()) {
+                        o.supported_usb_interfaces = i;
+                    }
+                }
+                ConfigKey::Serial => {
+                    if val.len() != 4 {
+                        continue;
+                    }
+                    o.serial = val.try_into().map(u32::from_be_bytes).ok();
+                }
+                ConfigKey::EnabledUsbInterfaces => {
+                    if val.len() != 2 {
+                        continue;
+                    }
+                    let v = u16::from_be_bytes(
+                        val.try_into()
+                            .map_err(|_| WebauthnCError::InvalidMessageLength)?,
+                    );
+                    if let Some(i) = Interface::from_bits(v & Interface::all().bits()) {
+                        o.enabled_usb_interfaces = i;
+                    }
+                }
+                ConfigKey::FormFactor => {
+                    if val.is_empty() {
+                        continue;
+                    }
+                    if let Some(f) = FormFactor::from_u8(val[0] & 0x7) {
+                        o.form_factor = f;
+                    }
+                    o.is_fips = val[0] & 0x80 != 0;
+                    o.is_security_key = val[0] & 0x40 != 0;
+                }
+                ConfigKey::Version => {
+                    if let Ok(v) = val.try_into() {
+                        o.version = v;
+                    }
+                }
+                ConfigKey::AutoEjectTimeout => {
+                    if let Some(v) = variable_be_bytes_to_u16(val) {
+                        o.auto_eject_timeout = v;
+                    }
+                }
+                ConfigKey::ChallengeResponseTimeout => {
+                    if let Some(v) = variable_be_bytes_to_u16(val) {
+                        o.challenge_response_timeout = v;
+                    }
+                }
+                ConfigKey::DeviceFlags => {
+                    if val.is_empty() {
+                        continue;
+                    }
+                    o.supports_remote_wakeup = val[0] & 0x40 != 0;
+                    o.supports_eject = val[0] & 0x80 != 0;
+                }
+                ConfigKey::AppVersions => {
+                    continue;
+                }
+                ConfigKey::ConfigLock => {
+                    if val.is_empty() {
+                        continue;
+                    }
+                    o.is_locked = val[0] == 1;
+                }
+                ConfigKey::Unlock => continue,
+                ConfigKey::Reboot => continue,
+                ConfigKey::SupportedNfcInterfaces => {
+                    if val.len() != 2 {
+                        continue;
+                    }
+                    let v = u16::from_be_bytes(
+                        val.try_into()
+                            .map_err(|_| WebauthnCError::InvalidMessageLength)?,
+                    );
+                    if let Some(i) = Interface::from_bits(v & Interface::all().bits()) {
+                        o.supported_nfc_interfaces = i;
+                    }
+                }
+                ConfigKey::EnabledNfcInterfaces => {
+                    if val.len() != 2 {
+                        continue;
+                    }
+                    let v = u16::from_be_bytes(
+                        val.try_into()
+                            .map_err(|_| WebauthnCError::InvalidMessageLength)?,
+                    );
+                    if let Some(i) = Interface::from_bits(v & Interface::all().bits()) {
+                        o.enabled_nfc_interfaces = i;
+                    }
+                }
+            }
+        }
+
+        Ok(o)
+    }
+
+    pub fn is_preview(&self) -> bool {
+        match (self.version[0], self.version[1], self.version[2]) {
+            (5, 0, _) => true,
+            (5, 2, z) => z < 3,
+            (5, 5, z) => z < 2,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Display for YubiKeyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Form factor: {:?}{}",
+            self.form_factor,
+            if self.is_security_key {
+                " Security Key"
+            } else {
+                " YubiKey"
+            }
+        )?;
+        writeln!(
+            f,
+            "Version: {}.{}.{}",
+            self.version[0], self.version[1], self.version[2]
+        )?;
+
+        write!(f, "Flags: ")?;
+        if self.is_preview() {
+            write!(f, "preview, ")?;
+        }
+        if self.is_locked {
+            write!(f, "config locked, ")?;
+        }
+        if self.is_fips {
+            write!(f, "FIPS, ")?;
+        }
+        if self.supports_remote_wakeup {
+            write!(f, "remote wake-up, ")?;
+        }
+        if self.supports_eject {
+            write!(f, "eject, ")?;
+        }
+        writeln!(f)?;
+
+        if let Some(serial) = self.serial {
+            writeln!(f, "Serial: {serial}")?;
+        }
+
+        if !self.supported_usb_interfaces.is_empty() {
+            writeln!(
+                f,
+                "Supported USB interfaces: {:?}",
+                self.supported_usb_interfaces
+            )?;
+            writeln!(
+                f,
+                "Enabled USB interfaces: {:?}",
+                self.enabled_usb_interfaces
+            )?;
+        }
+
+        if !self.supported_nfc_interfaces.is_empty() {
+            writeln!(
+                f,
+                "Supported NFC interfaces: {:?}",
+                self.supported_nfc_interfaces
+            )?;
+            writeln!(
+                f,
+                "Enabled NFC interfaces: {:?}",
+                self.enabled_nfc_interfaces
+            )?;
+        }
+
+        if self.auto_eject_timeout != 0 {
+            writeln!(f, "Auto-eject timeout: {}", self.auto_eject_timeout)?;
+        }
+
+        if self.challenge_response_timeout != 0 {
+            writeln!(
+                f,
+                "Challenge-response timeout: {}",
+                self.challenge_response_timeout
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
 /// See [`YubiKeyAuthenticator`](crate::ctap2::YubiKeyAuthenticator).
 #[async_trait]
 pub trait YubiKeyToken {
     /// See [`SoloKeyAuthenticator::get_solokey_lock()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_lock).
-    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError>;
+    async fn get_yubikey_config(&mut self) -> Result<YubiKeyConfig, WebauthnCError>;
 }
 
 #[async_trait]
 #[allow(clippy::unimplemented)]
 impl YubiKeyToken for AnyToken {
-    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError> {
+    async fn get_yubikey_config(&mut self) -> Result<YubiKeyConfig, WebauthnCError> {
         match self {
             AnyToken::Stub => unimplemented!(),
             #[cfg(feature = "bluetooth")]
@@ -41,5 +341,70 @@ impl YubiKeyToken for AnyToken {
             #[cfg(feature = "usb")]
             AnyToken::Usb(u) => u.get_yubikey_config().await,
         }
+    }
+}
+
+fn variable_be_bytes_to_u16(b: &[u8]) -> Option<u16> {
+    if b.len() == 1 {
+        Some(u16::from(b[0]))
+    } else if b.len() == 2 {
+        b.try_into().map(u16::from_be_bytes).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yubikey_5c() {
+        let _ = tracing_subscriber::fmt().try_init();
+        let expected = YubiKeyConfig {
+            serial: Some(0xcafe1234),
+            form_factor: FormFactor::UsbCKeychain,
+            version: [5, 1, 2],
+            supported_usb_interfaces: Interface::OTP
+                | Interface::CTAP1
+                | Interface::CTAP2
+                | Interface::OPENPGP
+                | Interface::PIV
+                | Interface::OATH,
+            enabled_usb_interfaces: Interface::OPENPGP | Interface::PIV | Interface::CTAP2,
+            supported_nfc_interfaces: Interface::empty(),
+            enabled_nfc_interfaces: Interface::empty(),
+            auto_eject_timeout: 0,
+            challenge_response_timeout: 15,
+            ..Default::default()
+        };
+        let v =
+            hex::decode("230102023f030202180204cafe123404010305030501020602000007010f0801000a0100")
+                .unwrap();
+        let cfg = YubiKeyConfig::from_bytes(v.as_slice()).unwrap();
+        assert_eq!(expected, cfg);
+    }
+
+    #[test]
+    fn yubico_security_key_c_nfc() {
+        let _ = tracing_subscriber::fmt().try_init();
+        let expected = YubiKeyConfig {
+            version: [5,4,3],
+            form_factor: FormFactor::UsbCKeychain,
+            is_security_key: true,
+            supported_usb_interfaces: Interface::CTAP1 | Interface::CTAP2,
+            enabled_usb_interfaces: Interface::CTAP2,
+            supported_nfc_interfaces: Interface::CTAP1 | Interface::CTAP2,
+            enabled_nfc_interfaces: Interface::CTAP2,
+            challenge_response_timeout: 15,
+            ..Default::default()
+        };
+
+        let v = hex::decode(
+            "28010202020302020004014305030504030602000007010f0801000d0202060e0202000a01000f0100",
+        )
+        .unwrap();
+        let cfg = YubiKeyConfig::from_bytes(v.as_slice()).unwrap();
+        assert_eq!(expected, cfg);
     }
 }

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -1,0 +1,45 @@
+//! YubiKey vendor-specific commands.
+//!
+//! ## USB HID
+//!
+//! Commands are sent on a `U2FHIDFrame` level, and values are bitwise-OR'd
+//! with `transport::TYPE_INIT` (0x80).
+//!
+//! Command | Description | Request | Response
+//! ------- | ----------- | ------- | --------
+//!
+//! ## NFC
+//!
+//! ## References
+//!
+use async_trait::async_trait;
+
+use crate::prelude::WebauthnCError;
+
+use super::AnyToken;
+
+#[cfg(all(feature = "usb", feature = "vendor-yubikey"))]
+pub(crate) const CMD_GET_CONFIG: u8 = super::TYPE_INIT | 0x42;
+
+/// See [`YubiKeyAuthenticator`](crate::ctap2::YubiKeyAuthenticator).
+#[async_trait]
+pub trait YubiKeyToken {
+    /// See [`SoloKeyAuthenticator::get_solokey_lock()`](crate::ctap2::SoloKeyAuthenticator::get_solokey_lock).
+    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError>;
+}
+
+#[async_trait]
+#[allow(clippy::unimplemented)]
+impl YubiKeyToken for AnyToken {
+    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError> {
+        match self {
+            AnyToken::Stub => unimplemented!(),
+            #[cfg(feature = "bluetooth")]
+            AnyToken::Bluetooth(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "nfc")]
+            AnyToken::Nfc(_) => Err(WebauthnCError::NotSupported),
+            #[cfg(feature = "usb")]
+            AnyToken::Usb(u) => u.get_yubikey_config().await,
+        }
+    }
+}

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -389,7 +389,7 @@ mod tests {
     fn yubico_security_key_c_nfc() {
         let _ = tracing_subscriber::fmt().try_init();
         let expected = YubiKeyConfig {
-            version: [5,4,3],
+            version: [5, 4, 3],
             form_factor: FormFactor::UsbCKeychain,
             is_security_key: true,
             supported_usb_interfaces: Interface::CTAP1 | Interface::CTAP2,

--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -15,6 +15,8 @@ mod framing;
 mod responses;
 #[cfg(any(all(doc, not(doctest)), feature = "vendor-solokey"))]
 mod solokey;
+#[cfg(any(all(doc, not(doctest)), feature = "vendor-yubikey"))]
+mod yubikey;
 
 use fido_hid_rs::{
     HidReportBytes, HidSendReportBytes, USBDevice, USBDeviceImpl, USBDeviceInfo, USBDeviceInfoImpl,

--- a/webauthn-authenticator-rs/src/usb/yubikey.rs
+++ b/webauthn-authenticator-rs/src/usb/yubikey.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use uuid::Uuid;
 
 #[cfg(all(feature = "usb", feature = "vendor-yubikey"))]
 use crate::transport::yubikey::CMD_GET_CONFIG;
@@ -8,14 +7,14 @@ use crate::{
     prelude::WebauthnCError,
     transport::{
         types::{U2FError, U2FHID_ERROR},
-        yubikey::YubiKeyToken,
+        yubikey::{YubiKeyConfig, YubiKeyToken},
     },
     usb::{framing::U2FHIDFrame, USBToken},
 };
 
 #[async_trait]
 impl YubiKeyToken for USBToken {
-    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError> {
+    async fn get_yubikey_config(&mut self) -> Result<YubiKeyConfig, WebauthnCError> {
         let cmd = U2FHIDFrame {
             cid: self.cid,
             cmd: CMD_GET_CONFIG,
@@ -25,20 +24,10 @@ impl YubiKeyToken for USBToken {
         self.send_one(&cmd).await?;
 
         let r = self.recv_one().await?;
-        debug!("config: {}", hex::encode(r.data));
-        todo!()
-        // match r.cmd {
-        //     CMD_LOCK => {
-        //         if r.len != 1 || r.data.len() != 1 {
-        //             return Err(WebauthnCError::InvalidMessageLength);
-        //         }
-
-        //         Ok(r.data[0] != 0)
-        //     }
-
-        //     U2FHID_ERROR => Err(U2FError::from(r.data.as_slice()).into()),
-
-        //     _ => Err(WebauthnCError::UnexpectedState),
-        // }
+        match r.cmd {
+            CMD_GET_CONFIG => YubiKeyConfig::from_bytes(r.data.as_slice()),
+            U2FHID_ERROR => Err(U2FError::from(r.data.as_slice()).into()),
+            _ => Err(WebauthnCError::UnexpectedState),
+        }
     }
 }

--- a/webauthn-authenticator-rs/src/usb/yubikey.rs
+++ b/webauthn-authenticator-rs/src/usb/yubikey.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+#[cfg(all(feature = "usb", feature = "vendor-yubikey"))]
+use crate::transport::yubikey::CMD_GET_CONFIG;
+
+use crate::{
+    prelude::WebauthnCError,
+    transport::{
+        types::{U2FError, U2FHID_ERROR},
+        yubikey::YubiKeyToken,
+    },
+    usb::{framing::U2FHIDFrame, USBToken},
+};
+
+#[async_trait]
+impl YubiKeyToken for USBToken {
+    async fn get_yubikey_config(&mut self) -> Result<bool, WebauthnCError> {
+        let cmd = U2FHIDFrame {
+            cid: self.cid,
+            cmd: CMD_GET_CONFIG,
+            len: 0,
+            data: vec![],
+        };
+        self.send_one(&cmd).await?;
+
+        let r = self.recv_one().await?;
+        debug!("config: {}", hex::encode(r.data));
+        todo!()
+        // match r.cmd {
+        //     CMD_LOCK => {
+        //         if r.len != 1 || r.data.len() != 1 {
+        //             return Err(WebauthnCError::InvalidMessageLength);
+        //         }
+
+        //         Ok(r.data[0] != 0)
+        //     }
+
+        //     U2FHID_ERROR => Err(U2FError::from(r.data.as_slice()).into()),
+
+        //     _ => Err(WebauthnCError::UnexpectedState),
+        // }
+    }
+}


### PR DESCRIPTION
This adds support for reading the configuration of a YubiKey 5 series over USB with the FIDO2 interface, and a custom BER-TLV parser for YubiKey's not-quite-BER-TLV configuration format.

This is similar to #377.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
