### PR TITLE
20250705 drop openssl phase 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,9 @@ async-std = { version = "1.6", features = ["attributes"] }
 anyhow = "1.0"
 base64 = "0.21"
 clap = { version = "^4.5", features = ["derive", "env"] }
-compact_jwt = "0.4.2"
+
+compact_jwt = { path = "../compact-jwt" }
+# compact_jwt = "0.4.2"
 futures = "^0.3.25"
 hex = "0.4.3"
 http = "^0.2.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,10 +74,8 @@ anyhow = "1.0"
 base64 = "0.21"
 clap = { version = "^4.5", features = ["derive", "env"] }
 
-crypto-glue = { path = "../crypto-glue" }
-# crypto-glue = "^0.1.5"
-compact_jwt = { path = "../compact-jwt" }
-# compact_jwt = "0.4.2"
+crypto-glue = "^0.1.8"
+compact_jwt = "0.5.1-dev"
 futures = "^0.3.25"
 hex = "0.4.3"
 http = "^0.2.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ anyhow = "1.0"
 base64 = "0.21"
 clap = { version = "^4.5", features = ["derive", "env"] }
 
+crypto-glue = { path = "../crypto-glue" }
+# crypto-glue = "^0.1.5"
 compact_jwt = { path = "../compact-jwt" }
 # compact_jwt = "0.4.2"
 futures = "^0.3.25"

--- a/attestation-ca/Cargo.toml
+++ b/attestation-ca/Cargo.toml
@@ -17,6 +17,11 @@ repository = { workspace = true }
 base64urlsafedata.workspace = true
 serde.workspace = true
 tracing.workspace = true
+uuid = { workspace = true, features = ["serde"] }
+crypto-glue.workspace = true
+
 openssl.workspace = true
 openssl-sys.workspace = true
-uuid = { workspace = true, features = ["serde"] }
+
+[build-dependencies]
+openssl.workspace = true

--- a/attestation-ca/src/lib.rs
+++ b/attestation-ca/src/lib.rs
@@ -5,12 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crypto_glue::{
-    x509::self,
-    traits::{
-        DecodePem,
-        EncodeDer,
-        DecodeDer,
-    },
+    traits::{DecodeDer, DecodePem, EncodeDer},
+    x509,
 };
 
 use uuid::Uuid;
