### PR TITLE
fix: elligibility -> eligibility

### DIFF
--- a/cable-tunnel-server/backend/src/main.rs
+++ b/cable-tunnel-server/backend/src/main.rs
@@ -162,7 +162,7 @@ impl From<tungstenite::Error> for CableError {
 }
 
 impl CableError {
-    fn close_reason(&self) -> Option<CloseFrame> {
+    fn close_reason(&self) -> Option<CloseFrame<'_>> {
         use CableError::*;
         let code = match self {
             RemotePeerErrorFrame => CloseCode::Policy,

--- a/sshkey-attest/src/lib.rs
+++ b/sshkey-attest/src/lib.rs
@@ -275,7 +275,7 @@ impl TryFrom<&[u8]> for SshSkAttestation {
     }
 }
 
-fn parse_ssh_sk_attestation(i: &[u8]) -> nom::IResult<&[u8], SshSkAttestationRaw> {
+fn parse_ssh_sk_attestation(i: &[u8]) -> nom::IResult<&[u8], SshSkAttestationRaw<'_>> {
     // Starts with a 4 byte u32 for the len of the header.
 
     let (i, _tag_len) = tag([0, 0, 0, 17])(i)?;

--- a/webauthn-authenticator-rs/src/nfc/tlv.rs
+++ b/webauthn-authenticator-rs/src/nfc/tlv.rs
@@ -7,7 +7,7 @@ pub(crate) struct CompactTlv<'a> {
 
 impl CompactTlv<'_> {
     /// Parses a Compact-TLV structure in the given slice.
-    pub fn new(tlv: &[u8]) -> CompactTlv {
+    pub fn new(tlv: &[u8]) -> CompactTlv<'_> {
         // Skip null bytes at the start
         let mut i = 0;
         loop {

--- a/webauthn-authenticator-rs/src/win10/cose.rs
+++ b/webauthn-authenticator-rs/src/win10/cose.rs
@@ -84,7 +84,7 @@ impl WinCoseCredentialParameters {
             let l = &mut Pin::get_unchecked_mut(mut_ref)._l;
             let l_ptr = l.as_mut_ptr();
             for i in 0..len {
-                *l_ptr.add(i) = (*p_ptr.add(i)).native;
+                *l_ptr.add(i) = (&(*p_ptr.add(i))).native;
             }
 
             l.set_len(len);

--- a/webauthn-rs-core/src/attestation.rs
+++ b/webauthn-rs-core/src/attestation.rs
@@ -28,7 +28,7 @@ pub trait AttestationX509Extension {
     const OID: Oid<'static>;
 
     /// how to parse the value out of the certificate extension
-    fn parse(i: &[u8]) -> der_parser::error::BerResult<(Self::Output, AttestationMetadata)>;
+    fn parse(i: &[u8]) -> der_parser::error::BerResult<'_, (Self::Output, AttestationMetadata)>;
 
     /// if `true`, then validating this certificate fails if this extension is
     /// missing
@@ -52,7 +52,7 @@ impl AttestationX509Extension for FidoGenCeAaguid {
     // verify that the value of this extension matches the aaguid in authenticatorData.
     type Output = Aaguid;
 
-    fn parse(i: &[u8]) -> der_parser::error::BerResult<(Self::Output, AttestationMetadata)> {
+    fn parse(i: &[u8]) -> der_parser::error::BerResult<'_, (Self::Output, AttestationMetadata)> {
         let (rem, aaguid) = der_parser::der::parse_der_octetstring(i)?;
         let aaguid: Aaguid = aaguid
             .as_slice()
@@ -113,7 +113,7 @@ pub(crate) mod android_key_attestation {
     }
 
     impl AuthorizationList {
-        pub fn parse(i: &[u8]) -> der_parser::error::BerResult<Self> {
+        pub fn parse(i: &[u8]) -> der_parser::error::BerResult<'_, Self> {
             use der_parser::{der::*, error::BerError};
             parse_der_container(|i: &[u8], hdr: Header| {
                 if hdr.tag() != Tag::Sequence {
@@ -165,7 +165,7 @@ pub(crate) mod android_key_attestation {
     }
 
     impl Data {
-        pub fn parse(i: &[u8]) -> der_parser::error::BerResult<(Vec<u8>, AttestationMetadata)> {
+        pub fn parse(i: &[u8]) -> der_parser::error::BerResult<'_, (Vec<u8>, AttestationMetadata)> {
             use der_parser::{der::*, error::BerError};
             parse_der_container(|i: &[u8], hdr: Header| {
                 if hdr.tag() != Tag::Sequence {
@@ -264,7 +264,7 @@ impl AttestationX509Extension for AndroidKeyAttestationExtensionData {
     // verify that the value of this extension matches the aaguid in authenticatorData.
     type Output = Vec<u8>;
 
-    fn parse(i: &[u8]) -> der_parser::error::BerResult<(Self::Output, AttestationMetadata)> {
+    fn parse(i: &[u8]) -> der_parser::error::BerResult<'_, (Self::Output, AttestationMetadata)> {
         android_key_attestation::Data::parse(i)
     }
 
@@ -279,7 +279,7 @@ impl AttestationX509Extension for AppleAnonymousNonce {
     // 4. Verify that nonce equals the value of the extension with OID ( 1.2.840.113635.100.8.2 ) in credCert. The nonce here is used to prove that the attestation is live and to protect the integrity of the authenticatorData and the client data.
     const OID: Oid<'static> = der_parser::oid!(1.2.840 .113635 .100 .8 .2);
 
-    fn parse(i: &[u8]) -> der_parser::error::BerResult<(Self::Output, AttestationMetadata)> {
+    fn parse(i: &[u8]) -> der_parser::error::BerResult<'_, (Self::Output, AttestationMetadata)> {
         use der_parser::{der::*, error::BerError};
         parse_der_container(|i: &[u8], hdr: Header| {
             if hdr.tag() != Tag::Sequence {

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -735,7 +735,7 @@ impl WebauthnCore {
         // OUT OF SPEC - It is invalid for a credential to indicate it is backed up
         // but not that it is elligible for backup
         if credential.backup_state && !credential.backup_eligible {
-            error!("Credential indicates it is backed up, but has not declared valid backup elligibility");
+            error!("Credential indicates it is backed up, but has not declared valid backup eligibility");
             return Err(WebauthnError::CredentialMayNotBeHardwareBound);
         }
 
@@ -871,7 +871,7 @@ impl WebauthnCore {
             _ => {}
         }
 
-        // OUT OF SPEC - if the backup elligibility of this device has changed, this may represent
+        // OUT OF SPEC - if the backup eligibility of this device has changed, this may represent
         // a compromise of the credential, tampering with the device, or some other change to its
         // risk profile from when it was originally enrolled. Reject the authentication if this
         // situation occurs.
@@ -881,17 +881,17 @@ impl WebauthnCore {
                 && !cred.backup_eligible
                 && data.authenticator_data.backup_eligible
             {
-                debug!("Credential backup elligibility has changed!");
+                debug!("Credential backup eligibility has changed!");
             } else {
-                error!("Credential backup elligibility has changed!");
-                return Err(WebauthnError::CredentialBackupElligibilityInconsistent);
+                error!("Credential backup eligibility has changed!");
+                return Err(WebauthnError::CredentialBackupEligibilityInconsistent);
             }
         }
 
         // OUT OF SPEC - It is invalid for a credential to indicate it is backed up
         // but not that it is elligible for backup
         if data.authenticator_data.backup_state && !cred.backup_eligible {
-            error!("Credential indicates it is backed up, but has not declared valid backup elligibility");
+            error!("Credential indicates it is backed up, but has not declared valid backup eligibility");
             return Err(WebauthnError::CredentialMayNotBeHardwareBound);
         }
 

--- a/webauthn-rs-core/src/error.rs
+++ b/webauthn-rs-core/src/error.rs
@@ -243,8 +243,8 @@ pub enum WebauthnError {
     #[error("The provided call back failed to allow reporting the credential failure")]
     CredentialCompromiseReportFailure,
 
-    #[error("The backup (passkey) elligibility of this device has changed, meaning it must be re-enrolled for security validation")]
-    CredentialBackupElligibilityInconsistent,
+    #[error("The backup (passkey) eligibility of this device has changed, meaning it must be re-enrolled for security validation")]
+    CredentialBackupEligibilityInconsistent,
 
     #[error("The trust path could not be established")]
     TrustFailure,

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -272,7 +272,7 @@ impl Eq for AttestedPasskey {}
 #[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
 impl PartialOrd for AttestedPasskey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cred.cred_id.cmp(&other.cred.cred_id))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
The word `elligibility` is actually spelled with one `l`: `eligibility`

I came across this by reading an error message in another project and found out that it actually came from this code.

This PR fixes the spelling. The only thing I was not quite sure about was changing the error constant, but this crate is still 0.y.z, thus breaking changes are allowed according to semver.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)

