### PR TITLE
patched fido-mds to fix 'unknown variant wireless' error

### DIFF
--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -504,6 +504,9 @@ pub enum AuthenticatorTransport {
     /// usb
     #[serde(rename = "usb")]
     Usb,
+    /// wireless
+    #[serde(rename = "wireless")]
+    Wireless,
     /// nfc
     #[serde(rename = "nfc")]
     Nfc,
@@ -522,6 +525,7 @@ impl fmt::Display for AuthenticatorTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AuthenticatorTransport::Usb => write!(f, "usb"),
+            AuthenticatorTransport::Wireless => write!(f, "wireless"),
             AuthenticatorTransport::Nfc => write!(f, "nfc"),
             AuthenticatorTransport::Lightning => write!(f, "lightning"),
             AuthenticatorTransport::Ble => write!(f, "ble"),
@@ -536,6 +540,7 @@ impl FromStr for AuthenticatorTransport {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "usb" => Ok(AuthenticatorTransport::Usb),
+            "wireless" => Ok(AuthenticatorTransport::Wireless),
             "nfc" => Ok(AuthenticatorTransport::Nfc),
             "lightning" => Ok(AuthenticatorTransport::Lightning),
             "ble" => Ok(AuthenticatorTransport::Ble),


### PR DESCRIPTION
This patch was just made to suppress the following error. I dont know if it has any serious implications, but it worked for me.:
```bash
serde_err=Error("unknown variant `wireless`, expected one of `usb`, `nfc`, `lightning`, `ble`, `internal`", line: 1, column: 14303)
```
When running:
```bash
./fido-mds-tool query --output-cert-roots "desc cnt yubikey"
./fido-mds-tool list-u2f
./fido-mds-tool list-fido2
```
On a freshly updated Arch Linux, and compiled using both 'stable-x86_64-unknown-linux-gnu' 'nightly-2025-02-16-x86_64-unknown-linux-gnu' toolchains from rust-up.

Error was encountered while following [this guide.](https://kanidm.github.io/kanidm/stable/accounts/account_policy.html)
- [?] cargo test has been run and passes

I received the following errors running "cargo test". I don't think that they are related to my patch, but I could be wrong.

```bash
2025-02-17T07:42:17.221766Z ERROR sshkey_attest: ed25519 or ed448 public keys are not supported
2025-02-17T07:42:17.221922Z ERROR sshkey_attest: aaguid not trusted by this CA aaguid=cb69481e-8ff7-4039-93ec-0a2729a154a8
2025-02-17T07:42:17.227172Z ERROR webauthn_authenticator_rs::nfc: could not convert "\xff\xff" to UTF-8: Utf8Error { valid_up_to: 0, error_len: Some(1) }
2025-02-17T07:42:17.227207Z ERROR webauthn_authenticator_rs::nfc: could not convert "\xffYubico YubiKey FIDO+CCID\xff" to UTF-8: Utf8Error { valid_up_to: 0, error_len: Some(1) }
2025-02-17T07:42:24.335063Z ERROR webauthn_rs_core::core: Authenticator ignored requested algorithm set - ES256 - [RS256, EDDSA, INSECURE_RS1]
```
