### PR TITLE
cable_tunnel: Port to RustCrypto (#499)

### DIFF
--- a/webauthn-authenticator-rs/examples/cable_tunnel.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel.rs
@@ -11,7 +11,7 @@ use bluetooth_hci::{
     BdAddr, BdAddrType,
 };
 use clap::{ArgGroup, Parser};
-use crypto_glue::rand::{RngCore as _, rngs::ThreadRng};
+use crypto_glue::rand::{rngs::ThreadRng, RngCore as _};
 use futures::StreamExt;
 use serialport::FlowControl;
 use serialport_hci::{

--- a/webauthn-authenticator-rs/examples/cable_tunnel.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel.rs
@@ -11,8 +11,8 @@ use bluetooth_hci::{
     BdAddr, BdAddrType,
 };
 use clap::{ArgGroup, Parser};
+use crypto_glue::rand::{rngs::ThreadRng, Rng};
 use futures::StreamExt;
-use openssl::rand::rand_bytes;
 use serialport::FlowControl;
 use serialport_hci::{
     vendor::none::{Event, Vendor},
@@ -169,7 +169,8 @@ impl Advertiser for SerialHciAdvertiser {
         };
         let mut addr = [0u8; 6];
         addr[5] = 0xc0;
-        rand_bytes(&mut addr[..5])?;
+        let mut rng = ThreadRng::default();
+        rng.fill_bytes(&mut addr[..5])?;
 
         self.hci.le_set_random_address(BdAddr(addr)).unwrap();
         let _ = self.read();

--- a/webauthn-authenticator-rs/examples/cable_tunnel.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel.rs
@@ -11,7 +11,7 @@ use bluetooth_hci::{
     BdAddr, BdAddrType,
 };
 use clap::{ArgGroup, Parser};
-use crypto_glue::rand::{rngs::ThreadRng, Rng};
+use crypto_glue::rand::{RngCore as _, rngs::ThreadRng};
 use futures::StreamExt;
 use serialport::FlowControl;
 use serialport_hci::{
@@ -170,7 +170,7 @@ impl Advertiser for SerialHciAdvertiser {
         let mut addr = [0u8; 6];
         addr[5] = 0xc0;
         let mut rng = ThreadRng::default();
-        rng.fill_bytes(&mut addr[..5])?;
+        rng.try_fill_bytes(&mut addr[..5])?;
 
         self.hci.le_set_random_address(BdAddr(addr)).unwrap();
         let _ = self.read();


### PR DESCRIPTION
Replace `openssl::rand::rand_bytes` with `crypto_glue::rand` (#499).

This currently won't build due to existing breakages in the `6.0-dev-drop-openssl` branch when the `cable` feature is enabled. I'm looking at those in #534. 
