### PR TITLE
Resolve compilation warnings in fido-mds-tools

### DIFF
--- a/compat_tester/webauthn-rs-demo/src/actors.rs
+++ b/compat_tester/webauthn-rs-demo/src/actors.rs
@@ -44,9 +44,9 @@ pub enum TypedCredential {
 }
 
 pub struct WebauthnActor {
-    pub rp_name: String,
-    pub rp_id: String,
-    pub rp_origin: Url,
+    // pub rp_name: String,
+    // pub rp_id: String,
+    // pub rp_origin: Url,
     /// Used for testing with compat.
     wan: WebauthnCore,
     /// For demoing the simple cases.
@@ -81,9 +81,9 @@ impl WebauthnActor {
             .expect("Failed to build swan");
 
         WebauthnActor {
-            rp_name,
-            rp_id,
-            rp_origin,
+            // rp_name,
+            // rp_id,
+            // rp_origin,
             wan,
             swan,
             device_cat_strict,

--- a/fido-key-manager/Cargo.toml
+++ b/fido-key-manager/Cargo.toml
@@ -28,6 +28,8 @@ yubikey = ["webauthn-authenticator-rs/vendor-yubikey"]
 
 default = ["nfc", "usb"]
 
+disable_windows_manifest = []
+
 [dependencies]
 webauthn-authenticator-rs = { workspace = true, features = ["ui-cli", "ctap2-management"] }
 

--- a/fido-key-manager/build.rs
+++ b/fido-key-manager/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
-    if !cfg!(disable_windows_manifest) && target_os == "windows" {
+    if !cfg!(feature = "disable_windows_manifest") && target_os == "windows" {
         embed_resource::compile("windows/fido-key-manager.rc", embed_resource::NONE);
     }
 }

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -235,7 +235,7 @@ pub struct EcdaaAnchor {
     pub x: String,
     /// base64url encoding of the result of ECPoint2ToB of the ECPoint2 Y = P_2^yY=P
     /// See FIDOEcdaaAlgorithm for the definition of ECPoint2ToB.
-    #[serde(rename = "X")]
+    #[serde(rename = "Y")]
     pub y: String,
     /// base64url encoding of the result of BigNumberToB(cc). See section "Issuer Specific ECDAA Parameters" in FIDOEcdaaAlgorithm for an explanation of cc. See FIDOEcdaaAlgorithm for the definition of BigNumberToB.
     pub c: String,

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/kanidm/webauthn-rs"
 
 [features]
 nfc_raw_transmit = ["nfc"]
+nfc_allow_ignored_readers = []
 
 # Basic command line `UiCallback` implementation
 ui-cli = ["dep:rpassword"]

--- a/webauthn-authenticator-rs/src/nfc/mod.rs
+++ b/webauthn-authenticator-rs/src/nfc/mod.rs
@@ -133,7 +133,7 @@ fn ignored_reader(reader_name: &CStr) -> bool {
 
     let r = IGNORED_READERS.iter().any(|i| reader_name.contains(i));
 
-    #[cfg(nfc_allow_ignored_readers)]
+    #[cfg(feature = "nfc_allow_ignored_readers")]
     if r {
         warn!("allowing ignored reader: {reader_name:?}");
         return false;

--- a/webauthn-rs-proto/src/wasm.rs
+++ b/webauthn-rs-proto/src/wasm.rs
@@ -7,8 +7,10 @@ extern "C" {
     pub type PublicKeyCredentialExt;
 
     #[wasm_bindgen(static_method_of = PublicKeyCredentialExt, js_class = "PublicKeyCredential", js_name = isConditionalMediationAvailable, catch)]
+    /// Is Conditional Mediation Available
     pub fn is_conditional_mediation_available() -> Result<::js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(static_method_of = PublicKeyCredentialExt, js_class = "PublicKeyCredential", js_name = isExternalCTAP2SecurityKeySupported, catch)]
+    /// Is External Ctap2 SecurityKey Supported
     pub fn is_external_ctap2_securitykey_supported() -> Result<::js_sys::Promise, JsValue>;
 }


### PR DESCRIPTION
A number of warnings were emitted by newer versions of rust that were preventing successful build of a number of tools. This PR resolves those warnings. 

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
