### PR TITLE
fix axum tutorial in makefile

### DIFF
--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -13,7 +13,7 @@ actix: wasm
 
 axum: ## Build and run the axum server
 axum:
-	cd server/axum && ./build_wasm.sh && cargo run
+	cd server/axum && cargo run
 
 
 tide: ## Build and run the tide server


### PR DESCRIPTION
Fixes #469

Remove the wasm build from the axum tutorial, as it defaults to the js display anyway. 

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
