### PR TITLE
Bump MSRV to 1.81 to match home@0.5.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [ stable, 1.79.0 ]
+        rust_version: [ stable, 1.81.0 ]
         os:
           - ubuntu-latest
           - windows-latest
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [ stable, 1.79.0 ]
+        rust_version: [ stable, 1.81.0 ]
         features:
           - bluetooth
           - cable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "William Brown <william@blackhats.net.au>",
     "Michael Farrell <micolous+git@gmail.com>"
 ]
-rust-version = "1.79"
+rust-version = "1.81"
 edition = "2021"
 repository = "https://github.com/kanidm/webauthn-rs"
 homepage = "https://github.com/kanidm/webauthn-rs"


### PR DESCRIPTION
`fido-hid-rs` has a transitive build dependency on `home`:

```
% cargo tree -i home
home v0.5.9
└── which v4.4.2
    └── bindgen v0.65.1
        [build-dependencies]
        └── fido-hid-rs v0.5.0
```

This now [fails in CI on `rustc` 1.79](https://github.com/kanidm/webauthn-rs/actions/runs/12387201838/job/34576258939#step:8:407), which pulls in `home@0.5.11`:

```
error: rustc 1.79.0 is not supported by the following package:
  home@0.5.11 requires rustc 1.81
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.79.0
```

MSRV has been bumped by point releases in https://github.com/rust-lang/cargo/pull/14867 and https://github.com/rust-lang/cargo/pull/14871

`home@0.5.9` is the last version to support `rustc` 1.79.

This would probably also be fixed by [an MSRV-aware resolver](https://github.com/rust-lang/cargo/issues/13873).

FWIW `home` is "[not intended for external use](https://github.com/rust-lang/cargo/blob/99dff6d77db779716dda9ca3b29c26addd02c1be/crates/home/README.md)" .. and should use [something like `env-home`](https://github.com/notpeter/env-home): https://github.com/harryfei/which-rs/issues/104





- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
