### PR TITLE
authenticator/usb: detect wink capability

### DIFF
--- a/webauthn-authenticator-rs/src/usb/mod.rs
+++ b/webauthn-authenticator-rs/src/usb/mod.rs
@@ -54,6 +54,7 @@ pub struct USBToken {
     cid: u32,
     supports_ctap1: bool,
     supports_ctap2: bool,
+    supports_wink: bool,
     initialised: bool,
 }
 
@@ -69,6 +70,7 @@ impl fmt::Debug for USBToken {
             .field("cid", &self.cid)
             .field("supports_ctap1", &self.supports_ctap1)
             .field("supports_ctap2", &self.supports_ctap2)
+            .field("supports_wink", &self.supports_wink)
             .field("initialised", &self.initialised)
             .finish()
     }
@@ -152,6 +154,7 @@ impl USBToken {
             cid: 0,
             supports_ctap1: false,
             supports_ctap2: false,
+            supports_wink: false,
             initialised: false,
         }
     }
@@ -288,6 +291,7 @@ impl Token for USBToken {
                 self.cid = i.cid;
                 self.supports_ctap1 = i.supports_ctap1();
                 self.supports_ctap2 = i.supports_ctap2();
+                self.supports_wink = i.supports_wink();
 
                 if self.supports_ctap2 {
                     self.initialised = true;

--- a/webauthn-authenticator-rs/src/usb/responses.rs
+++ b/webauthn-authenticator-rs/src/usb/responses.rs
@@ -11,6 +11,7 @@ use crate::transport::{
 use crate::usb::framing::U2FHIDFrame;
 use crate::usb::*;
 
+const CAPABILITY_WINK: u8 = 0x01;
 const CAPABILITY_CBOR: u8 = 0x04;
 const CAPABILITY_NMSG: u8 = 0x08;
 
@@ -29,14 +30,19 @@ pub struct InitResponse {
 }
 
 impl InitResponse {
-    /// `true` if the device suports CTAPv1 / U2F protocol
+    /// `true` if the device supports CTAPv1 / U2F protocol.
     pub fn supports_ctap1(&self) -> bool {
         self.capabilities & CAPABILITY_NMSG == 0
     }
 
-    /// `true` if the device suports CTAPv2 / CBOR protocol
+    /// `true` if the device supports CTAPv2 / CBOR protocol.
     pub fn supports_ctap2(&self) -> bool {
         self.capabilities & CAPABILITY_CBOR > 0
+    }
+
+    /// `true` if the device supports wink function.
+    pub fn supports_wink(&self) -> bool {
+        self.capabilities & CAPABILITY_WINK > 0
     }
 }
 
@@ -169,6 +175,7 @@ mod tests {
         if let Response::Init(r) = r {
             assert!(r.supports_ctap1());
             assert!(r.supports_ctap2());
+            assert!(r.supports_wink());
         } else {
             panic!("bad response");
         }
@@ -201,6 +208,7 @@ mod tests {
         if let Response::Init(r) = r {
             assert!(!r.supports_ctap1());
             assert!(r.supports_ctap2());
+            assert!(r.supports_wink());
         } else {
             panic!("bad response");
         }
@@ -227,6 +235,7 @@ mod tests {
         if let Response::Init(r) = r {
             assert!(r.supports_ctap1());
             assert!(!r.supports_ctap2());
+            assert!(!r.supports_wink());
         } else {
             panic!("bad response");
         }


### PR DESCRIPTION
This adds USB-HID logic for detecting `CTAPHID_WINK` support.

Ref: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-init

---

- [x] cargo test has been run and passes
- [ ] ~~documentation has been updated with relevant examples (if relevant)~~
