### PR TITLE
Bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       # Don't run clippy on Windows, we only need to run it on Linux
       - if: runner.os != 'windows'
         run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server --all-targets
+      - name: javascript feature clippy
+        if: runner.os != 'windows'
+        run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server --all-targets --features javascript,bluetooth,nfc,usb
+      - name: WASM feature clippy
+        if: runner.os != 'windows'
+        run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server --all-targets --features wasm,bluetooth,nfc,usb --no-default-features
 
       - run: cargo test --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ tracing-subscriber = { version = "0.3", features = [
     "std",
     "fmt",
 ] }
-tracing-log = { version = "0.2.0" }
 tungstenite = { version = "^0.24.0", default-features = false, features = [
     "handshake",
 ] }

--- a/authenticator-cli/Cargo.toml
+++ b/authenticator-cli/Cargo.toml
@@ -13,9 +13,10 @@ repository = { workspace = true }
 
 [dependencies]
 
-authenticator = { version = "0.3.2-dev.1", default-features = false, features = ["crypto_openssl"], package = "authenticator-ctap2-2021" }
+authenticator = { version = "0.3.2-dev.1", default-features = false, features = [
+    "crypto_openssl",
+], package = "authenticator-ctap2-2021" }
 clap.workspace = true
 
 tracing.workspace = true
 tracing-subscriber.workspace = true
-tracing-log.workspace = true

--- a/authenticator-cli/src/main.rs
+++ b/authenticator-cli/src/main.rs
@@ -7,7 +7,8 @@ use authenticator::{
 };
 use std::sync::mpsc::{channel, RecvError};
 use std::thread;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, level_filters::LevelFilter, trace};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Subcommand)]
 #[clap(about = "Authenticator Utility")]
