### PR TITLE
Bugs2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,12 @@ jobs:
       - if: runner.os != 'windows'
         run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server --all-targets
 
+      - name: javascript feature clippy
+        if: runner.os != 'windows'
+        run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server --all-targets --features javascript,bluetooth,nfc,usb
+      - name: WASM feature clippy
+        if: runner.os != 'windows'
+        run: cargo clippy --no-deps --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server --all-targets --features wasm,bluetooth,nfc,usb --no-default-features
       - run: cargo test --workspace --exclude webauthn-authenticator-rs  --exclude actix_web --exclude web_authn --exclude tide-server
 
       # Some clap errors manifest as panics at runtime. Running tools with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ http-body-util = "0.1.2"
 hyper = { version = "1.5.1", default-features = false, features = ["http1"] }
 hyper-util = { version = "0.1.10", features = ["tokio"] }
 nom = "7.1"
+num-derive = { version = "0.4.2" }
 peg = "0.8.1"
 openssl = "^0.10.56"
 

--- a/authenticator-cli/Cargo.toml
+++ b/authenticator-cli/Cargo.toml
@@ -13,9 +13,10 @@ repository = { workspace = true }
 
 [dependencies]
 
-authenticator = { version = "0.3.2-dev.1", default-features = false, features = ["crypto_openssl"], package = "authenticator-ctap2-2021" }
-clap.workspace = true
+authenticator = { version = "0.3.2-dev.1", default-features = false, features = [
+    "crypto_openssl",
+], package = "authenticator-ctap2-2021" }
+clap = { workspace = true }
 
-tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-log.workspace = true
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/authenticator-cli/src/main.rs
+++ b/authenticator-cli/src/main.rs
@@ -7,7 +7,8 @@ use authenticator::{
 };
 use std::sync::mpsc::{channel, RecvError};
 use std::thread;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, level_filters::LevelFilter, trace};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Subcommand)]
 #[clap(about = "Authenticator Utility")]
@@ -16,9 +17,16 @@ enum Opt {
 }
 
 fn main() {
-    tracing_subscriber::fmt::init();
-    tracing_log::LogTracer::init().expect("Failed to create tracing log bridge");
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .compact()
+        .init();
 
+    info!("Starting...");
     let timeout_ms = 25000;
 
     let mut manager = AuthenticatorService::new(CtapVersion::CTAP2)

--- a/base64urlsafedata/Cargo.toml
+++ b/base64urlsafedata/Cargo.toml
@@ -18,7 +18,7 @@ repository = { workspace = true }
 [dependencies]
 serde.workspace = true
 base64.workspace = true
-paste = "1.0.14"
+pastey = "0.1.0"
 
 [dev-dependencies]
 serde_cbor_2.workspace = true

--- a/base64urlsafedata/src/common.rs
+++ b/base64urlsafedata/src/common.rs
@@ -115,7 +115,7 @@ macro_rules! common_impls {
             }
         }
 
-        paste! {
+        pastey::paste! {
             #[doc(hidden)]
             struct [<$type Visitor>];
 

--- a/base64urlsafedata/src/lib.rs
+++ b/base64urlsafedata/src/lib.rs
@@ -84,9 +84,6 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate paste;
-
-#[macro_use]
 mod common;
 mod human;
 #[cfg(test)]

--- a/fido-hid-rs/Cargo.toml
+++ b/fido-hid-rs/Cargo.toml
@@ -27,16 +27,25 @@ tracing.workspace = true
 bindgen = "0.65.1"
 
 [dev-dependencies]
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true }
 
 # descriptors tests
-hex.workspace = true
-num-derive = "0.3"
+hex = { workspace = true }
+num-derive = { workspace = true }
 num-traits = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 lazy_static = "1.4.0"
-windows = { version = "0.41.0", features = ["Win32_Foundation", "Win32_Devices_HumanInterfaceDevice", "Devices_Enumeration", "Devices_HumanInterfaceDevice", "Foundation", "Foundation_Collections", "Storage", "Storage_Streams" ] }
+windows = { version = "0.41.0", features = [
+    "Win32_Foundation",
+    "Win32_Devices_HumanInterfaceDevice",
+    "Devices_Enumeration",
+    "Devices_HumanInterfaceDevice",
+    "Foundation",
+    "Foundation_Collections",
+    "Storage",
+    "Storage_Streams",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
@@ -45,6 +54,6 @@ mach2 = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.26.2", features = ["ioctl", "poll"] }
-num-derive = "0.3"
+num-derive = { workspace = true }
 num-traits = "0.2"
 udev = "0.7.0"

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -105,7 +105,7 @@ serde.workspace = true
 bitflags = "1.3.2"
 unicode-normalization = "0.1.22"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = { workspace = true }
 async-stream = "0.3.5"
 async-trait = "0.1.58"
 futures.workspace = true

--- a/webauthn-rp-proxy/tests/integration_test.rs
+++ b/webauthn-rp-proxy/tests/integration_test.rs
@@ -16,7 +16,7 @@ mod tests {
             .expect("failed to execute process");
 
         Ok(serde_json::from_str(
-            &String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stdout).as_ref(),
         )?)
     }
 

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -28,7 +28,6 @@ base64urlsafedata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 url = { workspace = true, features = ["serde"] }
-# num_enum = "0.5"
 
 # Webauthn Components
 wasm-bindgen = { version = "0.2", features = [


### PR DESCRIPTION
Replaces #481 

- Fixes some compile warnings that've been coming up for a while.
- Fixes: #480
- Fixes: authenticator-cli was crashing on startup due to double-init tracing

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
