### PR TITLE
Fix building on nightly, broken doc links

### DIFF
--- a/base64urlsafedata/src/lib.rs
+++ b/base64urlsafedata/src/lib.rs
@@ -101,7 +101,6 @@ use base64::{
     Engine,
 };
 use serde::{Serialize, Serializer};
-use std::convert::TryFrom;
 use std::fmt;
 use std::hash::Hash;
 

--- a/base64urlsafedata/src/tests.rs
+++ b/base64urlsafedata/src/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::convert::TryFrom;
 
 #[test]
 fn test_try_from() {

--- a/tutorial/server/actix_web/Cargo.toml
+++ b/tutorial/server/actix_web/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Niklas Pfister <git@omikron.dev>"]
 
 [dependencies]
 # Webframework
-actix-web = { version = "~4.2" }
+actix-web = { version = "~4.5.1" }
 # Session framework for actix-web
 actix-session = { version = "~0.7", features = ["cookie-session"] }
 # Async trait, anyhow, chrono, once_cell and rand are required for the implementation of a
@@ -19,7 +19,7 @@ actix-session = { version = "~0.7", features = ["cookie-session"] }
 async-trait = { version = "~0.1" }
 anyhow = { version = "~1.0" }
 chrono = { version = "~0.4" }
-once_cell = { version = "~1.17" }
+once_cell = { version = "~1.18" }
 rand.workspace = true
 
 # Serve static file. Used to serve wasm

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -2,16 +2,12 @@
 //! This contains a transparent type allowing callbacks to
 //! make attestation decisions.
 
-use std::convert::TryFrom;
-
 use crate::crypto::{
     check_extension, compute_sha256, only_hash_from_type, verify_signature, TpmSanData,
 };
 use crate::error::WebauthnError;
 use crate::internals::*;
-use crate::internals::{tpm_device_attribute_parser, TpmVendor};
 use crate::proto::*;
-use base64urlsafedata::Base64UrlSafeData;
 use openssl::hash::MessageDigest;
 use openssl::sha::sha256;
 use openssl::stack;

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -16,7 +16,6 @@
 #![warn(missing_docs)]
 
 use rand::prelude::*;
-use std::convert::TryFrom;
 use std::time::Duration;
 use url::Url;
 
@@ -30,7 +29,6 @@ use crate::crypto::compute_sha256;
 use crate::error::WebauthnError;
 use crate::internals::*;
 use crate::proto::*;
-use base64urlsafedata::Base64UrlSafeData;
 
 /// The Core Webauthn handler.
 ///

--- a/webauthn-rs-core/src/crypto.rs
+++ b/webauthn-rs-core/src/crypto.rs
@@ -5,7 +5,6 @@
 
 #![allow(non_camel_case_types)]
 
-use core::convert::TryFrom;
 use openssl::{bn, ec, hash, nid, pkey, rsa, sha, sign, x509};
 
 use super::error::*;

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -4,11 +4,9 @@
 use crate::attestation::AttestationFormat;
 use crate::error::WebauthnError;
 use crate::proto::*;
-use base64urlsafedata::Base64UrlSafeData;
 use serde::Deserialize;
 
 use std::borrow::Borrow;
-use std::convert::TryFrom;
 use std::ops::Deref;
 
 use nom::bytes::complete::{tag, take};
@@ -1298,7 +1296,6 @@ mod tests {
     };
     use crate::interface::*;
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use std::convert::TryFrom;
 
     #[test]
     fn deserialise_register_response() {

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -147,7 +147,7 @@ impl PartialEq for Passkey {
     feature = "danger-allow-state-serialisation",
     derive(Serialize, Deserialize)
 )]
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 pub struct AttestedPasskeyRegistration {
     pub(crate) rs: RegistrationState,
     pub(crate) ca_list: AttestationCaList,
@@ -167,7 +167,7 @@ pub struct AttestedPasskeyRegistration {
     feature = "danger-allow-state-serialisation",
     derive(Serialize, Deserialize)
 )]
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 pub struct AttestedPasskeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -178,12 +178,12 @@ pub struct AttestedPasskeyAuthentication {
 ///
 /// These can be safely serialised and deserialised from a database for use.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 pub struct AttestedPasskey {
     pub(crate) cred: Credential,
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl AttestedPasskey {
     /// Retrieve a reference to this AttestedPasskey Key's credential ID.
     pub fn cred_id(&self) -> &CredentialID {
@@ -252,38 +252,38 @@ impl AttestedPasskey {
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl std::borrow::Borrow<CredentialID> for AttestedPasskey {
     fn borrow(&self) -> &CredentialID {
         &self.cred.cred_id
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl PartialEq for AttestedPasskey {
     fn eq(&self, other: &Self) -> bool {
         self.cred.cred_id == other.cred.cred_id
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl Eq for AttestedPasskey {}
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl PartialOrd for AttestedPasskey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cred.cred_id.cmp(&other.cred.cred_id))
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl Ord for AttestedPasskey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.cred.cred_id.cmp(&other.cred.cred_id)
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl From<&AttestedPasskey> for Passkey {
     fn from(k: &AttestedPasskey) -> Self {
         Passkey {
@@ -292,7 +292,7 @@ impl From<&AttestedPasskey> for Passkey {
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl From<AttestedPasskey> for Passkey {
     fn from(k: AttestedPasskey) -> Self {
         Passkey { cred: k.cred }
@@ -430,7 +430,7 @@ impl From<Credential> for SecurityKey {
     }
 }
 
-/// An in progress registration session for a [AttestedResidentKey].
+/// An in progress registration session for an [AttestedResidentKey].
 ///
 /// WARNING ⚠️  YOU MUST STORE THIS VALUE SERVER SIDE.
 ///
@@ -444,7 +444,7 @@ impl From<Credential> for SecurityKey {
     feature = "danger-allow-state-serialisation",
     derive(Serialize, Deserialize)
 )]
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 pub struct AttestedResidentKeyRegistration {
     pub(crate) rs: RegistrationState,
     pub(crate) ca_list: AttestationCaList,
@@ -464,7 +464,7 @@ pub struct AttestedResidentKeyRegistration {
     feature = "danger-allow-state-serialisation",
     derive(Serialize, Deserialize)
 )]
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 pub struct AttestedResidentKeyAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -482,12 +482,12 @@ pub struct AttestedResidentKeyAuthentication {
 ///
 /// These can be safely serialised and deserialised from a database for use.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 pub struct AttestedResidentKey {
     pub(crate) cred: Credential,
 }
 
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 impl AttestedResidentKey {
     /// Retrieve a reference to this Resident Key's credential ID.
     pub fn cred_id(&self) -> &CredentialID {
@@ -556,14 +556,14 @@ impl AttestedResidentKey {
     }
 }
 
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 impl PartialEq for AttestedResidentKey {
     fn eq(&self, other: &Self) -> bool {
         self.cred.cred_id == other.cred.cred_id
     }
 }
 
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 impl From<&AttestedResidentKey> for Passkey {
     fn from(k: &AttestedResidentKey) -> Self {
         Passkey {
@@ -572,7 +572,7 @@ impl From<&AttestedResidentKey> for Passkey {
     }
 }
 
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 impl From<AttestedResidentKey> for Passkey {
     fn from(k: AttestedResidentKey) -> Self {
         Passkey { cred: k.cred }
@@ -615,7 +615,7 @@ impl From<Credential> for AttestedResidentKey {
     feature = "danger-allow-state-serialisation",
     derive(Serialize, Deserialize)
 )]
-#[cfg(feature = "conditional-ui")]
+#[cfg(any(all(doc, not(doctest)), feature = "conditional-ui"))]
 pub struct DiscoverableAuthentication {
     pub(crate) ast: AuthenticationState,
 }
@@ -626,12 +626,15 @@ pub struct DiscoverableAuthentication {
 /// Generally this is used as part of conditional ui which allows autofill of discovered
 /// credentials in username fields.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg(feature = "conditional-ui")]
+#[cfg(any(all(doc, not(doctest)), feature = "conditional-ui"))]
 pub struct DiscoverableKey {
     pub(crate) cred: Credential,
 }
 
-#[cfg(all(feature = "conditional-ui", feature = "resident-key-support"))]
+#[cfg(any(
+    all(doc, not(doctest)),
+    all(feature = "conditional-ui", feature = "resident-key-support")
+))]
 impl From<&AttestedResidentKey> for DiscoverableKey {
     fn from(k: &AttestedResidentKey) -> Self {
         DiscoverableKey {
@@ -640,14 +643,20 @@ impl From<&AttestedResidentKey> for DiscoverableKey {
     }
 }
 
-#[cfg(all(feature = "conditional-ui", feature = "resident-key-support"))]
+#[cfg(any(
+    all(doc, not(doctest)),
+    all(feature = "conditional-ui", feature = "resident-key-support")
+))]
 impl From<AttestedResidentKey> for DiscoverableKey {
     fn from(k: AttestedResidentKey) -> Self {
         DiscoverableKey { cred: k.cred }
     }
 }
 
-#[cfg(all(feature = "conditional-ui", feature = "attestation"))]
+#[cfg(any(
+    all(doc, not(doctest)),
+    all(feature = "conditional-ui", feature = "attestation")
+))]
 impl From<&AttestedPasskey> for DiscoverableKey {
     fn from(k: &AttestedPasskey) -> Self {
         DiscoverableKey {
@@ -656,14 +665,17 @@ impl From<&AttestedPasskey> for DiscoverableKey {
     }
 }
 
-#[cfg(all(feature = "conditional-ui", feature = "attestation"))]
+#[cfg(any(
+    all(doc, not(doctest)),
+    all(feature = "conditional-ui", feature = "attestation")
+))]
 impl From<AttestedPasskey> for DiscoverableKey {
     fn from(k: AttestedPasskey) -> Self {
         DiscoverableKey { cred: k.cred }
     }
 }
 
-#[cfg(feature = "conditional-ui")]
+#[cfg(any(all(doc, not(doctest)), feature = "conditional-ui"))]
 impl From<&Passkey> for DiscoverableKey {
     fn from(k: &Passkey) -> Self {
         DiscoverableKey {
@@ -672,7 +684,7 @@ impl From<&Passkey> for DiscoverableKey {
     }
 }
 
-#[cfg(feature = "conditional-ui")]
+#[cfg(any(all(doc, not(doctest)), feature = "conditional-ui"))]
 impl From<Passkey> for DiscoverableKey {
     fn from(k: Passkey) -> Self {
         DiscoverableKey { cred: k.cred }

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -441,7 +441,7 @@ impl<'a> WebauthnBuilder<'a> {
 /// You **MUST** only use it in tightly controlled environments where you supply devices to your
 /// users.
 ///
-/// > You should use [`start_attested_resident_key_registration`](Webauthn::start_attested_resident_key_registration) (still in development)
+/// > You should use [`start_attested_resident_key_registration`](Webauthn::start_attested_resident_key_registration) (still in development, requires `resident-key-support` feature)
 ///
 ///
 /// __I want a security token along with an external password to create multi-factor authentication__
@@ -591,7 +591,10 @@ impl Webauthn {
     /// on your site ahead of time to choose between a security key / screen unlock
     /// (triggered by [`start_passkey_registration`](Webauthn::start_passkey_registration))
     /// or a 'Google Passkey stored in Google Password Manager' (triggered by this function).
-    #[cfg(feature = "workaround-google-passkey-specific-issues")]
+    #[cfg(any(
+        all(doc, not(doctest)),
+        feature = "workaround-google-passkey-specific-issues"
+    ))]
     pub fn start_google_passkey_in_google_password_manager_only_registration(
         &self,
         user_unique_id: Uuid,
@@ -988,7 +991,7 @@ impl Webauthn {
     }
 }
 
-#[cfg(feature = "attestation")]
+#[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl Webauthn {
     /// Initiate the registration of a new attested_passkey key for a user. A attested_passkey key is a
     /// cryptographic authenticator that is a self-contained multifactor authenticator. This means
@@ -1266,7 +1269,7 @@ impl Webauthn {
     }
 }
 
-#[cfg(feature = "conditional-ui")]
+#[cfg(any(all(doc, not(doctest)), feature = "conditional-ui"))]
 impl Webauthn {
     /// This function will initiate a conditional ui authentication for discoverable
     /// credentials.
@@ -1350,7 +1353,7 @@ impl Webauthn {
     }
 }
 
-#[cfg(feature = "resident-key-support")]
+#[cfg(any(all(doc, not(doctest)), feature = "resident-key-support"))]
 impl Webauthn {
     /// TODO
     pub fn start_attested_resident_key_registration(


### PR DESCRIPTION
* Updates `actix_web` and `once_cell` to pick up `ahash>=0.8.7` (https://github.com/tkaitchuck/aHash/issues/188), as older versions are broken on nightly.
* Removes redundant imports, which are now an error on nightly.
* Expose optional features / types with `any(all(doc, not(doctest)), feature(...))` so that documentation links always work.


- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
