### PR TITLE
6.0: Bump MSRV to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [ stable, 1.85.0 ]
+        rust_version: [ stable, 1.88.0 ]
         os:
           - ubuntu-latest
           - windows-latest
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [ stable, 1.85.0 ]
+        rust_version: [ stable, 1.88.0 ]
         features:
           - bluetooth
           - cable
@@ -111,7 +111,7 @@ jobs:
             rust_version: stable
         exclude:
           - os: windows-latest
-            rust_version: 1.79.0
+            rust_version: 1.88.0
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
     "William Brown <william@blackhats.net.au>",
     "Michael Farrell <micolous+git@gmail.com>",
 ]
-rust-version = "1.87"
+rust-version = "1.88"
 edition = "2021"
 repository = "https://github.com/kanidm/webauthn-rs"
 homepage = "https://github.com/kanidm/webauthn-rs"


### PR DESCRIPTION
Needed by `time`. This was applied to `master` in #532.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