@@ -16,8 +17,16 @@ enum Opt {
 }
 
 fn main() {
-    tracing_subscriber::fmt::init();
-    tracing_log::LogTracer::init().expect("Failed to create tracing log bridge");
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .compact()
+        .init();
+
+    info!("Starting...");
 
     let timeout_ms = 25000;
 

--- a/base64urlsafedata/Cargo.toml
+++ b/base64urlsafedata/Cargo.toml
@@ -18,7 +18,7 @@ repository = { workspace = true }
 [dependencies]
 serde.workspace = true
 base64.workspace = true
-paste = "1.0.14"
+pastey = "0.1.0"
 
 [dev-dependencies]
 serde_cbor_2.workspace = true

--- a/base64urlsafedata/src/lib.rs
+++ b/base64urlsafedata/src/lib.rs
@@ -84,7 +84,7 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate paste;
+extern crate pastey;
 
 #[macro_use]
 mod common;

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -19,7 +19,6 @@ use nix::{
     poll::{ppoll, PollFd, PollFlags},
     sys::signalfd::SigSet,
 };
-use num_traits::FromPrimitive;
 use tokio::{sync::mpsc, task::spawn_blocking};
 use tokio_stream::wrappers::ReceiverStream;
 use udev::{Device, Enumerator, EventType, MonitorBuilder};

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -200,7 +200,7 @@ impl USBDeviceInfoImpl {
         }
 
         // Drop unknown or non-USB BusTypes
-        let bustype = BusType::try_from(info.bustype);
+        let bustype = BusType::try_from(info.bustype)?;
         if bustype != BusType::Usb {
             // trace!(
             //     "{path:?} is not USB HID: {bustype:?} (0x{:x})",

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -196,11 +196,11 @@ impl USBDeviceInfoImpl {
 
         let mut info = hidraw_devinfo::default();
         unsafe {
-            hid_ioc_raw_info(fd.as_raw_fd(), &mut info)?;
+            hid_ioc_raw_info(fd.as_raw_fd(), &mut info).ok()?;
         }
 
         // Drop unknown or non-USB BusTypes
-        let bustype = BusType::try_from(info.bustype)?;
+        let bustype = BusType::try_from(info.bustype).ok()?;
         if bustype != BusType::Usb {
             // trace!(
             //     "{path:?} is not USB HID: {bustype:?} (0x{:x})",

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -196,7 +196,7 @@ impl USBDeviceInfoImpl {
 
         let mut info = hidraw_devinfo::default();
         unsafe {
-            hid_ioc_raw_info(fd.as_raw_fd(), &mut info).ok()?;
+            hid_ioc_raw_info(fd.as_raw_fd(), &mut info)?;
         }
 
         // Drop unknown or non-USB BusTypes

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -200,8 +200,8 @@ impl USBDeviceInfoImpl {
         }
 
         // Drop unknown or non-USB BusTypes
-        let bustype = BusType::from(info.bustype);
-        if bustype != Some(BusType::Usb) {
+        let bustype = BusType::try_from(info.bustype).ok()?;
+        if bustype != BusType::Usb {
             // trace!(
             //     "{path:?} is not USB HID: {bustype:?} (0x{:x})",
             //     info.bustype

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -200,7 +200,7 @@ impl USBDeviceInfoImpl {
         }
 
         // Drop unknown or non-USB BusTypes
-        let bustype = BusType::try_from(info.bustype).ok()?;
+        let bustype = BusType::try_from(info.bustype);
         if bustype != BusType::Usb {
             // trace!(
             //     "{path:?} is not USB HID: {bustype:?} (0x{:x})",

--- a/fido-hid-rs/src/linux/mod.rs
+++ b/fido-hid-rs/src/linux/mod.rs
@@ -200,7 +200,7 @@ impl USBDeviceInfoImpl {
         }
 
         // Drop unknown or non-USB BusTypes
-        let bustype = BusType::from_u32(info.bustype);
+        let bustype = BusType::from(info.bustype);
         if bustype != Some(BusType::Usb) {
             // trace!(
             //     "{path:?} is not USB HID: {bustype:?} (0x{:x})",

--- a/fido-hid-rs/src/linux/wrapper.rs
+++ b/fido-hid-rs/src/linux/wrapper.rs
@@ -5,7 +5,6 @@
 include!(concat!(env!("OUT_DIR"), "/linux_wrapper.rs"));
 
 use nix::ioctl_read;
-use num_derive::FromPrimitive;
 
 // The userspace API is lies: https://bugzilla.kernel.org/show_bug.cgi?id=217463
 ioctl_read!(hid_ioc_rd_desc_size, b'H', 0x01, u32);
@@ -19,7 +18,7 @@ impl hidraw_report_descriptor {
 }
 
 /// Linux input bus type.
-#[derive(Debug, FromPrimitive, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum BusType {
     Usb = BUS_USB,

--- a/fido-hid-rs/src/linux/wrapper.rs
+++ b/fido-hid-rs/src/linux/wrapper.rs
@@ -26,13 +26,13 @@ pub enum BusType {
     Virtual = BUS_VIRTUAL,
 }
 
-impl From<u32> for BusType {
-    fn from(value: u32) -> Self {
+impl BusType {
+    fn from_u32(value: u32) -> Option<Self> {
         match value {
-            BUS_USB => BusType::Usb,
-            BUS_BLUETOOTH => BusType::Bluetooth,
-            BUS_VIRTUAL => BusType::Virtual,
-            _ => BusType::Virtual,
+            BUS_USB => Some(BusType::Usb),
+            BUS_BLUETOOTH => Some(BusType::Bluetooth),
+            BUS_VIRTUAL => Some(BusType::Virtual),
+            _ => None,
         }
     }
 }

--- a/fido-hid-rs/src/linux/wrapper.rs
+++ b/fido-hid-rs/src/linux/wrapper.rs
@@ -36,3 +36,14 @@ impl BusType {
         }
     }
 }
+
+impl TryFrom<u32> for BusType {
+    type Error = u32;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match BusType::from_u32(value) {
+            Some(bus_type) => Ok(bus_type),
+            None => Err(value),
+        }
+    }
+}

--- a/fido-hid-rs/src/linux/wrapper.rs
+++ b/fido-hid-rs/src/linux/wrapper.rs
@@ -25,3 +25,14 @@ pub enum BusType {
     Bluetooth = BUS_BLUETOOTH,
     Virtual = BUS_VIRTUAL,
 }
+
+impl From<u32> for BusType {
+    fn from(value: u32) -> Self {
+        match value {
+            BUS_USB => BusType::Usb,
+            BUS_BLUETOOTH => BusType::Bluetooth,
+            BUS_VIRTUAL => BusType::Virtual,
+            _ => BusType::Virtual,
+        }
+    }
+}

--- a/tutorial/server/actix_web/Cargo.toml
+++ b/tutorial/server/actix_web/Cargo.toml
@@ -32,7 +32,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 tracing.workspace = true
 tracing-subscriber.workspace = true
-tracing-log.workspace = true
 
 # Webauthn framework
-webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"] }
+webauthn-rs = { workspace = true, features = [
+    "danger-allow-state-serialisation",
+] }

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -52,7 +52,7 @@ impl DerivedValueType {
     }
 
     pub fn derive(&self, ikm: &[u8], salt: &[u8], output: &mut [u8]) -> Result<(), WebauthnCError> {
-        hkdf_sha_256(salt, ikm, Some(&self.to_u32().to_le_bytes()), output)
+        hkdf_sha_256(salt, ikm, Some(self.to_u32().to_le_bytes()), output)
     }
 }
 

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -40,8 +40,19 @@ enum DerivedValueType {
 }
 
 impl DerivedValueType {
+    fn to_u32(self) -> u32 {
+        match self {
+            Self::EIDKey => 1,
+            Self::TunnelID => 2,
+            Self::Psk => 3,
+            Self::PairedSecret => 4,
+            Self::IdentityKeySeed => 5,
+            Self::PerContactIDSecret => 6,
+        }
+    }
+
     pub fn derive(&self, ikm: &[u8], salt: &[u8], output: &mut [u8]) -> Result<(), WebauthnCError> {
-        let typ = (self as u32).to_le_bytes();
+        let typ = self.to_u32().ok_or(WebauthnCError::Internal)?.to_le_bytes();
         hkdf_sha_256(salt, ikm, Some(&typ), output)
     }
 }

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -52,7 +52,7 @@ impl DerivedValueType {
     }
 
     pub fn derive(&self, ikm: &[u8], salt: &[u8], output: &mut [u8]) -> Result<(), WebauthnCError> {
-        hkdf_sha_256(salt, ikm, Some(self.to_u32().to_le_bytes()), output)
+        hkdf_sha_256(salt, ikm, Some(&self.to_u32().to_le_bytes()), output)
     }
 }
 

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -41,7 +41,7 @@ enum DerivedValueType {
 
 impl DerivedValueType {
     pub fn derive(&self, ikm: &[u8], salt: &[u8], output: &mut [u8]) -> Result<(), WebauthnCError> {
-        let typ = self.to_u32().ok_or(WebauthnCError::Internal)?.to_le_bytes();
+        let typ = (self as u32).to_le_bytes();
         hkdf_sha_256(salt, ikm, Some(&typ), output)
     }
 }

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -40,7 +40,7 @@ enum DerivedValueType {
 }
 
 impl DerivedValueType {
-    fn to_u32(self) -> u32 {
+    fn to_u32(&self) -> u32 {
         match self {
             Self::EIDKey => 1,
             Self::TunnelID => 2,

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -2,7 +2,6 @@
 #[cfg(doc)]
 use crate::stubs::*;
 
-use num_traits::ToPrimitive;
 use openssl::{
     ec::EcKey,
     hash::MessageDigest,
@@ -29,7 +28,7 @@ type TunnelId = [u8; 16];
 
 // const BASE64URL: base64::Config = base64::Config::new(base64::CharacterSet::UrlSafe, false);
 
-#[derive(FromPrimitive, ToPrimitive, Debug, PartialEq, Eq)]
+#[derive(FromPrimitive, Debug, PartialEq, Eq)]
 #[repr(u32)]
 enum DerivedValueType {
     EIDKey = 1,

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -28,7 +28,7 @@ type TunnelId = [u8; 16];
 
 // const BASE64URL: base64::Config = base64::Config::new(base64::CharacterSet::UrlSafe, false);
 
-#[derive(FromPrimitive, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(u32)]
 enum DerivedValueType {
     EIDKey = 1,

--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -52,8 +52,7 @@ impl DerivedValueType {
     }
 
     pub fn derive(&self, ikm: &[u8], salt: &[u8], output: &mut [u8]) -> Result<(), WebauthnCError> {
-        let typ = self.to_u32().ok_or(WebauthnCError::Internal)?.to_le_bytes();
-        hkdf_sha_256(salt, ikm, Some(&typ), output)
+        hkdf_sha_256(salt, ikm, Some(&self.to_u32().to_le_bytes()), output)
     }
 }
 

--- a/webauthn-authenticator-rs/src/ctap2/ctap21_bio.rs
+++ b/webauthn-authenticator-rs/src/ctap2/ctap21_bio.rs
@@ -262,7 +262,7 @@ where
 
         // Normalise into Normal Form C
         let friendly_name = friendly_name.nfc().collect::<String>();
-        if friendly_name.as_bytes().len() > r.get_max_template_friendly_name() {
+        if friendly_name.len() > r.get_max_template_friendly_name() {
             return Err(WebauthnCError::FriendlyNameTooLong);
         }
 

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -100,8 +100,6 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate num_derive;
-#[macro_use]
 extern crate tracing;
 
 use crate::error::WebauthnCError;

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -84,6 +84,29 @@ enum ConfigKey {
     EnabledNfcInterfaces = 0xe,
 }
 
+impl ConfigKey {
+    fn from_u16(tag: u16) -> Option<Self> {
+        match tag {
+            0x0 => Some(ConfigKey::Unknown),
+            0x1 => Some(ConfigKey::SupportedUsbInterfaces),
+            0x2 => Some(ConfigKey::Serial),
+            0x3 => Some(ConfigKey::EnabledUsbInterfaces),
+            0x4 => Some(ConfigKey::FormFactor),
+            0x5 => Some(ConfigKey::Version),
+            0x6 => Some(ConfigKey::AutoEjectTimeout),
+            0x7 => Some(ConfigKey::ChallengeResponseTimeout),
+            0x8 => Some(ConfigKey::DeviceFlags),
+            0x9 => Some(ConfigKey::AppVersions),
+            0xa => Some(ConfigKey::ConfigLock),
+            0xb => Some(ConfigKey::Unlock),
+            0xc => Some(ConfigKey::Reboot),
+            0xd => Some(ConfigKey::SupportedNfcInterfaces),
+            0xe => Some(ConfigKey::EnabledNfcInterfaces),
+            _ => None,
+        }
+    }
+}
+
 /// YubiKey device form factor.
 ///
 /// Only the lower 3 bits of the `u8` are used.

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -62,7 +62,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive)]
 #[repr(u16)]
 enum ConfigKey {
     #[default]
@@ -88,8 +88,7 @@ enum ConfigKey {
 /// YubiKey device form factor.
 ///
 /// Only the lower 3 bits of the `u8` are used.
-#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive, ToPrimitive)]
-#[repr(u8)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive)]
 pub enum FormFactor {
     #[default]
     Unknown = 0x0,

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -130,6 +130,24 @@ pub enum FormFactor {
     UsbCBio = 0x7,
 }
 
+impl TryFrom<u8> for FormFactor {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value & 0x7 {
+            0x0 => Ok(FormFactor::Unknown),
+            0x1 => Ok(FormFactor::UsbAKeychain),
+            0x2 => Ok(FormFactor::UsbANano),
+            0x3 => Ok(FormFactor::UsbCKeychain),
+            0x4 => Ok(FormFactor::UsbCNano),
+            0x5 => Ok(FormFactor::UsbCLightning),
+            0x6 => Ok(FormFactor::UsbABio),
+            0x7 => Ok(FormFactor::UsbCBio),
+            _ => Err(()),
+        }
+    }
+}
+
 /// YubiKey device info / configuration structure
 ///
 /// ## Payload format
@@ -231,7 +249,7 @@ impl YubiKeyConfig {
                     if val.is_empty() {
                         continue;
                     }
-                    if let Some(f) = FormFactor::from_u8(val[0] & 0x7) {
+                    if let Some(f) = FormFactor::try_from(val[0] & 0x7).ok() {
                         o.form_factor = f;
                     }
                     o.is_fips = val[0] & 0x80 != 0;

--- a/webauthn-authenticator-rs/src/transport/yubikey.rs
+++ b/webauthn-authenticator-rs/src/transport/yubikey.rs
@@ -35,7 +35,6 @@
 //! [0]: https://github.com/Yubico/yubikey-manager/blob/51a7ae438c923189788a1e31d3de18d452131942/yubikit/management.py#L223
 use async_trait::async_trait;
 use bitflags::bitflags;
-use num_traits::cast::FromPrimitive;
 
 use crate::{prelude::WebauthnCError, tlv::ber::BerTlvParser};
 
@@ -62,7 +61,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[repr(u16)]
 enum ConfigKey {
     #[default]
@@ -88,7 +87,7 @@ enum ConfigKey {
 /// YubiKey device form factor.
 ///
 /// Only the lower 3 bits of the `u8` are used.
-#[derive(Debug, Clone, PartialEq, Eq, Default, FromPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum FormFactor {
     #[default]
     Unknown = 0x0,

--- a/webauthn-authenticator-rs/src/types.rs
+++ b/webauthn-authenticator-rs/src/types.rs
@@ -49,7 +49,7 @@ pub enum CableState {
 }
 
 // lastEnrollSampleStatus
-#[derive(FromPrimitive, ToPrimitive, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EnrollSampleStatus {
     Good = 0x00,
@@ -67,4 +67,29 @@ pub enum EnrollSampleStatus {
     // 0x0c unused
     NoUserActivity = 0x0d,
     NoUserPresenceTransition = 0x0e,
+}
+
+impl TryFrom<u32> for EnrollSampleStatus {
+    type Error = u32;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(EnrollSampleStatus::Good),
+            0x01 => Ok(EnrollSampleStatus::TooHigh),
+            0x02 => Ok(EnrollSampleStatus::TooLow),
+            0x03 => Ok(EnrollSampleStatus::TooLeft),
+            0x04 => Ok(EnrollSampleStatus::TooRight),
+            0x05 => Ok(EnrollSampleStatus::TooFast),
+            0x06 => Ok(EnrollSampleStatus::TooSlow),
+            0x07 => Ok(EnrollSampleStatus::PoorQuality),
+            0x08 => Ok(EnrollSampleStatus::TooSkewed),
+            0x09 => Ok(EnrollSampleStatus::TooShort),
+            0x0a => Ok(EnrollSampleStatus::MergeFailure),
+            0x0b => Ok(EnrollSampleStatus::AlreadyExists),
+            // 0x0c unused
+            0x0d => Ok(EnrollSampleStatus::NoUserActivity),
+            0x0e => Ok(EnrollSampleStatus::NoUserPresenceTransition),
+            _ => Err(value),
+        }
+    }
 }

--- a/webauthn-rp-proxy/tests/integration_test.rs
+++ b/webauthn-rp-proxy/tests/integration_test.rs
@@ -16,7 +16,7 @@ mod tests {
             .expect("failed to execute process");
 
         Ok(serde_json::from_str(
-            &String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stdout).as_ref(),
         )?)
     }
 

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -28,7 +28,6 @@ base64urlsafedata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 url = { workspace = true, features = ["serde"] }
-# num_enum = "0.5"
 
 # Webauthn Components
 wasm-bindgen = { version = "0.2", features = [


### PR DESCRIPTION
- Fixes some compile warnings that've been coming up for a while.
- Fixes: #480
- Fixes: authenticator-cli was crashing on startup due to double-init tracing

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
