### PR TITLE
Fix PublicKeyCredentialHints serde

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          version: v0.4.2
+      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - if: runner.os != 'windows'
         run: |
@@ -122,9 +120,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          version: v0.4.2
+      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - if: runner.os != 'windows'
         run: |
@@ -199,7 +195,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.4.2
       - run: |
@@ -257,7 +253,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.4.2
       - if: runner.os == 'windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
       - uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.4.2
       - run: |
           sudo apt-get update && \
           sudo apt-get -y install libudev-dev
@@ -207,7 +205,8 @@ jobs:
       # This tests that all the stubs work properly for optional dependencies,
       # but doesn't work for fido-key-manager which includes NFC and USB support
       # by default.
-      - run: cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all --exclude fido-key-manager --no-deps --document-private-items
+      - name: generate docs
+        run: cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all --exclude fido-key-manager --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
       - uses: actions/upload-artifact@v4
@@ -254,8 +253,6 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.4.2
       - if: runner.os == 'windows'
         uses: johnwason/vcpkg-action@v4
         with:

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -269,7 +269,7 @@ pub enum AuthenticatorAttachment {
 ///
 /// <https://www.w3.org/TR/webauthn-3/#enumdef-publickeycredentialhints>
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 #[allow(unused)]
 pub enum PublicKeyCredentialHints {
     /// The credential is a removable security key


### PR DESCRIPTION
Fixes #

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)

Hi team, thanks for providing this very helpful crate! I've submitted this PR to address a bug I encountered. I'm hoping this proposed fix can be reviewed and merged soon.

What fixed: `PublicKeyCredentialHint` must be in kebab-case format according to [documentation](https://www.w3.org/TR/webauthn-3/#enum-hints)