### PR TITLE
6.0: allow expect in webauthn-authenticator-rs, and in all tests

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
+allow-expect-in-tests = true
 allow-unwrap-in-tests = true

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -91,7 +91,8 @@
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
+// TODO: remove expect() calls from examples, cable, mozilla, softtoken, ui-cli, win10
+// #![deny(clippy::expect_used)]
 #![deny(clippy::panic)]
 #![deny(clippy::unreachable)]
 #![deny(clippy::await_holding_lock)]


### PR DESCRIPTION
The `master` branch currently allows `expect()` to be used anywhere, but the 6.0 branch doesn't.

In the longer term, we should fix these.

But denying `expect()` currently triggers CI build failures with certain features enabled (`cable`, `mozilla`, `softtoken`, `ui-cli`, `win10`), which aren't enabled by default.

Some of these uses will be addressed as we rewrite to drop OpenSSL support for #499, but with `clippy` being an early step in CI, additional failures make it impossible to measure progress using the CI build matrix (ie: feature combinations becoming or returning to green).

I've also allowed `expect()` in tests, like `unwrap()` is allowed. Using `expect()` or `unwrap()` gives us stack traces for unexpected errors in tests, so it's much easier to trace how a test broke.

This takes us from 11/35 to 19/35 passing tests.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
