### PR TITLE
Add build-time OpenSSL version checks

### DIFF
--- a/attestation-ca/Cargo.toml
+++ b/attestation-ca/Cargo.toml
@@ -11,3 +11,6 @@ serde.workspace = true
 tracing.workspace = true
 openssl.workspace = true
 uuid = { workspace = true, features = ["serde"] }
+
+[build-dependencies]
+openssl.workspace = true

--- a/attestation-ca/build.rs
+++ b/attestation-ca/build.rs
@@ -1,0 +1,21 @@
+use openssl::version::{number, version};
+
+const OPENSSL_DOC: &str = "https://github.com/kanidm/webauthn-rs/blob/master/OpenSSL.md";
+
+fn main() {
+    // LibreSSL reports as OpenSSL v2 (which was skipped).
+    if number() < 0x2_00_00_00_0 {
+        println!(
+            r#"
+Your version of OpenSSL is out of date, and not supported by this library.
+
+Please upgrade to OpenSSL v3.0.0 or later.
+
+More info: {OPENSSL_DOC}
+OpenSSL version string: {}
+"#,
+            version(),
+        );
+        panic!("The installed version of OpenSSL is unusable.");
+    }
+}

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -42,3 +42,6 @@ uuid = { workspace = true, features = ["serde"] }
 hex-literal = "0.3"
 tracing-subscriber.workspace = true
 webauthn-rs-device-catalog.workspace = true
+
+[build-dependencies]
+openssl.workspace = true

--- a/webauthn-rs-core/build.rs
+++ b/webauthn-rs-core/build.rs
@@ -1,0 +1,21 @@
+use openssl::version::{number, version};
+
+const OPENSSL_DOC: &str = "https://github.com/kanidm/webauthn-rs/blob/master/OpenSSL.md";
+
+fn main() {
+    // LibreSSL reports as OpenSSL v2.
+    if number() < 0x2_00_00_00_0 {
+        println!(
+            r#"
+Your version of OpenSSL is out of date, and not supported by this library.
+
+Please upgrade to OpenSSL v3.0.0 or later.
+
+More info: {OPENSSL_DOC}
+OpenSSL version string: {}
+"#,
+            version(),
+        );
+        panic!("The installed version of OpenSSL is unusable.");
+    }
+}


### PR DESCRIPTION
[The `webauthn-rs` OpenSSL policy](https://github.com/kanidm/webauthn-rs/blob/master/OpenSSL.md) is currently only "enforced" for `webauthn-authenticator-rs`.

This PR adds OpenSSL version number checks to `attestation-ca` and `webauthn-rs-core` using `OPENSSL_VERSION_NUMBER`. Every other package in this repo with an OpenSSL dependency depends on one of these two packages, so can be handled transitively.

This will make builds fail with OpenSSL v1.x, in line with [our OpenSSL policy](https://github.com/kanidm/webauthn-rs/blob/master/OpenSSL.md).

## OpenSSL alternatives

We don't currently support OpenSSL alternatives, but I've attempted to avoid breaking them with this PR:

- [BoringSSL sets `OPENSSL_VERSION_NUMBER` to whichever it's targetting](https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md), so doesn't need special casing.
- [LibreSSL always reports as "OpenSSL v2"](https://man.openbsd.org/OPENSSL_VERSION_NUMBER.3) (which doesn't exist), so I've set that as the minimum. It probably has similar bugs, but `rust-openssl` doesn't expose the LibreSSL version, and LibreSSL doesn't target parity with specific OpenSSL versions.

I haven't tested with either.

## What failures look like

When building with outdated OpenSSL, this PR now makes it so you get a build-time error:

```
error: failed to run custom build command for `webauthn-attestation-ca v0.1.0`

Caused by:
  process didn't exit successfully: `/target/debug/build/webauthn-attestation-ca-2944cc0bf508a0c6/build-script-build` (exit status: 101)
  --- stdout

  Your version of OpenSSL is out of date, and not supported by this library.

  Please upgrade to OpenSSL v3.0.0 or later.

  More info: https://github.com/kanidm/webauthn-rs/blob/master/OpenSSL.md
  OpenSSL version string: OpenSSL x.x.x 29 Feb 1985


  --- stderr
  thread 'main' panicked at attestation-ca/build.rs:18:9:
  The installed version of OpenSSL is unusable.
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
