### PR TITLE
6.0: Windows 11 Hello caBLE fixes

### DIFF
--- a/webauthn-authenticator-rs/src/win10/extensions.rs
+++ b/webauthn-authenticator-rs/src/win10/extensions.rs
@@ -246,8 +246,31 @@ pub fn native_to_assertion_extensions(
 ) -> Result<AuthenticationExtensionsClientOutputs, WebauthnCError> {
     let /* mut */ o = AuthenticationExtensionsClientOutputs::default();
 
+    if native.cExtensions == 0 || native.pExtensions.is_null() {
+        return Ok(o);
+    }
+
+    if !native.pExtensions.is_aligned() {
+        // Windows gave us garbage
+        return Err(WebauthnCError::Internal);
+    }
+
+    if native.cExtensions > 0xf {
+        // Too many extensions
+        return Err(WebauthnCError::MessageTooLarge);
+    }
+
     for i in 0..(native.cExtensions as usize) {
-        let extn = unsafe { &*native.pExtensions.add(i) };
+        let extn = unsafe {
+            let p = native.pExtensions.add(i);
+            // This should always be true, unless the start pointer was very high
+            if p.is_null() || !p.is_aligned() {
+                break;
+            }
+
+            &*p
+        };
+
         let win = WinExtensionGetAssertionResponse::try_from(extn)?;
         match win {
             WinExtensionGetAssertionResponse::CredBlob => (),

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -1,12 +1,26 @@
-//! Bindings for Windows 10 WebAuthn API.
+//! Bindings for [Windows Hello WebAuthn API][winhello].
 //!
-//! This API is available in Windows 10 bulid 1903 and later.
+//! This API is available in Windows 10 build 1903 and later.
+//!
+//! Its use is **effectively mandatory** on Windows:
+//!
+//! * Windows attempts to block applications from using transport-level APIs (BTLE, PC/SC and USB
+//!   HID) to directly communicate with FIDO authenticators (unless running as Administrator).
+//!
+//! * This API automatically tunnels WebAuthn API calls made in RDP sessions to the client via a
+//!   virtual channel (currently only supported with Microsoft's RDP client on Windows).
+//!
+//! * This API provides access to synchronised credential managers, via a plugin API available in
+//!   Windows 11 24H4 and later.
 //!
 //! ## API docs
 //!
 //! * [MSDN: WebAuthn API](https://learn.microsoft.com/en-us/windows/win32/api/webauthn/)
-//! * [webauthn.h](github.com/microsoft/webauthn) (describes versions)
-//! * [windows-rs API](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WindowsWebServices/index.html)
+//! * [`webauthn.h`](https://github.com/microsoft/webauthn) (describes versions)
+//! * [`windows-rs` API](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WindowsWebServices/index.html)
+//!
+//! [winhello]: https://learn.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/webauthn-apis
+
 #[cfg(feature = "win10")]
 mod clientdata;
 #[cfg(feature = "win10")]
@@ -60,26 +74,39 @@ use windows::{
 
 use std::slice::from_raw_parts;
 
-/// Authenticator backend for Windows 10 WebAuthn API.
+/// Authenticator backend for Windows Hello WebAuthn API.
 pub struct Win10 {}
 
 impl Default for Win10 {
     fn default() -> Self {
-        unsafe {
-            trace!(
-                "WebAuthNGetApiVersionNumber(): {}",
-                WebAuthNGetApiVersionNumber()
-            );
-            match WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable() {
-                Ok(v) => trace!(
-                    "WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable() = {:?}",
-                    <_ as Into<bool>>::into(v)
-                ),
-                Err(e) => trace!("error requesting platform authenticator: {:?}", e),
-            }
-        }
-
         Self {}
+    }
+}
+
+impl Win10 {
+    /// Returns the Windows WebAuthn API version.
+    ///
+    /// This may change at runtime if connecting to a Windows PC via RDP.
+    ///
+    /// When using RDP, this is the lesser of the host and client's WebAuthn API versions.
+    pub fn api_version() -> u32 {
+        unsafe { WebAuthNGetApiVersionNumber() }
+    }
+
+    /// Returns `true` if the current system's WebAuthn APIs *might* support caBLE authenticators.
+    ///
+    /// This is available in Windows 11, possibly 22H2 and later (but Microsoft doesn't document
+    /// this). Applications should prefer using Windows APIs to support caBLE on systems that
+    /// support it.
+    ///
+    /// This may change at runtime if connecting to a Windows PC via RDP.
+    ///
+    /// This function may return `true` on devices lacks a BTLE radio (needed to complete the caBLE
+    /// handshake).
+    pub fn supports_cable() -> bool {
+        // According to Chromium:
+        // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/win/webauthn_api.cc;l=339-341;drc=83434e88fd49da16e9a21957c564299b37a320af
+        Self::api_version() >= 7
     }
 }
 

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -209,29 +209,41 @@ impl AuthenticatorBackend for Win10 {
         // trace!("got result from WebAuthNAuthenticatorMakeCredential");
         // trace!("{:?}", (*a));
 
-        unsafe {
-            let cred_id = from_raw_parts(a.pbCredentialId, a.cbCredentialId as usize).to_vec();
-            let attesation_object =
-                from_raw_parts(a.pbAttestationObject, a.cbAttestationObject as usize).to_vec();
-            let type_: String = a
-                .pwszFormatType
-                .to_string()
-                .map_err(|_| WebauthnCError::Internal)?;
+        let cred_id = unsafe {
+            if a.pbCredentialId.is_null() || a.cbCredentialId == 0 || a.cbCredentialId > 0xffff {
+                &[]
+            } else {
+                from_raw_parts(a.pbCredentialId, a.cbCredentialId as usize)
+            }
+        };
 
-            Ok(RegisterPublicKeyCredential {
-                id: BASE64_ENGINE.encode(&cred_id),
-                raw_id: cred_id.into(),
-                type_,
-                extensions: native_to_registration_extensions(&a.Extensions)?,
-                response: AuthenticatorAttestationResponseRaw {
-                    attestation_object: attesation_object.into(),
-                    client_data_json: Base64UrlSafeData::from(
-                        clientdata.client_data_json().as_bytes().to_vec(),
-                    ),
-                    transports: Some(native_to_transports(a.dwUsedTransport)),
-                },
-            })
-        }
+        let attestation_object = unsafe {
+            if a.pbAttestationObject.is_null()
+                || a.cbAttestationObject == 0
+                || a.cbAttestationObject > 0xffff
+            {
+                &[]
+            } else {
+                from_raw_parts(a.pbAttestationObject, a.cbAttestationObject as usize)
+            }
+        };
+
+        let type_: String =
+            unsafe { a.pwszFormatType.to_string() }.map_err(|_| WebauthnCError::Internal)?;
+
+        Ok(RegisterPublicKeyCredential {
+            id: BASE64_ENGINE.encode(&cred_id),
+            raw_id: cred_id.into(),
+            type_,
+            extensions: native_to_registration_extensions(&a.Extensions)?,
+            response: AuthenticatorAttestationResponseRaw {
+                attestation_object: attestation_object.into(),
+                client_data_json: Base64UrlSafeData::from(
+                    clientdata.client_data_json().as_bytes().to_vec(),
+                ),
+                transports: Some(native_to_transports(a.dwUsedTransport)),
+            },
+        })
     }
 
     /// Perform an authentication action using Windows WebAuth API.
@@ -331,42 +343,65 @@ impl AuthenticatorBackend for Win10 {
         drop(hwnd);
         // trace!("got result from WebAuthNAuthenticatorGetAssertion");
 
-        unsafe {
-            let user_id = from_raw_parts(a.pbUserId, a.cbUserId as usize).to_vec();
-            let authenticator_data =
-                from_raw_parts(a.pbAuthenticatorData, a.cbAuthenticatorData as usize).to_vec();
-            let signature = from_raw_parts(a.pbSignature, a.cbSignature as usize).to_vec();
-
-            let credential_id =
-                from_raw_parts(a.Credential.pbId, a.Credential.cbId as usize).to_vec();
-            let type_ = a
-                .Credential
-                .pwszCredentialType
-                .to_string()
-                .map_err(|_| WebauthnCError::Internal)?;
-
-            let mut extensions = if a.dwVersion >= 2 {
-                native_to_assertion_extensions(&a.Extensions)?
+        let user_id = unsafe {
+            if a.pbUserId.is_null() || a.cbUserId == 0 || a.cbUserId > 0xffff {
+                None
             } else {
-                Default::default()
-            };
-            extensions.appid = Some(app_id_used.into());
+                Some(from_raw_parts(a.pbUserId, a.cbUserId as usize))
+            }
+        };
 
-            Ok(PublicKeyCredential {
-                id: BASE64_ENGINE.encode(&credential_id),
-                raw_id: credential_id.into(),
-                response: AuthenticatorAssertionResponseRaw {
-                    authenticator_data: authenticator_data.into(),
-                    client_data_json: Base64UrlSafeData::from(
-                        clientdata.client_data_json().as_bytes().to_vec(),
-                    ),
-                    signature: signature.into(),
-                    user_handle: Some(user_id.into()),
-                },
-                type_,
-                extensions,
-            })
-        }
+        let authenticator_data = unsafe {
+            if a.pbAuthenticatorData.is_null()
+                || a.cbAuthenticatorData == 0
+                || a.cbAuthenticatorData > 0xffff
+            {
+                &[]
+            } else {
+                from_raw_parts(a.pbAuthenticatorData, a.cbAuthenticatorData as usize)
+            }
+        };
+
+        let signature = unsafe {
+            if a.pbSignature.is_null() || a.cbSignature == 0 || a.cbSignature > 0xffff {
+                &[]
+            } else {
+                from_raw_parts(a.pbSignature, a.cbSignature as usize)
+            }
+        };
+
+        let cred_id = unsafe {
+            if a.Credential.pbId.is_null() || a.Credential.cbId == 0 || a.Credential.cbId > 0xffff {
+                &[]
+            } else {
+                from_raw_parts(a.Credential.pbId, a.Credential.cbId as usize)
+            }
+        };
+
+        let type_: String = unsafe { a.Credential.pwszCredentialType.to_string() }
+            .map_err(|_| WebauthnCError::Internal)?;
+
+        let mut extensions = if a.dwVersion >= 2 {
+            native_to_assertion_extensions(&a.Extensions)?
+        } else {
+            Default::default()
+        };
+        extensions.appid = Some(app_id_used.into());
+
+        Ok(PublicKeyCredential {
+            id: BASE64_ENGINE.encode(cred_id),
+            raw_id: cred_id.into(),
+            response: AuthenticatorAssertionResponseRaw {
+                authenticator_data: authenticator_data.into(),
+                client_data_json: Base64UrlSafeData::from(
+                    clientdata.client_data_json().as_bytes().to_vec(),
+                ),
+                signature: signature.into(),
+                user_handle: user_id.map(Into::into),
+            },
+            type_,
+            extensions,
+        })
     }
 }
 

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -101,8 +101,8 @@ impl Win10 {
     ///
     /// This may change at runtime if connecting to a Windows PC via RDP.
     ///
-    /// This function may return `true` on devices lacks a BTLE radio (needed to complete the caBLE
-    /// handshake).
+    /// This function may return `true` on devices without a BTLE radio (needed to complete the
+    /// caBLE handshake).
     pub fn supports_cable() -> bool {
         // According to Chromium:
         // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/win/webauthn_api.cc;l=339-341;drc=83434e88fd49da16e9a21957c564299b37a320af


### PR DESCRIPTION
Windows Hello related fixes:

* Fix null pointer dereference when using caBLE via Windows 11 platform APIs (`GetAssertion` returns `pbUserId == NULL`).
* Check a bunch of other pointers from Windows at the C FFI boundary.
* Expand the Windows module docs.
* Add `Win10::get_version()` and `Win10::supports_cable()` helpers (only supported on Windows 11).

While not related to OpenSSL removal, this can just be in the 6.0 branch.

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
