### PR TITLE
Update MDS to support undocumented FIDO additions

### DIFF
--- a/fido-mds/src/lib.rs
+++ b/fido-mds/src/lib.rs
@@ -1126,7 +1126,7 @@ impl TryFrom<RawFidoDevice> for FidoDevice {
             mut authenticator_get_info,
         } = metadata_statement;
 
-        let status_reports: BTreeSet<_> = status_reports
+        let mut status_reports: BTreeSet<_> = status_reports
             .into_iter()
             .filter_map(|sr| {
                 sr.try_into()
@@ -1140,6 +1140,10 @@ impl TryFrom<RawFidoDevice> for FidoDevice {
                     .ok()
             })
             .collect();
+
+        if let Some(status_report) = patch::mds_deny_insecure_authenticators(aaguid) {
+            status_reports.insert(status_report);
+        }
 
         let attestation_root_certificates = attestation_root_certificates.into_iter()
             .filter_map(|cert| {

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -103,6 +103,7 @@ pub struct BiometricAccuracyDescriptor {
     /// in related biometricStatusReport as specified in FIDOMetadataService).
     #[serde(rename = "selfAttestedFAR")]
     pub self_attested_far: Option<f32>,
+
     /// Maximum number of alternative templates from different fingers allowed (for other modalities,
     /// multiple parts of the body that can be used interchangeably), e.g. 3 if the user is allowed
     /// to enroll up to 3 different fingers to a fingerprint based authenticator.
@@ -115,6 +116,10 @@ pub struct BiometricAccuracyDescriptor {
     /// until an alternative user verification method succeeded. All alternative user verification
     /// methods must be specified appropriately in the metadata in userVerificationDetails.
     pub block_slowdown: Option<u16>,
+
+    /// ⚠️  WARNING - CONTENT AND USE OF THIS VALUE IS NOT DOCUMENTED BY FIDO
+    #[serde(rename = "iAPARThreshold")]
+    pub iapar_threshold: Option<serde_json::Value>,
 }
 
 impl Hash for BiometricAccuracyDescriptor {
@@ -319,6 +324,9 @@ pub enum AuthenticationAlgorithm {
     /// secp384r1_ecdsa_sha384_raw
     #[serde(rename = "secp384r1_ecdsa_sha384_raw")]
     Secp384r1EcdsaSha384Raw,
+    /// secp521r1_ecdsa_sha512_raw
+    #[serde(rename = "secp521r1_ecdsa_sha512_raw")]
+    Secp521r1EcdsaSha512Raw,
     /// rsassa_pkcsv15_sha256_raw
     #[serde(rename = "rsassa_pkcsv15_sha256_raw")]
     RsassaPkcsv15Sha256Raw,
@@ -345,6 +353,9 @@ impl fmt::Display for AuthenticationAlgorithm {
             AuthenticationAlgorithm::Ed25519EddsaSha512Raw => write!(f, "ed25519_eddsa_sha512_raw"),
             AuthenticationAlgorithm::Secp384r1EcdsaSha384Raw => {
                 write!(f, "secp384r1_ecdsa_sha384_raw")
+            }
+            AuthenticationAlgorithm::Secp521r1EcdsaSha512Raw => {
+                write!(f, "secp521r1_ecdsa_sha512_raw")
             }
             AuthenticationAlgorithm::RsassaPkcsv15Sha256Raw => {
                 write!(f, "rsassa_pkcsv15_sha256_raw")
@@ -991,6 +1002,9 @@ pub struct StatusReport {
     /// The Document Version of the Authenticator Security Requirements (DV)
     /// FIDOAuthenticatorSecurityRequirements the implementation is certified to, e.g. "1.2.0".
     pub certification_requirements_version: Option<String>,
+
+    /// ⚠️  WARNING - CONTENT AND USE OF THIS VALUE IS NOT DOCUMENTED BY FIDO
+    certification_profiles: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/fido-mds/src/patch.rs
+++ b/fido-mds/src/patch.rs
@@ -1,7 +1,7 @@
 use crate::mds::{
     UserVerificationMethod as RawUserVerificationMethod, VerificationMethodAndCombinations,
 };
-use crate::UserVerificationMethod;
+use crate::{StatusReport, UserVerificationMethod};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
@@ -25,6 +25,8 @@ const VERIMARK_GUARD_FINGERPRINT_HASH: u64 = 3483018605;
 
 const AUTHENTON1: Uuid = uuid::uuid!("b267239b-954f-4041-a01b-ee4f33c145b6");
 const AUTHENTON1_HASH: u64 = 1117557365;
+
+const NITROKEY_3_AM: Uuid = uuid::uuid!("2cd2f727-f6ca-44da-8f48-5c2e5da000a2");
 
 pub(crate) fn mds_user_verification_method_code_accuracy_descriptor(
     uvm: &mut [Vec<VerificationMethodAndCombinations>],
@@ -150,6 +152,19 @@ pub(crate) fn user_verification_method(
             }
         }
         None => Ok(None),
+    }
+}
+
+/// Deny authenticators that have publicly known security vulnerabilities, that FIDO
+/// has not yet acknowledged.
+pub(crate) fn mds_deny_insecure_authenticators(aaguid: Option<Uuid>) -> Option<StatusReport> {
+    match aaguid {
+        Some(NITROKEY_3_AM) => Some(StatusReport::UserKeyRemoteCompromise {
+            effective_date: None,
+            authenticator_version: 0,
+            url: None,
+        }),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
This updates the MDS to support undocumented FIDO elements that were added without documentation in the relevant specifications.

This also updates the mds tool to support filtering of compromised devices that FIDO haven't acted on.

Fixes #451 Fixes #450 Fixes #449

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
