### PR TITLE
Uniquely ID softtokens

### DIFF
--- a/fido-mds/src/lib.rs
+++ b/fido-mds/src/lib.rs
@@ -29,10 +29,10 @@ use crate::mds::AuthenticatorTransport;
 use crate::mds::FidoDevice as RawFidoDevice;
 use crate::mds::FidoMds as RawFidoMds;
 use crate::mds::MetadataStatement as RawMetadataStatement;
+use crate::mds::MultiDeviceCredentialSupport;
 use crate::mds::StatusReport as RawStatusReport;
 use crate::mds::UserVerificationMethod as RawUserVerificationMethod;
 use crate::mds::VerificationMethodAndCombinations;
-use crate::mds::MultiDeviceCredentialSupport;
 use crate::mds::{
     AttestationType, AuthenticationAlgorithm, AuthenticatorGetInfo, BiometricAccuracyDescriptor,
     CodeAccuracyDescriptor, EcdaaAnchor, ExtensionDescriptor, KeyProtection,

--- a/fido-mds/src/mds.rs
+++ b/fido-mds/src/mds.rs
@@ -580,7 +580,6 @@ impl fmt::Display for MultiDeviceCredentialSupport {
     }
 }
 
-
 /// The output of authenticatorGetInfo. Some fields are hidden as they are duplicated
 /// in the metadata statement.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -77,7 +77,7 @@ webauthn-rs-core = { workspace = true, optional = true }
 
 tracing.workspace = true
 url.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 serde_json.workspace = true
 nom.workspace = true
 serde_cbor_2.workspace = true


### PR DESCRIPTION
If we use two softtokens in a single test, openssl can't handle this as it id's CA's by subject DN, and our previous DN's were always the same between two softtokens.

This adds a UUID to the softtoken CA DN so that openssl can resolve this properly in tests. 

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
