### PR TITLE
Upgrade hyper/http, use new APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,13 @@ compact_jwt = "0.4.2"
 futures = "^0.3.25"
 hex = "0.4.3"
 http = "^0.2.9"
-http-body = "=1.0.0-rc.2"
-http-body-util = "=0.1.0-rc.2"
-hyper = { version = "=1.0.0-rc.3", default-features = false, features = [
+http-body = "1.0.1"
+http-body-util = "0.1.2"
+hyper = { version = "1.5.1", default-features = false, features = [
     "http1",
+] }
+hyper-util = { version = "0.1.10", features = [
+    "tokio",
 ] }
 nom = "7.1"
 peg = "0.8.1"
@@ -100,14 +103,14 @@ tokio = { version = "1.22.0", features = [
 ] }
 tokio-native-tls = "^0.3.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-tungstenite = { version = "^0.18.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "^0.24.0", features = ["native-tls"] }
 tracing = "^0.1.35"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
     "std",
     "fmt",
 ] }
-tungstenite = { version = "^0.18.0", default-features = false, features = [
+tungstenite = { version = "^0.24.0", default-features = false, features = [
     "handshake",
 ] }
 url = "2"

--- a/cable-tunnel-server/backend/Cargo.toml
+++ b/cable-tunnel-server/backend/Cargo.toml
@@ -20,6 +20,7 @@ hex.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["server"] }
+hyper-util.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-native-tls.workspace = true

--- a/cable-tunnel-server/common/Cargo.toml
+++ b/cable-tunnel-server/common/Cargo.toml
@@ -16,6 +16,7 @@ hex.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["server"] }
+hyper-util.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-native-tls.workspace = true

--- a/cable-tunnel-server/common/src/lib.rs
+++ b/cable-tunnel-server/common/src/lib.rs
@@ -322,10 +322,10 @@ pub async fn run_server<F, R, ResBody, T>(
     bind_address: SocketAddr,
     tls_acceptor: Option<TlsAcceptor>,
     server_state: T,
-    mut request_handler: F,
+    request_handler: F,
 ) -> Result<(), Box<dyn StdError>>
 where
-    F: FnMut(Arc<T>, SocketAddr, Request<Incoming>) -> R + Copy + Send + Sync + 'static,
+    F: Fn(Arc<T>, SocketAddr, Request<Incoming>) -> R + Copy + Send + Sync + 'static,
     R: Future<Output = Result<Response<ResBody>, Infallible>> + Send,
     ResBody: Body + Send + 'static,
     <ResBody as Body>::Error: Into<Box<dyn StdError + Send + Sync>>,
@@ -362,6 +362,7 @@ where
                         }
                     },
                 };
+                let stream = hyper_util::rt::tokio::TokioIo::new(stream);
 
                 let conn =
                     hyper::server::conn::http1::Builder::new().serve_connection(stream, service);

--- a/cable-tunnel-server/frontend/Cargo.toml
+++ b/cable-tunnel-server/frontend/Cargo.toml
@@ -18,6 +18,7 @@ clap.workspace = true
 hex.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["client", "server"] }
+hyper-util.workspace = true
 tokio.workspace = true
 tokio-native-tls.workspace = true
 tokio-tungstenite.workspace = true


### PR DESCRIPTION
**Note:** it compiles, but I need to test with physical hardware.

Upgrades `http`, `http-body-util` and `hyper` to current versions.

`hyper` switched from using Tokio traits to their own custom traits [a while ago](https://github.com/hyperium/hyper/issues/3110), but have an adapter to Tokio traits (`hyper-util`). So this switches everything to use the adapter.


Related to #444 

- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
