### PR TITLE
authenticator/usb: add support for wink function

### DIFF
--- a/webauthn-authenticator-rs/src/transport/types.rs
+++ b/webauthn-authenticator-rs/src/transport/types.rs
@@ -11,6 +11,8 @@ pub const U2FHID_MSG: u8 = TYPE_INIT | 0x03;
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_INIT: u8 = TYPE_INIT | 0x06;
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
+pub const U2FHID_WINK: u8 = TYPE_INIT | 0x08;
+#[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_CBOR: u8 = TYPE_INIT | 0x10;
 #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
 pub const U2FHID_CANCEL: u8 = TYPE_INIT | 0x11;
@@ -28,6 +30,8 @@ pub enum Response {
     Ping(Vec<u8>),
     #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
     Msg(ISO7816ResponseAPDU),
+    #[cfg(any(all(doc, not(doctest)), feature = "usb"))]
+    Wink,
     Cbor(CBORResponse),
     Error(U2FError),
     KeepAlive(KeepAliveStatus),

--- a/webauthn-authenticator-rs/src/usb/responses.rs
+++ b/webauthn-authenticator-rs/src/usb/responses.rs
@@ -90,6 +90,7 @@ impl TryFrom<&U2FHIDFrame> for Response {
             U2FHID_INIT => InitResponse::try_from(b).map(Response::Init)?,
             U2FHID_PING => Response::Ping(b.to_vec()),
             U2FHID_MSG => ISO7816ResponseAPDU::try_from(b).map(Response::Msg)?,
+            U2FHID_WINK => Response::Wink,
             U2FHID_CBOR => CBORResponse::try_from(b).map(Response::Cbor)?,
             U2FHID_KEEPALIVE => Response::KeepAlive(KeepAliveStatus::from(b)),
             U2FHID_ERROR => Response::Error(U2FError::from(b)),


### PR DESCRIPTION
This adds support for `CTAPHID_WINK`, i.e. winking function for USB tokens.

Ref: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-wink

- [x] cargo test has been run and passes
- [ ] ~~documentation has been updated with relevant examples (if relevant)~~

Manually tested on a Titan USB-C key:

https://github.com/user-attachments/assets/b25682c2-33f3-48a5-9341-dcff9a82ffab