@@ -67,9 +63,7 @@ pub struct AttestationCa {
 impl Into<SerialisableAttestationCa> for AttestationCa {
     fn into(self) -> SerialisableAttestationCa {
         SerialisableAttestationCa {
-            ca: Base64UrlSafeData::from(
-                self.ca.to_der().expect("Invalid DER")
-            ),
+            ca: Base64UrlSafeData::from(self.ca.to_der().expect("Invalid DER")),
             aaguids: self.aaguids,
             blanket_allow: self.blanket_allow,
         }
@@ -272,8 +266,7 @@ impl AttestationCaListBuilder {
         desc_english: String,
         desc_localised: BTreeMap<String, String>,
     ) -> Result<(), OpenSSLErrorStack> {
-        let ca = x509::Certificate::from_der(&ca_openssl.to_der().unwrap())
-            .unwrap();
+        let ca = x509::Certificate::from_der(&ca_openssl.to_der().unwrap()).unwrap();
 
         let kid = ca_openssl
             .digest(hash::MessageDigest::sha256())

--- a/fido-mds/Cargo.toml
+++ b/fido-mds/Cargo.toml
@@ -20,7 +20,6 @@ webauthn-attestation-ca.workspace = true
 base64.workspace = true
 crc32c = "^0.6.4"
 compact_jwt.workspace = true
-openssl.workspace = true
 peg = "0.8.1"
 serde.workspace = true
 serde_json.workspace = true

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -5,11 +5,10 @@
 //! for more.
 
 use compact_jwt::{crypto::JwsX509VerifierBuilder, JwsCompact, JwsVerifier, JwtError};
-use openssl::x509;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
-
+use std::time::SystemTime;
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
@@ -1094,19 +1093,22 @@ impl FromStr for FidoMds {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Setup the trusted CA store so that we can validate the authenticity of the MDS blob.
         let root_ca = x509::X509::from_pem(GLOBAL_SIGN_ROOT_CA_R3.as_bytes())
-            .map_err(|_| JwtError::OpenSSLError)?;
+            .map_err(|_| JwtError::CryptoError)?;
 
         let jws = JwsCompact::from_str(s)?;
 
-        let fullchain = jws
+        let (leaf, chain) = jws
             .get_x5c_chain()
             .and_then(|chain| chain.ok_or(JwtError::InvalidHeaderFormat))?;
 
-        let verifier = JwsX509VerifierBuilder::new()
-            .add_fullchain(fullchain)
+        let now = SystemTime::now();
+
+        let verifier = JwsX509VerifierBuilder::new(
+            &leaf, &chain
+        )
             .add_trust_root(root_ca)
-            .build()
-            .map_err(|_| JwtError::OpenSSLError)?;
+            .build(now)
+            .map_err(|_| JwtError::CryptoError)?;
 
         // Now we can release the embedded cert, since we have asserted the trust in the chain
         // that has signed this metadata.

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -22,6 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 base64.workspace = true
 base64urlsafedata.workspace = true
+crypto-glue.workspace = true
 hex.workspace = true
 webauthn-attestation-ca.workspace = true
 webauthn-rs-proto.workspace = true

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -10,7 +10,7 @@ use crypto_glue::{
     traits::DecodeDer,
     x509::{
         self, oiddb::rfc4519, BasicConstraints, ExtendedKeyUsage, ObjectIdentifier, SubjectAltName,
-        X509Display
+        X509Display,
     },
 };
 use std::time::SystemTime;

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -2,25 +2,21 @@
 //! This contains a transparent type allowing callbacks to
 //! make attestation decisions.
 
-use crate::crypto::{
-    check_extension, compute_sha256, only_hash_from_type, verify_signature, TpmSanData,
-};
+use crate::crypto::{compute_sha256, only_hash_from_type, verify_signature, TpmSanData};
 use crate::error::WebauthnError;
 use crate::internals::*;
 use crate::proto::*;
-use openssl::hash::MessageDigest;
-use openssl::stack;
-use openssl::x509::X509;
-use openssl::x509::store;
-use openssl::x509::verify;
-use uuid::Uuid;
-use x509_parser::oid_registry::Oid;
-use x509_parser::prelude::GeneralName;
-use x509_parser::X509Version;
 use crypto_glue::{
-    x509::{self},
-    traits::{DecodeDer},
+    traits::DecodeDer,
+    x509::{
+        self, oiddb::rfc4519, BasicConstraints, ExtendedKeyUsage, ObjectIdentifier, SubjectAltName,
+        X509Display
+    },
 };
+use std::time::SystemTime;
+use uuid::Uuid;
+
+const OID_JOINT_ISO_ITU_T: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.23.133.8.3");
 
 /// x509 certificate extensions are validated in the webauthn spec by checking
 /// that the value of the extension is equal to some other value
@@ -29,7 +25,7 @@ pub trait AttestationX509Extension {
     type Output: Eq;
 
     /// the oid of the extension
-    const OID: Oid<'static>;
+    const OID: ObjectIdentifier;
 
     /// how to parse the value out of the certificate extension
     fn parse(i: &[u8]) -> der_parser::error::BerResult<(Self::Output, AttestationMetadata)>;
@@ -51,7 +47,7 @@ pub(crate) struct AndroidKeyAttestationExtensionData;
 
 impl AttestationX509Extension for FidoGenCeAaguid {
     // If cert contains an extension with OID 1 3 6 1 4 1 45724 1 1 4 (id-fido-gen-ce-aaguid)
-    const OID: Oid<'static> = der_parser::oid!(1.3.6 .1 .4 .1 .45724 .1 .1 .4);
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.45724.1.1.4");
 
     // verify that the value of this extension matches the aaguid in authenticatorData.
     type Output = Aaguid;
@@ -263,7 +259,7 @@ pub(crate) mod android_key_attestation {
 
 impl AttestationX509Extension for AndroidKeyAttestationExtensionData {
     // If cert contains an extension with OID 1.3.6.1.4.1.11129.2.1.17 (android key attestation)
-    const OID: Oid<'static> = der_parser::oid!(1.3.6 .1 .4 .1 .11129 .2 .1 .17);
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129.2.1.17");
 
     // verify that the value of this extension matches the aaguid in authenticatorData.
     type Output = Vec<u8>;
@@ -281,7 +277,7 @@ impl AttestationX509Extension for AppleAnonymousNonce {
     type Output = [u8; 32];
 
     // 4. Verify that nonce equals the value of the extension with OID ( 1.2.840.113635.100.8.2 ) in credCert. The nonce here is used to prove that the attestation is live and to protect the integrity of the authenticatorData and the client data.
-    const OID: Oid<'static> = der_parser::oid!(1.2.840 .113635 .100 .8 .2);
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113635.100.8.2");
 
     fn parse(i: &[u8]) -> der_parser::error::BerResult<(Self::Output, AttestationMetadata)> {
         use der_parser::{der::*, error::BerError};
@@ -309,29 +305,28 @@ impl AttestationX509Extension for AppleAnonymousNonce {
 
 /// Validate an x509 extension is present in an x509 certificate
 pub fn validate_extension<T>(
-    x509: &X509,
+    x509: &x509::Certificate,
     data: &<T as AttestationX509Extension>::Output,
 ) -> Result<AttestationMetadata, WebauthnError>
 where
     T: AttestationX509Extension,
 {
-    let der_bytes = x509.to_der()?;
-    x509_parser::parse_x509_certificate(&der_bytes)
-        .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)?
-        .1
-        .extensions()
-        .iter()
-        .find_map(|extension| {
-            (extension.oid == T::OID).then(|| {
-                T::parse(extension.value)
-                    .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)
-                    .and_then(|(_, (output, metadata))| {
-                        if &output == data {
-                            Ok(metadata)
-                        } else {
-                            Err(T::VALIDATION_ERROR)
-                        }
-                    })
+    x509.tbs_certificate
+        .extensions
+        .as_ref()
+        .and_then(|extensions| {
+            extensions.iter().find_map(|extension| {
+                (extension.extn_id == T::OID).then(|| {
+                    T::parse(extension.extn_value.as_bytes())
+                        .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)
+                        .and_then(|(_, (output, metadata))| {
+                            if &output == data {
+                                Ok(metadata)
+                            } else {
+                                Err(T::VALIDATION_ERROR)
+                            }
+                        })
+                })
             })
         })
         .unwrap_or({
@@ -392,7 +387,10 @@ pub(crate) fn verify_packed_attestation(
                 .map(|values| {
                     cbor_try_bytes!(values)
                         .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)
-                        .and_then(|b| x509::Certificate::from_der(b).map_err(WebauthnError::OpenSSLError))
+                        .and_then(|b| {
+                            x509::Certificate::from_der(b)
+                                .map_err(|_| WebauthnError::X509DerInvalid)
+                        })
                 })
                 .collect();
 
@@ -494,16 +492,13 @@ pub(crate) fn verify_packed_attestation(
 /// [§ 8.2.1 Packed Attestation Statement Certificate Requirements][0]
 ///
 /// [0]: https://www.w3.org/TR/webauthn-2/#sctn-packed-attestation-cert-requirements
-pub fn assert_packed_attest_req(pubk: &X509) -> Result<(), WebauthnError> {
+fn assert_packed_attest_req(pubk: &x509::Certificate) -> Result<(), WebauthnError> {
     // https://w3c.github.io/webauthn/#sctn-packed-attestation-cert-requirements
-    let der_bytes = pubk.to_der()?;
-    let x509_cert = x509_parser::parse_x509_certificate(&der_bytes)
-        .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)?
-        .1;
+    let x509_cert = &pubk.tbs_certificate;
 
     // The attestation certificate MUST have the following fields/extensions:
     // Version MUST be set to 3 (which is indicated by an ASN.1 INTEGER with value 2).
-    if x509_cert.version != X509Version::V3 {
+    if x509_cert.version != x509::Version::V3 {
         trace!("X509 Version != v3");
         return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
     }
@@ -520,33 +515,44 @@ pub fn assert_packed_attest_req(pubk: &X509) -> Result<(), WebauthnError> {
     //  A UTF8String of the vendor’s choosing
     let subject = &x509_cert.subject;
 
-    let subject_c = subject.iter_country().take(1).next();
-    let subject_o = subject.iter_organization().take(1).next();
-    let subject_ou = subject.iter_organizational_unit().take(1).next();
-    let subject_cn = subject.iter_common_name().take(1).next();
+    let mut subject_c_present = false;
+    let mut subject_o_present = false;
+    let mut subject_cn_present = false;
+    let mut subject_ou_valid = false;
 
-    if subject_c.is_none() || subject_o.is_none() || subject_cn.is_none() {
-        trace!("Invalid subject details");
-        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
-    }
+    for rdn in subject.0.iter() {
+        if rdn.0.len() != 1 {
+            // We don't want to deal with empty or multivalue rdns.
+            continue;
+        }
 
-    match subject_ou {
-        Some(ou) => match ou.attr_value().as_str() {
-            Ok(ou_d) => {
-                if ou_d != "Authenticator Attestation" {
-                    trace!("ou != Authenticator Attestation");
-                    return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
-                }
-            }
-            Err(_) => {
+        let ava = &rdn.0.as_slice()[0];
+
+        if ava.oid == rfc4519::C {
+            subject_c_present = true
+        } else if ava.oid == rfc4519::O {
+            subject_o_present = true
+        } else if ava.oid == rfc4519::CN {
+            subject_cn_present = true
+        } else if ava.oid == rfc4519::OU {
+            let Ok(ava_value_str) = str::from_utf8(ava.value.value()) else {
+                // Invalid data.
                 trace!("ou invalid");
                 return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+            };
+
+            if ava_value_str == "Authenticator Attestation" {
+                subject_ou_valid = true
+            } else {
+                trace!("ou != Authenticator Attestation");
+                return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
             }
-        },
-        None => {
-            trace!("ou not found");
-            return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
         }
+    }
+
+    if !(subject_c_present && subject_o_present && subject_cn_present && subject_ou_valid) {
+        trace!("Invalid subject details");
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
     }
 
     // If the related attestation root certificate is used for multiple authenticator models,
@@ -558,16 +564,26 @@ pub fn assert_packed_attest_req(pubk: &X509) -> Result<(), WebauthnError> {
     //
     // The problem with this check, is that it's not actually required that this
     // oid be present at all ...
-    check_extension(
-        &x509_cert.get_extension_unique(&FidoGenCeAaguid::OID),
-        false,
-        |fido_gen_ce_aaguid| !fido_gen_ce_aaguid.critical,
-    )?;
+    let fido_gen_ce_aaguid_critical = x509_cert.extensions.as_ref().and_then(|extensions| {
+        extensions.iter().find_map(|extension| {
+            (extension.extn_id == FidoGenCeAaguid::OID).then_some(extension.critical)
+        })
+    });
+
+    if fido_gen_ce_aaguid_critical == Some(true) {
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
 
     // The Basic Constraints extension MUST have the CA component set to false.
-    check_extension(&x509_cert.basic_constraints(), true, |basic_constraints| {
-        !basic_constraints.value.ca
-    })?;
+    let basic_constraints = x509_cert
+        .get::<BasicConstraints>()
+        .map_err(|_| WebauthnError::AttestationCertificateRequirementsNotMet)?
+        .and_then(|(critical, extn)| critical.then_some(extn))
+        .ok_or(WebauthnError::AttestationCertificateRequirementsNotMet)?;
+
+    if basic_constraints.ca {
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
 
     // An Authority Information Access (AIA) extension with entry id-ad-ocsp and a CRL
     // Distribution Point extension [RFC5280] are both OPTIONAL as the status of many
@@ -622,7 +638,8 @@ pub(crate) fn verify_fidou2f_attestation(
         .iter()
         .map(|att_cert_bytes| {
             cbor_try_bytes!(att_cert_bytes).and_then(|att_cert| {
-                X509::from_der(att_cert.as_slice()).map_err(WebauthnError::OpenSSLError)
+                x509::Certificate::from_der(att_cert.as_slice())
+                    .map_err(|_| WebauthnError::X509DerInvalid)
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -769,7 +786,9 @@ pub(crate) fn verify_tpm_attestation(
         .map(|values| {
             cbor_try_bytes!(values)
                 .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)
-                .and_then(|b| X509::from_der(b).map_err(WebauthnError::OpenSSLError))
+                .and_then(|b| {
+                    x509::Certificate::from_der(b).map_err(|_| WebauthnError::X509DerInvalid)
+                })
         })
         .collect();
 
@@ -941,82 +960,72 @@ pub(crate) fn verify_tpm_attestation(
     ))
 }
 
-pub(crate) fn assert_tpm_attest_req(x509: &X509) -> Result<(), WebauthnError> {
-    let der_bytes = x509.to_der()?;
-    let x509_cert = x509_parser::parse_x509_certificate(&der_bytes)
-        .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)?
-        .1;
+pub(crate) fn assert_tpm_attest_req(x509: &x509::Certificate) -> Result<(), WebauthnError> {
+    let x509_cert = &x509.tbs_certificate;
 
     // TPM attestation certificate MUST have the following fields/extensions:
 
     // Version MUST be set to 3.
-    if x509_cert.version != X509Version::V3 {
+    if x509_cert.version != x509::Version::V3 {
         return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
     }
 
     // Subject field MUST be set to empty.
-    let subject_name_ref = x509.subject_name();
-    if subject_name_ref.entries().count() != 0 {
+    if !x509_cert.subject.is_empty() {
         return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
     }
 
     // The Subject Alternative Name extension MUST be set as defined in [TPMv2-EK-Profile] section 3.2.9.
     // https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
-    check_extension(
-        &x509_cert.subject_alternative_name(),
-        true,
-        |subject_alternative_name| {
-            // From [TPMv2-EK-Profile]:
-            // In accordance with RFC 5280[11], this extension MUST be critical if
-            // subject is empty and SHOULD be non-critical if subject is non-empty.
-            //
-            // We've already returned if the subject is non-empty, so we can just
-            // check that the extension is critical.
-            if !subject_alternative_name.critical {
-                return false;
-            };
 
-            // The issuer MUST include TPM manufacturer, TPM part number and TPM
-            // firmware version, using the directoryName form within the GeneralName
-            // structure.
-            subject_alternative_name
-                .value
-                .general_names
-                .iter()
-                .any(|general_name| {
-                    if let GeneralName::DirectoryName(x509_name) = general_name {
-                        TpmSanData::try_from(x509_name)
-                            .and_then(|san_data| {
-                                tpm_device_attribute_parser(san_data.manufacturer.as_bytes())
-                                    .map_err(|_| WebauthnError::ParseNOMFailure)
-                            })
-                            .and_then(|(_, manufacturer_bytes)| {
-                                TpmVendor::try_from(manufacturer_bytes)
-                            })
-                            .is_ok()
-                    } else {
-                        false
-                    }
-                })
-        },
-    )?;
+    // From [TPMv2-EK-Profile]:
+    // In accordance with RFC 5280[11], this extension MUST be critical if
+    // subject is empty and SHOULD be non-critical if subject is non-empty.
+    //
+    // We've already returned if the subject is non-empty, so we can just
+    // check that the extension is critical.
+    //
+    // The issuer MUST include TPM manufacturer, TPM part number and TPM
+    // firmware version, using the directoryName form within the GeneralName
+    // structure.
+    let subject_alt_name = x509_cert
+        .get::<SubjectAltName>()
+        .map_err(|_| WebauthnError::AttestationCertificateRequirementsNotMet)?
+        .and_then(|(critical, extn)| critical.then_some(extn))
+        .ok_or(WebauthnError::AttestationCertificateRequirementsNotMet)?;
+
+    let _tpm_san_data = TpmSanData::try_from(&subject_alt_name)
+        .and_then(|san_data| {
+            tpm_device_attribute_parser(san_data.manufacturer.as_bytes())
+                .map_err(|_| WebauthnError::ParseNOMFailure)
+        })
+        .and_then(|(_, manufacturer_bytes)| TpmVendor::try_from(manufacturer_bytes))?;
 
     // The Extended Key Usage extension MUST contain the "joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)" OID.
-    check_extension(
-        &x509_cert.extended_key_usage(),
-        true,
-        |extended_key_usage| {
-            extended_key_usage
-                .value
-                .other
-                .contains(&der_parser::oid!(2.23.133 .8 .3))
-        },
-    )?;
+    let extended_key_usage = x509_cert
+        .get::<ExtendedKeyUsage>()
+        .map_err(|_| WebauthnError::AttestationCertificateRequirementsNotMet)?
+        .and_then(|(critical, extn)| critical.then_some(extn))
+        .ok_or(WebauthnError::AttestationCertificateRequirementsNotMet)?;
+
+    if !extended_key_usage
+        .0
+        .iter()
+        .any(|oid| *oid == OID_JOINT_ISO_ITU_T)
+    {
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
 
     // The Basic Constraints extension MUST have the CA component set to false.
-    check_extension(&x509_cert.basic_constraints(), true, |basic_constraints| {
-        !basic_constraints.value.ca
-    })?;
+    let basic_constraints = x509_cert
+        .get::<BasicConstraints>()
+        .map_err(|_| WebauthnError::AttestationCertificateRequirementsNotMet)?
+        .and_then(|(critical, extn)| critical.then_some(extn))
+        .ok_or(WebauthnError::AttestationCertificateRequirementsNotMet)?;
+
+    if basic_constraints.ca {
+        return Err(WebauthnError::AttestationCertificateRequirementsNotMet);
+    }
 
     // An Authority Information Access (AIA) extension with entry id-ad-ocsp and a CRL Distribution
     // Point extension [RFC5280] are both OPTIONAL as the status of many attestation certificates is
@@ -1054,7 +1063,9 @@ pub(crate) fn verify_apple_anonymous_attestation(
         .map(|values| {
             cbor_try_bytes!(values)
                 .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)
-                .and_then(|b| X509::from_der(b).map_err(WebauthnError::OpenSSLError))
+                .and_then(|b| {
+                    x509::Certificate::from_der(b).map_err(|_| WebauthnError::X509DerInvalid)
+                })
         })
         .collect();
 
@@ -1141,7 +1152,9 @@ pub(crate) fn verify_android_key_attestation(
             .map(|values| {
                 cbor_try_bytes!(values)
                     .map_err(|_| WebauthnError::AttestationStatementX5CInvalid)
-                    .and_then(|b| X509::from_der(b).map_err(WebauthnError::OpenSSLError))
+                    .and_then(|b| {
+                        x509::Certificate::from_der(b).map_err(|_| WebauthnError::X509DerInvalid)
+                    })
             })
             .collect();
 
@@ -1202,7 +1215,7 @@ pub(crate) fn verify_android_key_attestation(
 pub fn verify_attestation_ca_chain<'a>(
     att_data: &'_ ParsedAttestationData,
     ca_list: &'a AttestationCaList,
-    danger_disable_certificate_time_checks: bool,
+    current_time: SystemTime,
 ) -> Result<Option<&'a AttestationCa>, WebauthnError> {
     // If the ca_list is empty, Immediately fail since no valid attestation can be created.
     if ca_list.cas().is_empty() {
@@ -1226,94 +1239,35 @@ pub fn verify_attestation_ca_chain<'a>(
     };
 
     for crt in fullchain {
-        debug!(?crt);
+        debug!(cert = %X509Display::from(crt));
     }
-    debug!(?ca_list);
 
     let (leaf, chain) = fullchain
         .split_first()
         .ok_or(WebauthnError::AttestationLeafCertMissing)?;
 
-    // Convert the chain to a stackref so that openssl can use it.
-    let mut chain_stack = stack::Stack::new().map_err(WebauthnError::OpenSSLError)?;
+    // Convert to a crypto-clue x509 cert.
+    let cg_ca_list = ca_list
+        .cas()
+        .values()
+        .map(|att_ca| att_ca.ca().clone())
+        .collect::<Vec<_>>();
 
-    for crt in chain.iter() {
-        chain_stack
-            .push(crt.clone())
-            .map_err(WebauthnError::OpenSSLError)?;
+    for ca in cg_ca_list.iter() {
+        debug!(ca = %X509Display::from(ca));
     }
 
-    // Create the x509 store that we will validate against.
-    let mut ca_store = store::X509StoreBuilder::new().map_err(WebauthnError::OpenSSLError)?;
+    let mut store = x509::X509Store::new(&cg_ca_list);
+    // Google does not put basic contrants on their leaf certs
+    store.leaf_basic_constraints_required(false);
 
-    // In tests we may need to allow disabling time window validity.
-    if danger_disable_certificate_time_checks {
-        ca_store
-            .set_flags(verify::X509VerifyFlags::NO_CHECK_TIME)
-            .map_err(WebauthnError::OpenSSLError)?;
-    }
-
-    for ca_crt in ca_list.cas().values() {
-        ca_store
-            .add_cert(ca_crt.ca().clone())
-            .map_err(WebauthnError::OpenSSLError)?;
-    }
-
-    let ca_store = ca_store.build();
-
-    let mut ca_ctx = X509StoreContext::new().map_err(WebauthnError::OpenSSLError)?;
-
-    // Providing the cert and chain, validate we have a ref to our store.
-    // Note this is a result<result ... because the inner .init must return an errorstack
-    // for openssl.
-    let res: Result<_, _> = ca_ctx
-        .init(&ca_store, leaf, &chain_stack, |ca_ctx_ref| {
-            ca_ctx_ref.verify_cert().map(|_| {
-                // The value as passed in is a boolean that we ignore in favour of the richer error type.
-                let res = ca_ctx_ref.error();
-                debug!("{:?}", res);
-                if res == X509VerifyResult::OK {
-                    ca_ctx_ref
-                        .chain()
-                        .and_then(|chain| {
-                            // If there is a chain here, we get the root.
-                            let idx = chain.len() - 1;
-                            chain.get(idx)
-                        })
-                        .and_then(|ca_cert| {
-                            // If we got it from the stack, we can now digest it.
-                            ca_cert.digest(MessageDigest::sha256()).ok()
-                            // We let the digest bubble out now, we've done too much here
-                            // already!
-                        })
-                        .ok_or(WebauthnError::AttestationTrustFailure)
-                } else {
-                    debug!(
-                        "ca_ctx_ref verify cert - error depth={}, sn={:?}",
-                        ca_ctx_ref.error_depth(),
-                        ca_ctx_ref.current_cert().map(|crt| crt.subject_name())
-                    );
-                    Err(WebauthnError::AttestationChainNotTrusted(res.to_string()))
-                }
-            })
+    store
+        .verify(leaf, chain, current_time)
+        .map_err(WebauthnError::AttestationChainNotTrusted)
+        .map(|valid_ca| {
+            ca_list
+                .cas()
+                .values()
+                .find(|att_ca| att_ca.ca() == valid_ca)
         })
-        .map_err(|e| {
-            // If an openssl error occured, dump it here.
-            error!(?e);
-            e
-        })?;
-
-    // Now we have a result<DigestOfCaUsed, Error> and we want to attach our related
-    // attestation CA.
-    res.and_then(|dgst| {
-        ca_list
-            .cas()
-            .get(dgst.as_ref())
-            .ok_or_else(|| {
-                WebauthnError::AttestationChainNotTrusted("Invalid CA digest maps".to_string())
-            })
-            // We need to wrap in an extra Some here to indicate to the caller that we
-            // did use a CA compare to the Ok(None) case.
-            .map(Some)
-    })
 }

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -15,10 +15,6 @@
 
 #![warn(missing_docs)]
 
-use rand::prelude::*;
-use std::time::Duration;
-use url::Url;
-
 use crate::attestation::{
     verify_android_key_attestation, verify_apple_anonymous_attestation,
     verify_attestation_ca_chain, verify_fidou2f_attestation, verify_packed_attestation,
@@ -29,6 +25,10 @@ use crate::crypto::compute_sha256;
 use crate::error::WebauthnError;
 use crate::internals::*;
 use crate::proto::*;
+use rand::prelude::*;
+use std::time::Duration;
+use std::time::SystemTime;
+use url::Url;
 
 /// The Core Webauthn handler.
 ///
@@ -397,6 +397,7 @@ impl WebauthnCore {
             allow_synchronised_authenticators,
         } = state;
         let chal: &ChallengeRef = challenge.into();
+        let current_time = SystemTime::now();
 
         // send to register_credential_internal
         let credential = self.register_credential_internal(
@@ -406,9 +407,9 @@ impl WebauthnCore {
             exclude_credentials,
             credential_algorithms,
             attestation_cas,
-            false,
             extensions,
             *allow_synchronised_authenticators,
+            current_time,
         )?;
 
         // Check that the credentialId is not yet registered to any other user. If registration is
@@ -437,9 +438,9 @@ impl WebauthnCore {
         exclude_credentials: &[CredentialID],
         credential_algorithms: &[COSEAlgorithm],
         attestation_cas: Option<&AttestationCaList>,
-        danger_disable_certificate_time_checks: bool,
         req_extn: &RequestRegistrationExtensions,
         allow_synchronised_authenticators: bool,
+        current_time: SystemTime,
     ) -> Result<Credential, WebauthnError> {
         // Internal management - if the attestation ca list is some, but is empty, we need to fail!
         if attestation_cas
@@ -670,11 +671,8 @@ impl WebauthnCore {
 
         let attested_ca_crt = if let Some(ca_list) = attestation_cas {
             // If given a set of ca's assert that our attestation actually matched one.
-            let ca_crt = verify_attestation_ca_chain(
-                &credential.attestation.data,
-                ca_list,
-                danger_disable_certificate_time_checks,
-            )?;
+            let ca_crt =
+                verify_attestation_ca_chain(&credential.attestation.data, ca_list, current_time)?;
 
             // It may seem odd to unwrap the option and make this not verified at this point,
             // but in this case because we have the ca_list and none was the result (which happens)
@@ -1252,7 +1250,6 @@ impl WebauthnCore {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic)]
-
     use crate::constants::CHALLENGE_SIZE_BYTES;
     use crate::core::{CreationChallengeResponse, RegistrationState, WebauthnError};
     use crate::internals::*;
@@ -1260,9 +1257,8 @@ mod tests {
     use crate::WebauthnCore as Webauthn;
     use base64::{engine::general_purpose::STANDARD, Engine};
     use base64urlsafedata::{Base64UrlSafeData, HumanBinaryData};
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime};
     use url::Url;
-
     use webauthn_rs_device_catalog::data::{
         android::ANDROID_SOFTWARE_ROOT_CA, apple::APPLE_WEBAUTHN_ROOT_CA_PEM,
         google::GOOGLE_SAFETYNET_CA_OLD,
@@ -1316,9 +1312,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             Some(&YUBICO_U2F_ROOT_CA_SERIAL_457200631_PEM.try_into().unwrap()),
-            false,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(result.is_ok());
@@ -1362,9 +1358,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(result.is_ok());
@@ -1408,9 +1404,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         assert!(result.is_ok());
     }
@@ -1452,9 +1448,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(result.is_ok());
@@ -1497,9 +1493,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(result.is_ok());
@@ -1542,9 +1538,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(matches!(
@@ -1843,9 +1839,9 @@ mod tests {
             &[COSEAlgorithm::ES256],
             // This is what introduces the failure!
             Some(&AttestationCaList::default()),
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(matches!(
@@ -1861,9 +1857,9 @@ mod tests {
             &[COSEAlgorithm::ES256],
             // Exclude the matching CA!
             Some(&(APPLE_WEBAUTHN_ROOT_CA_PEM.try_into().unwrap())),
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(matches!(
@@ -1891,9 +1887,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             Some(&att_ca_list),
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(matches!(
@@ -1919,9 +1915,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             Some(&att_ca_list),
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(result.is_ok());
@@ -2010,9 +2006,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::RS256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(result.is_ok());
@@ -2383,9 +2379,9 @@ mod tests {
                     .try_into()
                     .unwrap()),
             ),
-            false,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
         trace!("{:?}", result);
         assert!(matches!(
@@ -2444,6 +2440,8 @@ mod tests {
 
     #[test]
     fn test_touchid_attest_apple_anonymous() {
+        // 20201208, 02:27:15 + 1 hour
+        const DATE: u64 = 1607394435 + 3600;
         let _ = tracing_subscriber::fmt::try_init();
         let wan = Webauthn::new_unsafe_experts_only(
             "https://spectral.local:8443/auth",
@@ -2586,11 +2584,11 @@ mod tests {
                 COSEAlgorithm::EDDSA,
             ],
             Some(&att_ca_list),
-            // Must disable time checks because the submission is limited to 5 days.
-            true,
             &RequestRegistrationExtensions::default(),
             // Don't allow passkeys
             false,
+            // Must manually set the clock as submission is limited to 5 days.
+            SystemTime::UNIX_EPOCH + Duration::from_secs(DATE),
         );
         debug!("{:?}", result);
         assert!(matches!(
@@ -2616,11 +2614,11 @@ mod tests {
                 COSEAlgorithm::EDDSA,
             ],
             Some(&(APPLE_WEBAUTHN_ROOT_CA_PEM.try_into().unwrap())),
-            // Must disable time checks because the submission is limited to 5 days.
-            true,
             &RequestRegistrationExtensions::default(),
             // Don't allow passkeys
             false,
+            // Must manually set the clock as submission is limited to 5 days.
+            SystemTime::UNIX_EPOCH + Duration::from_secs(DATE),
         );
         debug!("{:?}", result);
         assert!(result.is_ok());
@@ -2643,11 +2641,11 @@ mod tests {
                 COSEAlgorithm::EDDSA,
             ],
             Some(&(APPLE_WEBAUTHN_ROOT_CA_PEM.try_into().unwrap())),
-            // Must disable time checks because the submission is limited to 5 days.
-            true,
             &RequestRegistrationExtensions::default(),
             // Allow them.
             true,
+            // Must manually set the clock as submission is limited to 5 days.
+            SystemTime::UNIX_EPOCH + Duration::from_secs(DATE),
         );
         debug!("{:?}", result);
         assert!(result.is_ok());
@@ -2784,10 +2782,10 @@ mod tests {
                 COSEAlgorithm::EDDSA,
             ],
             Some(&(APPLE_WEBAUTHN_ROOT_CA_PEM.try_into().unwrap())),
-            // Must disable time checks because the submission is limited to 5 days.
-            true,
             &RequestRegistrationExtensions::default(),
             false,
+            // Must manually set the clock as submission is limited to 5 days.
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1),
         );
         debug!("{:?}", result);
         assert!(matches!(
@@ -3069,9 +3067,9 @@ mod tests {
                 &[],
                 &[COSEAlgorithm::ES256],
                 None,
-                false,
                 &RequestRegistrationExtensions::default(),
                 true,
+                SystemTime::now(),
             )
             .expect("Failed to register credential");
 
@@ -3163,9 +3161,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::EDDSA],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         debug!("{:?}", result);
         assert!(result.is_ok());
@@ -3206,9 +3204,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::EDDSA],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         debug!("{:?}", result);
         assert!(result.is_ok());
@@ -3249,9 +3247,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         debug!("{:?}", result);
         // Currently UNSUPPORTED as openssl doesn't have eddsa management utils that we need.
@@ -3293,9 +3291,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
         debug!("{:?}", result);
         assert!(result.is_ok());
@@ -3340,9 +3338,9 @@ mod tests {
                 COSEAlgorithm::INSECURE_RS1,
             ],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         debug!("{:?}", result);
         assert!(result.is_err());
@@ -3388,9 +3386,9 @@ mod tests {
                 COSEAlgorithm::INSECURE_RS1,
             ],
             None,
-            false,
             &RequestRegistrationExtensions::default(),
             false,
+            SystemTime::now(),
         );
         debug!("{:?}", result);
         assert!(matches!(result, Err(WebauthnError::ParseNOMFailure)));
@@ -3469,9 +3467,10 @@ mod tests {
             // Some(&AttestationCaList {
             //    cas: vec![AttestationCa::apple_webauthn_root_ca()],
             // }),
-            true,
             &RequestRegistrationExtensions::default(),
             true,
+            // Must manually set the clock as submission is limited to 5 days.
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1),
         );
         debug!("{:?}", result);
         let cred = result.unwrap();
@@ -3543,9 +3542,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             Some(&(GOOGLE_SAFETYNET_CA_OLD.try_into().unwrap())),
-            true,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
         dbg!(&result);
         assert_eq!(result, Err(WebauthnError::AttestationNotSupported));
@@ -3588,11 +3587,11 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             Some(&(ANDROID_SOFTWARE_ROOT_CA.try_into().unwrap())),
-            true,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
-        dbg!(&result);
+        debug!(?result);
         assert!(result.is_ok());
 
         match result.unwrap().attestation.metadata {
@@ -3657,9 +3656,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::ES256],
             None,
-            true,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
 
         assert!(matches!(
@@ -3724,9 +3723,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::EDDSA],
             None,
-            true,
             &RequestRegistrationExtensions::default(),
             true,
+            SystemTime::now(),
         );
 
         debug!(?result);
@@ -3790,9 +3789,9 @@ mod tests {
             &[],
             &[COSEAlgorithm::EDDSA],
             None,
-            true,
             &reg_extn,
             true,
+            SystemTime::now(),
         );
 
         debug!(?result);

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -26,8 +26,7 @@ use crate::error::WebauthnError;
 use crate::internals::*;
 use crate::proto::*;
 use rand::prelude::*;
-use std::time::Duration;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use url::Url;
 
 /// The Core Webauthn handler.

--- a/webauthn-rs-core/src/crypto.rs
+++ b/webauthn-rs-core/src/crypto.rs
@@ -6,19 +6,9 @@
 #![allow(non_camel_case_types)]
 
 use openssl::{bn, ec, hash, nid, pkey, rsa, sha, sign, x509};
-
 use super::error::*;
 use crate::proto::*;
-
 use x509_parser::prelude::{X509Error, X509Name};
-
-// Why OpenSSL over another rust crate?
-// - The openssl crate allows us to reconstruct a public key from the
-//   x/y group coords, where most others want a pkcs formatted structure. As
-//   a result, it's easiest to use openssl as it gives us exactly what we need
-//   for these operations, and despite it's many challenges as a library, it
-//   has resources and investment into it's maintenance, so we can a least
-//   assert a higher level of confidence in it that <backyard crypto here>.
 
 fn pkey_verify_signature(
     pkey: &pkey::PKeyRef<pkey::Public>,

--- a/webauthn-rs-core/src/error.rs
+++ b/webauthn-rs-core/src/error.rs
@@ -1,6 +1,7 @@
 //! Possible errors that may occur during Webauthn Operation processing
 
 use base64::DecodeError as b64DecodeError;
+use crypto_glue::x509::X509VerificationError;
 use openssl::error::ErrorStack as OpenSSLErrorStack;
 use serde_cbor_2::error::Error as CBORError;
 use serde_json::error::Error as JSONError;
@@ -154,7 +155,7 @@ pub enum WebauthnError {
     #[error(
         "The attestation was parsed, but is not trusted by one of the selected CA certificates"
     )]
-    AttestationChainNotTrusted(String),
+    AttestationChainNotTrusted(X509VerificationError),
 
     #[error("The X5C trust root is not a valid algorithm for signing")]
     CertificatePublicKeyInvalid,
@@ -289,6 +290,9 @@ pub enum WebauthnError {
 
     #[error("The attestation requst indicates cred protect was required, but user verification was not performed")]
     SshPublicKeyInconsistentUserVerification,
+
+    #[error("Malformed X509 DER was encountered")]
+    X509DerInvalid,
 }
 
 impl PartialEq for WebauthnError {

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -335,8 +335,6 @@ impl Credential {
         &'_ self,
         ca_list: &'a AttestationCaList,
     ) -> Result<Option<&'a AttestationCa>, WebauthnError> {
-        // Formerly we disabled this due to apple, but they no longer provide
-        // meaningful attestation so we can re-enable it.
         let current_time = SystemTime::now();
         verify_attestation_ca_chain(&self.attestation.data, ca_list, current_time)
     }


### PR DESCRIPTION
Relates #499 

This reworks x509 handling in webauthn-rs-core. This does cause breakage in a lot of other parts/tests, but rs-core does work and does pass testing at this time. 

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
