### PR TITLE
20250906 drop openssl kiwi edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ members = [
 exclude = ["compat_tester/webauthn-rs-demo-wasm", "tutorial/wasm"]
 
 [patch.crates-io]
-crypto-glue = { path = "../crypto-glue" }
-# crypto-glue = { git = "https://github.com/kanidm/crypto-glue.git", branch = "6.0-webauthn-rs" }
+# crypto-glue = { path = "../crypto-glue" }
+crypto-glue = { git = "https://github.com/kanidm/crypto-glue.git", branch = "6.0-webauthn-rs" }
 
 [workspace.dependencies]
 # These are in release/dependency order.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ members = [
 exclude = ["compat_tester/webauthn-rs-demo-wasm", "tutorial/wasm"]
 
 [patch.crates-io]
-# crypto-glue = { path = "../crypto-glue" }
-crypto-glue = { git = "https://github.com/kanidm/crypto-glue.git", branch = "6.0-webauthn-rs" }
+crypto-glue = { path = "../crypto-glue" }
+# crypto-glue = { git = "https://github.com/kanidm/crypto-glue.git", branch = "6.0-webauthn-rs" }
 
 [workspace.dependencies]
 # These are in release/dependency order.

--- a/sshkey-attest/Cargo.toml
+++ b/sshkey-attest/Cargo.toml
@@ -23,7 +23,6 @@ base64.workspace = true
 base64urlsafedata.workspace = true
 crypto-glue.workspace = true
 nom.workspace = true
-openssl.workspace = true
 serde.workspace = true
 serde_cbor_2.workspace = true
 sshkeys = { version = "0.3.3", features = ["serde"] }

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -33,6 +33,7 @@ bluetooth = ["dep:btleplug", "ctap2"]
 cable = [
     "dep:btleplug",
     "crypto",
+    "crypto_openssl",
     "ctap2",
     "dep:hex",
     "dep:tokio",
@@ -130,6 +131,9 @@ clap.workspace = true
 tokio.workspace = true
 tempfile = { version = "3.3.0" }
 hex = { workspace = true }
+
+# For doc tests
+openssl = { workspace = true }
 
 # cable_tunnel - used for connecting to Bluetooth HCI controller over serial
 serialport = { version = "4.2.0" }

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -20,7 +20,8 @@ ui-cli = ["dep:rpassword"]
 # Add QR code support for `UiCallback`, useful with `cable` feature
 qrcode = ["dep:qrcode", "ui-cli"]
 
-crypto = ["dep:openssl", "dep:openssl-sys", "dep:webauthn-rs-core"]
+crypto_openssl = ["dep:openssl", "dep:openssl-sys", "dep:webauthn-rs-core"]
+crypto = ["dep:webauthn-rs-core"]
 
 # Authenticator transports
 mozilla = ["dep:authenticator", "dep:rpassword"]

--- a/webauthn-authenticator-rs/build.rs
+++ b/webauthn-authenticator-rs/build.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "crypto")]
+#[cfg(feature = "crypto_openssl")]
 mod crypto {
     pub fn test_openssl() {
         use std::env;
@@ -33,6 +33,6 @@ OpenSSL version string: {version}
 }
 
 fn main() {
-    #[cfg(feature = "crypto")]
+    #[cfg(feature = "crypto_openssl")]
     crypto::test_openssl();
 }

--- a/webauthn-authenticator-rs/src/crypto.rs
+++ b/webauthn-authenticator-rs/src/crypto.rs
@@ -5,22 +5,17 @@ use crate::stubs::*;
 #[cfg(any(doc, feature = "cable"))]
 use openssl::{
     bn::BigNumContext,
-    ec::{EcKeyRef, EcPoint, EcPointRef, PointConversionForm},
-};
-use openssl::{
-    md::Md,
-    pkey::Id,
-    pkey_ctx::PkeyCtx,
-    symm::{Cipher, Crypter, Mode},
-};
-
-#[cfg(any(doc, feature = "cable"))]
-use openssl::{
-    ec::{EcGroup, EcKey},
+    ec::{EcGroup, EcKey, EcKeyRef, EcPoint, EcPointRef, PointConversionForm},
     pkey::{Private, Public},
 };
 
 use crypto_glue::{
+    aes256,
+    aes256cbc::{
+        Aes256CbcDec, Aes256CbcEnc, Aes256CbcIv, BlockDecryptMut, BlockEncryptMut, KeyIvInit,
+    },
+    block_padding::NoPadding,
+    hkdf_s256::HkdfSha256,
     s256::{Sha256, Sha256Output},
     traits::Digest,
 };
@@ -46,14 +41,19 @@ pub fn compute_sha256_2(a: &[u8], b: &[u8]) -> Sha256Output {
 ///
 /// `plaintext.len()` must be a multiple of the cipher's blocksize.
 pub fn encrypt(key: &[u8], iv: Option<&[u8]>, plaintext: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
-    let cipher = Cipher::aes_256_cbc();
-    let mut ct = vec![0; plaintext.len() + cipher.block_size()];
-    let mut c = Crypter::new(cipher, Mode::Encrypt, key, iv)?;
-    c.pad(false);
-    let l = c.update(plaintext, &mut ct)?;
-    let l = l + c.finalize(&mut ct[l..])?;
-    ct.truncate(l);
-    Ok(ct)
+    let iv = if let Some(iv) = iv {
+        Aes256CbcIv::clone_from_slice(iv)
+    } else {
+        // Zero IV.
+        Aes256CbcIv::default()
+    };
+
+    let key = aes256::key_from_slice(key).expect("Invalid Key");
+    let enc = Aes256CbcEnc::new(&key, &iv);
+
+    let ciphertext = enc.encrypt_padded_vec_mut::<NoPadding>(plaintext);
+
+    Ok(ciphertext)
 }
 
 /// Decrypts some data using AES-256-CBC, with no padding.
@@ -62,23 +62,21 @@ pub fn decrypt(
     iv: Option<&[u8]>,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, WebauthnCError> {
-    let cipher = Cipher::aes_256_cbc();
-    if ciphertext.len() % cipher.block_size() != 0 {
-        error!(
-            "ciphertext length {} is not a multiple of {} bytes",
-            ciphertext.len(),
-            cipher.block_size()
-        );
-        return Err(WebauthnCError::Internal);
-    }
+    let iv = if let Some(iv) = iv {
+        Aes256CbcIv::clone_from_slice(iv)
+    } else {
+        // Zero IV.
+        Aes256CbcIv::default()
+    };
 
-    let mut pt = vec![0; ciphertext.len() + cipher.block_size()];
-    let mut c = Crypter::new(cipher, Mode::Decrypt, key, iv)?;
-    c.pad(false);
-    let l = c.update(ciphertext, &mut pt)?;
-    let l = l + c.finalize(&mut pt[l..])?;
-    pt.truncate(l);
-    Ok(pt)
+    let key = aes256::key_from_slice(key).expect("Invalid Key");
+    let enc = Aes256CbcDec::new(&key, &iv);
+
+    let plaintext = enc
+        .decrypt_padded_vec_mut::<NoPadding>(ciphertext)
+        .expect("decrypt failure");
+
+    Ok(plaintext)
 }
 
 pub fn hkdf_sha_256(
@@ -87,15 +85,13 @@ pub fn hkdf_sha_256(
     info: Option<&[u8]>,
     output: &mut [u8],
 ) -> Result<(), WebauthnCError> {
-    let mut ctx = PkeyCtx::new_id(Id::HKDF)?;
-    ctx.derive_init()?;
-    ctx.set_hkdf_md(Md::sha256())?;
-    ctx.set_hkdf_salt(salt)?;
-    ctx.set_hkdf_key(ikm)?;
-    if let Some(info) = info {
-        ctx.add_hkdf_info(info)?;
-    }
-    ctx.derive(Some(output))?;
+    let hk = HkdfSha256::new(Some(salt), ikm);
+
+    let empty: &[u8] = &[];
+
+    let info = info.unwrap_or(empty);
+
+    hk.expand(info, output).expect("Invalid key output");
     Ok(())
 }
 

--- a/webauthn-authenticator-rs/src/crypto.rs
+++ b/webauthn-authenticator-rs/src/crypto.rs
@@ -11,7 +11,6 @@ use openssl::{
     md::Md,
     pkey::Id,
     pkey_ctx::PkeyCtx,
-    sha::Sha256,
     symm::{Cipher, Crypter, Mode},
 };
 
@@ -21,23 +20,26 @@ use openssl::{
     pkey::{Private, Public},
 };
 
+use crypto_glue::{
+    s256::{Sha256, Sha256Output},
+    traits::Digest,
+};
+
 use crate::error::WebauthnCError;
 
-pub type SHA256Hash = [u8; 32];
-
-pub fn compute_sha256(data: &[u8]) -> SHA256Hash {
+pub fn compute_sha256(data: &[u8]) -> Sha256Output {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    hasher.finish()
+    hasher.finalize()
 }
 
 #[cfg(feature = "cable")]
 /// Computes the SHA256 of `a || b`.
-pub fn compute_sha256_2(a: &[u8], b: &[u8]) -> SHA256Hash {
+pub fn compute_sha256_2(a: &[u8], b: &[u8]) -> Sha256Output {
     let mut hasher = Sha256::new();
     hasher.update(a);
     hasher.update(b);
-    hasher.finish()
+    hasher.finalize()
 }
 
 /// Encrypts some data using AES-256-CBC, with no padding.

--- a/webauthn-authenticator-rs/src/ctap2/ctap20.rs
+++ b/webauthn-authenticator-rs/src/ctap2/ctap20.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug, mem::size_of};
 
+use super::internal::CtapAuthenticatorVersion;
 #[cfg(feature = "ctap2-management")]
 use crate::util::check_pin;
 use crate::{
@@ -8,13 +9,11 @@ use crate::{
     error::{CtapError, WebauthnCError},
     transport::Token,
     ui::UiCallback,
-    SHA256Hash, BASE64_ENGINE,
+    BASE64_ENGINE,
 };
-
 use base64::Engine;
 use base64urlsafedata::Base64UrlSafeData;
 use futures::executor::block_on;
-
 use webauthn_rs_proto::{
     AuthenticationExtensionsClientOutputs, AuthenticatorAssertionResponseRaw,
     AuthenticatorAttestationResponseRaw, PubKeyCredParams, PublicKeyCredential,
@@ -22,7 +21,7 @@ use webauthn_rs_proto::{
     UserVerificationPolicy,
 };
 
-use super::internal::CtapAuthenticatorVersion;
+use crypto_glue::s256::Sha256Output;
 
 #[derive(Debug, Clone)]
 pub(super) enum AuthToken {
@@ -499,7 +498,7 @@ impl<'a, T: Token, U: UiCallback> Ctap20Authenticator<'a, T, U> {
         }
 
         let mc = MakeCredentialRequest {
-            client_data_hash: vec![0; size_of::<SHA256Hash>()],
+            client_data_hash: vec![0; size_of::<Sha256Output>()],
             rp: RelyingParty {
                 id: "SELECTION".to_string(),
                 name: "SELECTION".to_string(),

--- a/webauthn-authenticator-rs/src/ctap2/ctap21_cred.rs
+++ b/webauthn-authenticator-rs/src/ctap2/ctap21_cred.rs
@@ -11,7 +11,6 @@ use crate::ui::UiCallback;
 
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2-management"))]
 use crate::{
-    crypto::SHA256Hash,
     ctap2::{
         commands::{
             CredSubCommand, CredentialManagementRequestTrait, CredentialManagementResponse,
@@ -24,6 +23,9 @@ use crate::{
     error::{CtapError, WebauthnCError},
     transport::Token,
 };
+
+#[cfg(any(all(doc, not(doctest)), feature = "ctap2-management"))]
+use crypto_glue::s256::Sha256Output;
 
 /// Trait to provide a [CredentialManagementAuthenticator] implementation.
 pub trait CredentialManagementAuthenticatorInfo<U: UiCallback>: Sync + Send {
@@ -174,7 +176,7 @@ pub trait CredentialManagementAuthenticator {
     /// feature.
     async fn enumerate_credentials_by_hash(
         &mut self,
-        rp_id_hash: SHA256Hash,
+        rp_id_hash: Sha256Output,
     ) -> Result<Vec<DiscoverableCredential>, WebauthnCError>;
 
     /// Enumerates all discoverable credentials on the authenticator for a
@@ -287,7 +289,7 @@ where
 
     async fn enumerate_credentials_by_hash(
         &mut self,
-        rp_id_hash: SHA256Hash,
+        rp_id_hash: Sha256Output,
     ) -> Result<Vec<DiscoverableCredential>, WebauthnCError> {
         self.check_credential_management_support()?;
         enumerate_credentials_impl(self, CredSubCommand::EnumerateCredentialsBegin(rp_id_hash))

--- a/webauthn-authenticator-rs/src/ctap2/pin_uv.rs
+++ b/webauthn-authenticator-rs/src/ctap2/pin_uv.rs
@@ -293,6 +293,7 @@ impl PinUvPlatformInterfaceProtocol for PinUvPlatformInterfaceProtocolOne {
         // Return the first 16 bytes of the result of computing HMAC-SHA-256
         // with the given key and message.
         let key = hmac_s256::key_from_slice(key).expect("Invaid Key");
+
         let mut hmac = HmacSha256::new(&key);
         hmac.update(message);
         let mut output = hmac.finalize().into_bytes().to_vec();

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -146,7 +146,7 @@ impl From<crate::transport::iso7816::Error> for WebauthnCError {
     }
 }
 
-#[cfg(feature = "crypto")]
+#[cfg(feature = "crypto_openssl")]
 impl From<openssl::error::ErrorStack> for WebauthnCError {
     fn from(v: openssl::error::ErrorStack) -> Self {
         Self::OpenSSL(v.to_string())

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -106,6 +106,12 @@ pub enum WebauthnCError {
 
     #[error("Unable to perform COSE key operation or transformation")]
     CryptographyCose,
+
+    #[error("An ecdsa private key contained invalid sec1 bytes")]
+    CryptographyEcdsaSec1Invalid,
+
+    #[error("Unable to perform ecdsa signature")]
+    CryptographyEcdsaSignature,
 }
 
 #[cfg(feature = "nfc")]

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -110,7 +110,7 @@ pub enum WebauthnCError {
     #[error("An ECDSA private key contained invalid SEC1 bytes")]
     CryptographyEcdsaSec1Invalid,
 
-    #[error("Unable to perform ecdsa signature")]
+    #[error("Unable to perform ECDSA signature")]
     CryptographyEcdsaSignature,
 }
 

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -107,7 +107,7 @@ pub enum WebauthnCError {
     #[error("Unable to perform COSE key operation or transformation")]
     CryptographyCose,
 
-    #[error("An ecdsa private key contained invalid sec1 bytes")]
+    #[error("An ECDSA private key contained invalid SEC1 bytes")]
     CryptographyEcdsaSec1Invalid,
 
     #[error("Unable to perform ecdsa signature")]

--- a/webauthn-authenticator-rs/src/error.rs
+++ b/webauthn-authenticator-rs/src/error.rs
@@ -112,6 +112,15 @@ pub enum WebauthnCError {
 
     #[error("Unable to perform ECDSA signature")]
     CryptographyEcdsaSignature,
+
+    #[error("Invalid HMAC Key")]
+    CryptographyHmacKey,
+
+    #[error("Unable to decrypt cipher text")]
+    CryptographyAes256CbcDecrypt,
+
+    #[error("Unable to expand hkdf key")]
+    CryptographyHkdfExpand,
 }
 
 #[cfg(feature = "nfc")]

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -181,9 +181,6 @@ pub use crate::authenticator_hashed::{
     perform_auth_with_request, perform_register_with_request, AuthenticatorBackendHashedClientData,
 };
 
-#[cfg(any(all(doc, not(doctest)), feature = "crypto"))]
-pub use crate::crypto::SHA256Hash;
-
 pub struct WebauthnAuthenticator<T>
 where
     T: AuthenticatorBackend,

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -92,7 +92,7 @@
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::unwrap_used)]
-// #![deny(clippy::expect_used)]
+#![deny(clippy::expect_used)]
 #![deny(clippy::panic)]
 #![deny(clippy::unreachable)]
 #![deny(clippy::await_holding_lock)]

--- a/webauthn-authenticator-rs/src/softpasskey.rs
+++ b/webauthn-authenticator-rs/src/softpasskey.rs
@@ -311,7 +311,7 @@ impl AuthenticatorBackendHashedClientData for SoftPasskey {
         // Do the signature
         let signature = signer
             .try_sign(&verification_data)
-            .map(|sig: EcdsaP256Signature| sig.to_vec())
+            .map(|sig: EcdsaP256Signature| sig.to_der().to_bytes().into())
             .map_err(|_| WebauthnCError::CryptographyEcdsaSignature)?;
 
         let mut attest_map = BTreeMap::new();
@@ -498,7 +498,7 @@ impl U2FToken for SoftPasskey {
 
         let signature = signer
             .try_sign(&verification_data)
-            .map(|sig: EcdsaP256Signature| sig.to_vec())
+            .map(|sig: EcdsaP256Signature| sig.to_der().to_bytes().into())
             .map_err(|_| WebauthnCError::CryptographyEcdsaSignature)?;
 
         Ok(U2FSignData {

--- a/webauthn-authenticator-rs/src/softpasskey.rs
+++ b/webauthn-authenticator-rs/src/softpasskey.rs
@@ -2,18 +2,23 @@
 use crate::stubs::*;
 
 use crate::authenticator_hashed::AuthenticatorBackendHashedClientData;
-use crate::crypto::{compute_sha256, get_group};
+use crate::crypto::compute_sha256;
 use crate::error::WebauthnCError;
 use crate::BASE64_ENGINE;
 use base64::Engine;
-use openssl::{bn, ec, hash, pkey, rand, sign};
+use base64urlsafedata::Base64UrlSafeData;
+use crypto_glue::{
+    ecdsa_p256::{
+        self, EcdsaP256PrivateKey, EcdsaP256PublicEncodedPoint, EcdsaP256Signature,
+        EcdsaP256SigningKey,
+    },
+    rand::{self, RngCore},
+    traits::{Signer, Zeroizing},
+};
 use serde_cbor_2::value::Value;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::iter;
-
-use base64urlsafedata::Base64UrlSafeData;
-
 use webauthn_rs_proto::{
     AllowCredentials, AuthenticationExtensionsClientOutputs, AuthenticatorAssertionResponseRaw,
     AuthenticatorAttachment, AuthenticatorAttestationResponseRaw, PublicKeyCredential,
@@ -22,7 +27,7 @@ use webauthn_rs_proto::{
 };
 
 pub struct SoftPasskey {
-    tokens: HashMap<Vec<u8>, Vec<u8>>,
+    tokens: HashMap<Vec<u8>, Zeroizing<Vec<u8>>>,
     counter: u32,
     falsify_uv: bool,
 }
@@ -203,48 +208,35 @@ impl AuthenticatorBackendHashedClientData for SoftPasskey {
         }
 
         // Generate a random credential id
-        let mut key_handle: Vec<u8> = Vec::with_capacity(32);
-        key_handle.resize_with(32, Default::default);
-        rand::rand_bytes(key_handle.as_mut_slice())?;
+        let mut key_handle: Vec<u8> = vec![0; 32];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut key_handle);
 
         // Create a new key.
-        let ecgroup = get_group()?;
-
-        let eckey = ec::EcKey::generate(&ecgroup)?;
+        let eckey = ecdsa_p256::new_key();
 
         // Extract the public x and y coords.
-        let ecpub_points = eckey.public_key();
+        let ecpublic = eckey.public_key();
 
-        let mut bnctx = bn::BigNumContext::new()?;
+        let encoded_point = EcdsaP256PublicEncodedPoint::from(ecpublic);
 
-        let mut xbn = bn::BigNum::new()?;
+        let public_key_x = encoded_point
+            .x()
+            .map(|bytes| bytes.to_vec())
+            .unwrap_or_default();
 
-        let mut ybn = bn::BigNum::new()?;
-
-        ecpub_points.affine_coordinates_gfp(&ecgroup, &mut xbn, &mut ybn, &mut bnctx)?;
-
-        let mut public_key_x = Vec::with_capacity(32);
-        let mut public_key_y = Vec::with_capacity(32);
-
-        public_key_x.resize(32, 0);
-        public_key_y.resize(32, 0);
-
-        let xbnv = xbn.to_vec();
-        let ybnv = ybn.to_vec();
-
-        let (_pad, x_fill) = public_key_x.split_at_mut(32 - xbnv.len());
-        x_fill.copy_from_slice(&xbnv);
-
-        let (_pad, y_fill) = public_key_y.split_at_mut(32 - ybnv.len());
-        y_fill.copy_from_slice(&ybnv);
+        let public_key_y = encoded_point
+            .y()
+            .map(|bytes| bytes.to_vec())
+            .unwrap_or_default();
 
         // Extract the DER cert for later
-        let ecpriv_der = eckey.private_key_to_der()?;
+        let ecpriv_der = eckey
+            .to_sec1_der()
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSec1Invalid)?;
 
         // Now setup to sign.
-        let pkey = pkey::PKey::from_ec_key(eckey)?;
-
-        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &pkey)?;
+        let signer = EcdsaP256SigningKey::from(&eckey);
 
         // =====
 
@@ -318,8 +310,9 @@ impl AuthenticatorBackendHashedClientData for SoftPasskey {
 
         // Do the signature
         let signature = signer
-            .update(verification_data.as_slice())
-            .and_then(|_| signer.sign_to_vec())?;
+            .try_sign(&verification_data)
+            .map(|sig: EcdsaP256Signature| sig.to_vec())
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSignature)?;
 
         let mut attest_map = BTreeMap::new();
 
@@ -480,11 +473,10 @@ impl U2FToken for SoftPasskey {
 
         debug!("Using -> {:?}", key_handle);
 
-        let eckey = ec::EcKey::private_key_from_der(pkder.as_slice())?;
+        let eckey = EcdsaP256PrivateKey::from_sec1_der(pkder.as_slice())
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSec1Invalid)?;
 
-        let pkey = pkey::PKey::from_ec_key(eckey)?;
-
-        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &pkey)?;
+        let signer = EcdsaP256SigningKey::from(&eckey);
 
         // Increment the counter.
         self.counter += 1;
@@ -505,8 +497,9 @@ impl U2FToken for SoftPasskey {
             .collect();
 
         let signature = signer
-            .update(verification_data.as_slice())
-            .and_then(|_| signer.sign_to_vec())?;
+            .try_sign(&verification_data)
+            .map(|sig: EcdsaP256Signature| sig.to_vec())
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSignature)?;
 
         Ok(U2FSignData {
             key_handle,

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -740,7 +740,7 @@ impl U2FToken for SoftToken {
         trace!("Signing: {:?}", verification_data.as_slice());
         let signature = signer
             .try_sign(&verification_data)
-            .map(|sig: EcdsaP256Signature| sig.to_vec())
+            .map(|sig: EcdsaP256Signature| sig.to_der().to_bytes().into())
             .map_err(|_| WebauthnCError::CryptographyEcdsaSignature)?;
 
         Ok(U2FSignData {

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -3,17 +3,25 @@ use crate::stubs::*;
 
 use crate::{
     authenticator_hashed::AuthenticatorBackendHashedClientData,
-    crypto::{compute_sha256, get_group},
+    crypto::compute_sha256,
     ctap2::commands::{value_to_vec_u8, GetInfoResponse},
     error::WebauthnCError,
     BASE64_ENGINE,
 };
 use base64::Engine;
+use crypto_glue::{
+    ecdsa_p256::{
+        self, EcdsaP256PrivateKey, EcdsaP256PublicEncodedPoint, EcdsaP256Signature,
+        EcdsaP256SigningKey,
+    },
+    rand::{self, RngCore},
+    traits::{Signer, Zeroizing},
+};
 use openssl::x509::{
     extension::{AuthorityKeyIdentifier, BasicConstraints, KeyUsage, SubjectKeyIdentifier},
     X509NameBuilder, X509Ref, X509ReqBuilder, X509,
 };
-use openssl::{asn1, bn, ec, hash, pkey, rand, sign};
+use openssl::{asn1, bn, ec, hash, nid, pkey, sign};
 use serde::{Deserialize, Serialize};
 use serde_cbor_2::value::Value;
 use std::collections::HashMap;
@@ -46,7 +54,7 @@ pub struct SoftToken {
     intermediate_key: pkey::PKey<pkey::Private>,
     #[serde(with = "X509Def")]
     intermediate_cert: X509,
-    tokens: HashMap<Vec<u8>, Vec<u8>>,
+    tokens: HashMap<Vec<u8>, Zeroizing<Vec<u8>>>,
     counter: u32,
     falsify_uv: bool,
 }
@@ -91,7 +99,7 @@ impl From<X509Def> for X509 {
 }
 
 fn build_ca(unique_id: Uuid) -> Result<(pkey::PKey<pkey::Private>, X509), WebauthnCError> {
-    let ecgroup = get_group()?;
+    let ecgroup = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1)?;
     let eckey = ec::EcKey::generate(&ecgroup)?;
     let ca_key = pkey::PKey::from_ec_key(eckey)?;
     let mut x509_name = X509NameBuilder::new()?;
@@ -144,7 +152,7 @@ fn build_intermediate(
     ca_key: &pkey::PKeyRef<pkey::Private>,
     ca_cert: &X509Ref,
 ) -> Result<(pkey::PKey<pkey::Private>, X509), WebauthnCError> {
-    let ecgroup = get_group()?;
+    let ecgroup = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1)?;
     let eckey = ec::EcKey::generate(&ecgroup)?;
     let int_key = pkey::PKey::from_ec_key(eckey)?;
 
@@ -447,43 +455,32 @@ impl AuthenticatorBackendHashedClientData for SoftToken {
         }
 
         // Generate a random credential id
-        let mut key_handle: Vec<u8> = Vec::with_capacity(32);
-        key_handle.resize_with(32, Default::default);
-        rand::rand_bytes(key_handle.as_mut_slice())?;
+        let mut key_handle: Vec<u8> = vec![0; 32];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut key_handle);
 
         // Create a new key.
-        let ecgroup = get_group()?;
-
-        let eckey = ec::EcKey::generate(&ecgroup)?;
+        let eckey = ecdsa_p256::new_key();
 
         // Extract the public x and y coords.
-        let ecpub_points = eckey.public_key();
+        let ecpublic = eckey.public_key();
 
-        let mut bnctx = bn::BigNumContext::new()?;
+        let encoded_point = EcdsaP256PublicEncodedPoint::from(ecpublic);
 
-        let mut xbn = bn::BigNum::new()?;
+        let public_key_x = encoded_point
+            .x()
+            .map(|bytes| bytes.to_vec())
+            .unwrap_or_default();
 
-        let mut ybn = bn::BigNum::new()?;
-
-        ecpub_points.affine_coordinates_gfp(&ecgroup, &mut xbn, &mut ybn, &mut bnctx)?;
-
-        let mut public_key_x = Vec::with_capacity(32);
-        let mut public_key_y = Vec::with_capacity(32);
-
-        public_key_x.resize(32, 0);
-        public_key_y.resize(32, 0);
-
-        let xbnv = xbn.to_vec();
-        let ybnv = ybn.to_vec();
-
-        let (_pad, x_fill) = public_key_x.split_at_mut(32 - xbnv.len());
-        x_fill.copy_from_slice(&xbnv);
-
-        let (_pad, y_fill) = public_key_y.split_at_mut(32 - ybnv.len());
-        y_fill.copy_from_slice(&ybnv);
+        let public_key_y = encoded_point
+            .y()
+            .map(|bytes| bytes.to_vec())
+            .unwrap_or_default();
 
         // Extract the DER cert for later
-        let ecpriv_der = eckey.private_key_to_der()?;
+        let ecpriv_der = eckey
+            .to_sec1_der()
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSec1Invalid)?;
 
         // =====
 
@@ -717,11 +714,10 @@ impl U2FToken for SoftToken {
 
         debug!("Using -> {:?}", key_handle);
 
-        let eckey = ec::EcKey::private_key_from_der(pkder.as_slice())?;
+        let eckey = EcdsaP256PrivateKey::from_sec1_der(pkder.as_slice())
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSec1Invalid)?;
 
-        let pkey = pkey::PKey::from_ec_key(eckey)?;
-
-        let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &pkey)?;
+        let signer = EcdsaP256SigningKey::from(&eckey);
 
         // Increment the counter.
         self.counter += 1;
@@ -743,8 +739,9 @@ impl U2FToken for SoftToken {
 
         trace!("Signing: {:?}", verification_data.as_slice());
         let signature = signer
-            .update(verification_data.as_slice())
-            .and_then(|_| signer.sign_to_vec())?;
+            .try_sign(&verification_data)
+            .map(|sig: EcdsaP256Signature| sig.to_vec())
+            .map_err(|_| WebauthnCError::CryptographyEcdsaSignature)?;
 
         Ok(U2FSignData {
             key_handle,

--- a/webauthn-rs-core/src/interface.rs
+++ b/webauthn-rs-core/src/interface.rs
@@ -202,23 +202,6 @@ impl TryFrom<&COSEEC2Key> for EcdsaP256PublicKey {
     }
 }
 
-/*
-impl TryFrom<&COSEEC2Key> for ec::EcKey<pkey::Public> {
-    type Error = openssl::error::ErrorStack;
-
-    fn try_from(k: &COSEEC2Key) -> Result<Self, Self::Error> {
-        let group = ec::EcGroup::from_curve_name((&k.curve).into())?;
-        let mut ctx = bn::BigNumContext::new()?;
-        let mut point = ec::EcPoint::new(&group)?;
-        let x = bn::BigNum::from_slice(k.x.as_slice())?;
-        let y = bn::BigNum::from_slice(k.y.as_slice())?;
-        point.set_affine_coordinates_gfp(&group, &x, &y, &mut ctx)?;
-
-        ec::EcKey::from_public_key(&group, &point)
-    }
-}
-*/
-
 /// A COSE Elliptic Curve Public Key. This is generally the provided credential
 /// that an authenticator registers, and is used to authenticate the user.
 /// You will likely never need to interact with this value, as it is part of the Credential


### PR DESCRIPTION
Another phase of openssl changes - this focuses on authenticator-rs, mostly the interfaces that are used in ctap. CABLE still relies on openssl for now. 

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
