### PR TITLE
Pin clap to 4.4.18 (last version supporting rustc 1.70.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ fido-mds = { path = "./fido-mds" }
 
 async-std = { version = "1.6", features = ["attributes"] }
 base64 = "0.21"
-clap = { version = "^4.2.4", features = ["derive", "env"] }
+clap = { version = "=4.4.18", features = ["derive", "env"] }
 compact_jwt = "0.2.3"
 futures = "^0.3.25"
 hex = "0.4.3"


### PR DESCRIPTION
`clap` 4.5.0 wants rustc 1.74, but our MSRV is still 1.70:

```
 error: package `clap_derive v4.5.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
Either upgrade to rustc 1.74 or newer, or use
cargo update -p clap_derive@4.5.0 --precise ver
where `ver` is the latest version of `clap_derive` supporting rustc 1.70.0
Error: Process completed with exit code 101.
```

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
