### PR TITLE
Fix spelling, etc.

### DIFF
--- a/tutorial/server/tide/src/main.rs
+++ b/tutorial/server/tide/src/main.rs
@@ -106,7 +106,7 @@ async fn start_register(mut request: tide::Request<AppState>) -> tide::Result {
     // their username at any time.
     let username: String = request.param("username")?.parse()?;
 
-    // Since a user's username could change at anytime, we need to bind to a unique id.
+    // Since a user's username could change at any time, we need to bind to a unique id.
     // We use uuid's for this purpose, and you should generate these randomly. If the
     // username does exist and is found, we can match back to our unique id. This is
     // important in authentication, where presented credentials may *only* provide
@@ -120,7 +120,7 @@ async fn start_register(mut request: tide::Request<AppState>) -> tide::Result {
             .unwrap_or_else(Uuid::new_v4)
     };
 
-    // Remove any previous registrations that may have occured from the session.
+    // Remove any previous registrations that may have occurred from the session.
     let session = request.session_mut();
     session.remove("reg_state");
 
@@ -141,7 +141,7 @@ async fn start_register(mut request: tide::Request<AppState>) -> tide::Result {
         exclude_credentials,
     ) {
         Ok((ccr, reg_state)) => {
-            // Note that due to the session store in use being a server side memory store, this is
+            // Note that due to the session store in use being a server side memory store, it is
             // safe to store the reg_state into the session since it is not client controlled and
             // not open to replay attacks. If this was a cookie store, this would be UNSAFE.
             request
@@ -160,7 +160,7 @@ async fn start_register(mut request: tide::Request<AppState>) -> tide::Result {
     Ok(res)
 }
 
-// 4. The browser has completed it's steps and the user has created a public key
+// 4. The browser has completed its steps and the user has created a public key
 // on their device. Now we have the registration options sent to us, and we need
 // to verify these and persist them.
 
@@ -241,7 +241,7 @@ async fn start_authentication(mut request: tide::Request<AppState>) -> tide::Res
     // some other process.
     let username: String = request.param("username")?.parse()?;
 
-    // Remove any previous authentication that may have occured from the session.
+    // Remove any previous authentication that may have occurred from the session.
     let session = request.session_mut();
     session.remove("auth_state");
 
@@ -269,7 +269,7 @@ async fn start_authentication(mut request: tide::Request<AppState>) -> tide::Res
             // Drop the mutex to allow the mut borrows below to proceed
             drop(users_guard);
 
-            // Note that due to the session store in use being a server side memory store, this is
+            // Note that due to the session store in use being a server side memory store, it is
             // safe to store the auth_state into the session since it is not client controlled and
             // not open to replay attacks. If this was a cookie store, this would be UNSAFE.
             request

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -1,5 +1,5 @@
 //! Extended Structs and representations for Webauthn Operations. These types are designed
-//! to allow persistance and should not change.
+//! to allow persistence and should not change.
 
 use crate::attestation::{verify_attestation_ca_chain, AttestationFormat};
 use crate::error::*;
@@ -202,9 +202,9 @@ pub enum COSEKeyType {
     //    | Symmetric | 4     | Symmetric Keys                                |
     //    | Reserved  | 0     | This value is reserved                        |
     //    +-----------+-------+-----------------------------------------------+
-    /// Identifies this as an Eliptic Curve octet key pair
+    /// Identifies this as an Elliptic Curve octet key pair
     EC_OKP(COSEOKPKey),
-    /// Identifies this as an Eliptic Curve EC2 key
+    /// Identifies this as an Elliptic Curve EC2 key
     EC_EC2(COSEEC2Key),
     // EC_Symmetric,
     // EC_Reserved, // should always be invalid.
@@ -271,7 +271,7 @@ pub struct Credential {
     /// processor, and may have impacts on your risk assessments and modeling.
     pub backup_eligible: bool,
     /// This credential has indicated that it is currently backed up OR that it
-    /// is shared between mulitple devices.
+    /// is shared between multiple devices.
     pub backup_state: bool,
     /// During registration, the policy that was requested from this
     /// credential. This is used to understand if the how the verified
@@ -290,16 +290,16 @@ pub struct Credential {
 
 impl Credential {
     /// Re-verify this Credential's attestation chain. This re-applies the same process
-    /// for certificate authority verification that occured at registration. This can
+    /// for certificate authority verification that occurred at registration. This can
     /// be useful if you want to re-assert your credentials match an updated or changed
-    /// ca_list from the time that registration occured. This can also be useful to
+    /// ca_list from the time that registration occurred. This can also be useful to
     /// re-determine certain properties of your device that may exist.
     pub fn verify_attestation<'a>(
         &'_ self,
         ca_list: &'a AttestationCaList,
     ) -> Result<Option<&'a AttestationCa>, WebauthnError> {
         // Formerly we disabled this due to apple, but they no longer provide
-        // meaningful attesation so we can re-enable it.
+        // meaningful attestation so we can re-enable it.
         let danger_disable_certificate_time_checks = false;
         verify_attestation_ca_chain(
             &self.attestation.data,
@@ -425,8 +425,8 @@ impl Default for ParsedAttestation {
     }
 }
 
-/// The processed Attestation that the Authenticator is providing in it's AttestedCredentialData. This
-/// metadata may allow identification of the device and it's specific properties.
+/// The processed Attestation that the Authenticator is providing in its AttestedCredentialData. This
+/// metadata may allow identification of the device and its specific properties.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AttestationMetadata {
     /// no metadata available for this device.
@@ -470,7 +470,7 @@ pub enum AttestationMetadata {
     },
 }
 
-/// The processed Attestation that the Authenticator is providing in it's AttestedCredentialData
+/// The processed Attestation that the Authenticator is providing in its AttestedCredentialData
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(
     try_from = "SerialisableAttestationData",
@@ -484,10 +484,10 @@ pub enum ParsedAttestationData {
     /// it uses the credential private key to create the attestation signature
     Self_,
     /// The credential is authenticated using a CA, and may provide a
-    /// ca chain to validate to it's root.
+    /// ca chain to validate to its root.
     AttCa(Vec<x509::X509>),
     /// The credential is authenticated using an anonymization CA, and may provide a ca chain to
-    /// validate to it's root.
+    /// validate to its root.
     AnonCa(Vec<x509::X509>),
     /// Unimplemented
     ECDAA,
@@ -634,7 +634,7 @@ pub struct AttestedCredentialData {
     pub credential_pk: serde_cbor_2::Value,
 }
 
-/// Information about the authentication that occured.
+/// Information about the authentication that occurred.
 #[derive(Debug, Serialize, Clone, Deserialize)]
 pub struct AuthenticationResult {
     /// The credential ID that was used to authenticate.
@@ -664,7 +664,7 @@ impl AuthenticationResult {
     }
 
     /// If this authentication result should be applied to the associated
-    /// credential to update it's properties.
+    /// credential to update its properties.
     pub fn needs_update(&self) -> bool {
         self.needs_update
     }

--- a/webauthn-rs-proto/src/attest.rs
+++ b/webauthn-rs-proto/src/attest.rs
@@ -40,7 +40,7 @@ pub struct PublicKeyCredentialCreationOptions {
     pub extensions: Option<RequestRegistrationExtensions>,
 }
 
-/// A JSON serializable challenge which is issued to the user's webbrowser
+/// A JSON serializable challenge which is issued to the user's web browser
 /// for handling. This is meant to be opaque, that is, you should not need
 /// to inspect or alter the content of the struct - you should serialise it
 /// and transmit it to the client only.
@@ -126,7 +126,7 @@ pub struct AuthenticatorAttestationResponseRaw {
 }
 
 /// A client response to a registration challenge. This contains all required
-/// information to asses and assert trust in a credentials legitimacy, followed
+/// information to assess and assert trust in a credential's legitimacy, followed
 /// by registration to a user.
 ///
 /// You should not need to handle the inner content of this structure - you should

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -49,10 +49,10 @@ pub struct PasskeyAuthentication {
 /// Yubikey, a Windows Hello TPM, or even a password manager softtoken.
 ///
 /// Passkeys *may* opportunistically have some properties such as discoverability (residence). This
-/// is not a guarantee since enforcing residence on devices like yubikeys that have limited storage
+/// is not a guarantee since enforcing residence on devices like Yubikeys that have limited storage
 /// and no administration of resident keys may break the device.
 ///
-/// These can be safely serialised and deserialised from a database for persistance.
+/// These can be safely serialised and deserialised from a database for persistence.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Passkey {
     pub(crate) cred: Credential,
@@ -74,10 +74,10 @@ impl Passkey {
         &self.cred.cred
     }
 
-    /// Post authentication, update this credentials properties.
+    /// Post authentication, update this credential's properties.
     ///
     /// To determine if this is required, you can inspect the result of
-    /// `authentication_result.needs_update()`. Counter intuitively, most passkeys
+    /// `authentication_result.needs_update()`. Counterintuitively, most passkeys
     /// will never need their properties updated! This is because many passkeys lack an
     /// internal device activation counter (due to their synchronisation), and the
     /// backup-state flags are rarely if ever changed.
@@ -174,7 +174,7 @@ pub struct AttestedPasskeyAuthentication {
 
 /// An attested passkey for a user. This is a specialisation of [Passkey] as you can
 /// limit the make and models of authenticators that a user may register. Additionally
-/// these keys will always enforce userverification.
+/// these keys will always enforce user verification.
 ///
 /// These can be safely serialised and deserialised from a database for use.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -196,13 +196,13 @@ impl AttestedPasskey {
     }
 
     /// Retrieve a reference to the attestation used during this [`Credential`]'s
-    /// registration. This can tell you information about the manufacterer and
+    /// registration. This can tell you information about the manufacturer and
     /// what type of credential it is.
     pub fn attestation(&self) -> &ParsedAttestation {
         &self.cred.attestation
     }
 
-    /// Post authentication, update this credentials properties.
+    /// Post authentication, update this credential's properties.
     ///
     /// To determine if this is required, you can inspect the result of
     /// `authentication_result.needs_update()`. Generally this will always
@@ -373,13 +373,13 @@ impl SecurityKey {
     }
 
     /// Retrieve a reference to the attestation used during this [`Credential`]'s
-    /// registration. This can tell you information about the manufacterer and
+    /// registration. This can tell you information about the manufacturer and
     /// what type of credential it is.
     pub fn attestation(&self) -> &ParsedAttestation {
         &self.cred.attestation
     }
 
-    /// Post authentication, update this credentials properties.
+    /// Post authentication, update this credential's properties.
     ///
     /// To determine if this is required, you can inspect the result of
     /// `authentication_result.needs_update()`. Generally this will always
@@ -500,13 +500,13 @@ impl AttestedResidentKey {
     }
 
     /// Retrieve a reference to the attestation used during this [`Credential`]'s
-    /// registration. This can tell you information about the manufacterer and
+    /// registration. This can tell you information about the manufacturer and
     /// what type of credential it is.
     pub fn attestation(&self) -> &ParsedAttestation {
         &self.cred.attestation
     }
 
-    /// Post authentication, update this credentials properties.
+    /// Post authentication, update this credential'ds properties.
     ///
     /// To determine if this is required, you can inspect the result of
     /// `authentication_result.needs_update()`. Generally this will always

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -253,7 +253,7 @@ impl<'a> WebauthnBuilder<'a> {
     ///
     /// # Safety
     ///
-    /// rp_id is what Credentials (Authenticators) bind themself to - rp_id can NOT be changed
+    /// rp_id is what Credentials (Authenticators) bind themselves to - rp_id can NOT be changed
     /// without breaking all of your users' associated credentials in the future!
     ///
     /// # Examples
@@ -349,7 +349,7 @@ impl<'a> WebauthnBuilder<'a> {
     /// and/or vision impairments. Even a minor skin condition can make it hard
     /// to use a fingerprint reader!
     ///
-    /// Consult the [Webauthn specification's accessibilty considerations][2],
+    /// Consult the [Webauthn specification's accessibility considerations][2],
     /// [WCAG 2.1's "Enough time" guideline][3] and
     /// ["Timeouts" success criterion][4] when choosing a value, particularly if
     /// it is *shorter* than the default.
@@ -433,7 +433,7 @@ impl<'a> WebauthnBuilder<'a> {
 /// > You should use [`start_attested_passkey_registration`](Webauthn::start_attested_passkey_registration)
 ///
 ///
-/// __I want users to have their identites stored on their devices, and for them to authenticate with
+/// __I want users to have their identities stored on their devices, and for them to authenticate with
 /// strong multi-factor cryptographic authentication limited to a known set of trusted authenticator types__
 ///
 /// This authenticator type consumes limited storage space on users' authenticators, and may result in failures or device
@@ -542,7 +542,7 @@ impl Webauthn {
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: Some(CredProtect {
                 // Since this may contain PII, we want to enforce this. We also
-                // want the device to strictly enforce it's UV state.
+                // want the device to strictly enforce its UV state.
                 credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
                 // If set to true, causes many authenticators to shit the bed. We have to just hope
                 // and pray instead. This is because many device classes when they see this extension
@@ -853,7 +853,7 @@ impl Webauthn {
             None
         } else {
             Some(CredProtect {
-                // We want the device to strictly enforce it's UV state.
+                // We want the device to strictly enforce its UV state.
                 credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
                 // If set to true, causes many authenticators to shit the bed. Since this type doesn't
                 // have the same strict rules about attestation, then we just use this opportunistically.
@@ -905,7 +905,7 @@ impl Webauthn {
     }
 
     /// Complete the registration of the credential. The user agent (e.g. a browser) will return the data of `RegisterPublicKeyCredential`,
-    /// and the server provides it's paired [SecurityKeyRegistration]. The details of the Authenticator
+    /// and the server provides its paired [SecurityKeyRegistration]. The details of the Authenticator
     /// based on the registration parameters are asserted.
     ///
     /// # Errors
@@ -920,8 +920,8 @@ impl Webauthn {
     /// to any other account.
     ///
     /// # Verifying specific device models
-    /// If you wish to assert a specifc type of device model is in use, you can inspect the
-    /// SecurityKey `attestation()` and it's associated metadata. You can use this to check for
+    /// If you wish to assert a specific type of device model is in use, you can inspect the
+    /// SecurityKey `attestation()` and its associated metadata. You can use this to check for
     /// specific device aaguids for example.
     ///
     pub fn finish_securitykey_registration(
@@ -1001,17 +1001,17 @@ impl Webauthn {
     ///
     /// As a result, the server *only* requires this attested_passkey key to authenticate the user
     /// and assert their identity. Because of this reliance on the authenticator, attestation of
-    /// the authenticator and it's properties is strongly recommended.
+    /// the authenticator and its properties is strongly recommended.
     ///
     /// The primary difference to a passkey, is that these credentials *can not* 'roam' between multiple
     /// devices, and must be bound to a single authenticator. This precludes the use of certain types
     /// of authenticators (such as Apple's Passkeys as these are always synced).
     ///
     /// Additionally, these credentials must provide an attestation certificate of authenticity
-    /// which will be cryptographically validated to stricly enforce that only certain devices may be used.
+    /// which will be cryptographically validated to strictly enforce that only certain devices may be used.
     ///
     /// You *should* recommend to the user to register multiple attested_passkey keys to their account on
-    /// seperate devices so that they have fall back authentication in the case of device failure or loss.
+    /// separate devices so that they have fall back authentication in the case of device failure or loss.
     ///
     /// You *should* have a workflow that allows a user to register new devices without a need to register
     /// other factors. For example, allow a QR code that can be scanned from a phone, or a one-time
@@ -1069,7 +1069,7 @@ impl Webauthn {
     /// # let webauthn = builder.build()
     /// #     .expect("Invalid configuration");
     /// #
-    /// // you must store this user's unique id with the account. Alternatelly you can
+    /// // you must store this user's unique id with the account. Alternatively you can
     /// // use an existed UUID source.
     /// let user_unique_id = Uuid::new_v4();
     ///
@@ -1133,7 +1133,7 @@ impl Webauthn {
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: Some(CredProtect {
                 // Since this may contain PII, we need to enforce this. We also
-                // want the device to strictly enforce it's UV state.
+                // want the device to strictly enforce its UV state.
                 credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
                 // Set to true since this function requires attestation, and attestation is really
                 // only viable on FIDO2/CTAP2 creds that actually support this.
@@ -1177,7 +1177,7 @@ impl Webauthn {
     }
 
     /// Complete the registration of the credential. The user agent (e.g. a browser) will return the data of `RegisterPublicKeyCredential`,
-    /// and the server provides it's paired [AttestedPasskeyRegistration]. The details of the Authenticator
+    /// and the server provides its paired [AttestedPasskeyRegistration]. The details of the Authenticator
     /// based on the registration parameters are asserted.
     ///
     /// # Errors
@@ -1188,8 +1188,8 @@ impl Webauthn {
     /// authentications via [crate::Webauthn::start_attested_passkey_authentication].
     ///
     /// # Verifying specific device models
-    /// If you wish to assert a specifc type of device model is in use, you can inspect the
-    /// AttestedPasskey `attestation()` and it's associated metadata. You can use this to check for
+    /// If you wish to assert a specific type of device model is in use, you can inspect the
+    /// AttestedPasskey `attestation()` and its associated metadata. You can use this to check for
     /// specific device aaguids for example.
     ///
     pub fn finish_attested_passkey_registration(


### PR DESCRIPTION
These are various spelling fixes, etc. I made while reading comments as I wrote `webauthn-rp-proxy`.  (I used to be a copy editor, and can't help myself.)  I figured I'd pass them along in case they were helpful.

Fixes #

- [x ] cargo test has been run and passes
- [ N/A] documentation has been updated with relevant examples (if relevant)
