### PR TITLE
Use bumpalo 3.14.0 in CI (#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
           pkgs: openssl
           triplet: x64-windows-static-md
           token: ${{ github.token }}
+      # Transitive dependency of wasm-bindgen; works around https://github.com/rustwasm/wasm-bindgen/issues/3918
+      - run: cargo update -p bumpalo --precise 3.14.0
       - run: cargo build --workspace --exclude webauthn-authenticator-rs
 
       # Don't run clippy on Windows, we only need to run it on Linux


### PR DESCRIPTION
Fixes #427; works around https://github.com/rustwasm/wasm-bindgen/issues/3918 while keeping MSRV as-is.

- [x] cargo test has been run and passes
- [x] ~~documentation has been updated with relevant examples (if relevant)~~
