### PR TITLE
Add support for advertising with Bluez

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,13 +159,11 @@ jobs:
       - if: runner.os != 'windows'
         run: |
           sudo apt-get update && \
-          sudo apt-get -y install libudev-dev
+          sudo apt-get -y install libudev-dev libdbus-1-dev
       - if: contains(matrix.features, 'nfc') && runner.os != 'windows'
         run: sudo apt-get -y install libpcsclite-dev
       - if: contains(matrix.features, 'usb') && runner.os != 'windows'
         run: sudo apt-get -y install libusb-1.0-0-dev
-      - if: (contains(matrix.features, 'bluetooth') || contains(matrix.features, 'cable'))  && runner.os != 'windows'
-        run: sudo apt-get -y install libdbus-1-dev
 
       # Don't try to install OpenSSL when there's only the "win10" feature
       # enabled. We should be able to operate without it.

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -138,6 +138,9 @@ bluetooth-hci = { git = "https://github.com/micolous/bluetooth-hci.git", rev = "
 bardecoder = "=0.5.0"
 image = "0.24.9"
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+bluer = { version = "0.17.4", features = ["bluetoothd"] }
+
 [[example]]
 name = "authenticate"
 required-features = ["crypto", "ui-cli"]

--- a/webauthn-authenticator-rs/examples/cable_tunnel.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel.rs
@@ -30,8 +30,8 @@
 //!     --cable-url FIDO:/...
 //! ```
 //!
-//! You can also a cropped screenshot of a caBLE QR code with `--qr-image`, instead of using
-//! `--cable-url`, but this is not very reliable.
+//! You can also try to parse a cropped screenshot of a caBLE QR code with `--qr-image`, instead of
+//! using `--cable-url`, but this is not very reliable.
 //!
 //! [0]: https://github.com/micolous/serialport-hci/blob/main/README.md
 #[macro_use]


### PR DESCRIPTION
Follow-on from #537, for testing #534 (so I want it in both branches to compare).

This adds support for acting as a caBLE authenticator with Bluez on Linux to `cable_tunnel`.

Unfortunately, this means we always pull in `bluer` as a `dev-dependency` on Linux (and thus depend on `libdbus-1-dev`), but that's already a dependency when the `bluetooth` or `cable` features are enabled.

Tested with `webauthn_authenticator_rs`, iOS 26 and Android as an initiator. Android registered OK, but only offered to authenticate with Google Password Manager (there was not even a caBLE option, even with non-RK non-UV). The others worked fine.

- [x] Test with an existing caBLE implementation
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
