### PR TITLE
CredProps uses a boolean with three states

### DIFF
--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -289,7 +289,7 @@ pub struct CredProps {
     /// signal.
     ///
     /// Note that this extension is UNSIGNED and may have been altered by page javascript.
-    pub rk: bool,
+    pub rk: Option<bool>,
 }
 
 /// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientoutputs>
@@ -335,7 +335,7 @@ impl From<web_sys::AuthenticationExtensionsClientOutputs> for RegistrationExtens
                 js_sys::Reflect::get(&cred_props_struct, &"rk".into())
                     .ok()
                     .and_then(|jv| jv.as_bool())
-                    .map(|rk| CredProps { rk })
+                    .map(|rk| CredProps { rk: Some(rk) })
             });
 
         let hmac_secret = js_sys::Reflect::get(&ext, &"hmac-secret".into())


### PR DESCRIPTION
the credProps extension uses a boolean with an optional so that in the non-present (none) cases, it represents "the inability to determine key residency during the registration".

Chromium now decided that despite having direct hardware access to a yubikey, where CTAP2 operations are unambiguous about the rk state, that now my key somehow is "nebulously" in a state of both rk and not rk at the same time.

Fixes https://github.com/kanidm/kanidm/issues/3969

- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
