### PR TITLE
6.0: API change: Make `WebauthnAuthenticator` a trait

### DIFF
--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -4,12 +4,12 @@ extern crate tracing;
 #[cfg(feature = "softtoken")]
 use std::fs::OpenOptions;
 use std::io::{stdin, stdout, Write};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
-use clap::clap_derive::ValueEnum;
 #[cfg(any(feature = "cable", feature = "softtoken"))]
 use clap::Args;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+use crypto_glue::rand::{rngs::ThreadRng, RngCore};
 #[cfg(feature = "cable")]
 use tokio_tungstenite::tungstenite::http::uri::Builder;
 #[cfg(feature = "cable-override-tunnel")]
@@ -26,7 +26,7 @@ use webauthn_authenticator_rs::softtoken::{SoftToken, SoftTokenFile};
 use webauthn_authenticator_rs::transport::*;
 use webauthn_authenticator_rs::types::CableRequestType;
 use webauthn_authenticator_rs::ui::{Cli, UiCallback};
-use webauthn_authenticator_rs::AuthenticatorBackend;
+use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 use webauthn_rs_core::proto::RequestAuthenticationExtensions;
 use webauthn_rs_core::WebauthnCore as Webauthn;
 use webauthn_rs_proto::{AttestationConveyancePreference, UserVerificationPolicy};
@@ -224,6 +224,7 @@ async fn main() {
         )
         .compact()
         .init();
+    let mut rng = ThreadRng::default();
 
     let opt = CliParser::parse();
     let ui = Cli {};
@@ -232,23 +233,28 @@ async fn main() {
         .connect_provider(CableRequestType::MakeCredential, &ui)
         .await;
 
+    let origin = Url::parse("https://demo.webauthn-authenticator-rs.example").unwrap();
+
     // WARNING: don't use this as an example of how to use the library!
     let wan = Webauthn::new_unsafe_experts_only(
-        "https://localhost:8080/auth",
-        "localhost",
-        vec![url::Url::parse("https://localhost:8080").unwrap()],
+        "webauthn-authenticator-rs demo",
+        "demo.webauthn-authenticator-rs.example",
+        vec![origin.clone()],
         Duration::from_secs(60),
         None,
         None,
     );
 
-    let unique_id = [
-        158, 170, 228, 89, 68, 28, 73, 194, 134, 19, 227, 153, 107, 220, 150, 238,
-    ];
-    let name = "william";
+    let mut unique_id = [0u8; 16];
+    rng.fill_bytes(&mut unique_id);
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let user_name = format!("demo-{}", now.as_secs());
+    let display_name = format!("Authenticate Demo {}", now.as_secs());
 
     let builder = wan
-        .new_challenge_register_builder(&unique_id, name, name)
+        .new_challenge_register_builder(&unique_id, &user_name, &display_name)
         .unwrap()
         .attestation(AttestationConveyancePreference::None)
         .user_verification_policy(opt.verification_policy.into());
@@ -257,18 +263,11 @@ async fn main() {
 
     info!("🍿 challenge -> {:x?}", chal);
 
-    let r = u
-        .perform_register(
-            Url::parse("https://localhost:8080").unwrap(),
-            chal.public_key,
-            60_000,
-        )
-        .unwrap();
+    let r = u.do_registration(origin.clone(), chal).unwrap();
 
     let cred = wan.register_credential(&r, &reg_state, None).unwrap();
 
     trace!(?cred);
-    drop(u);
     let mut buf = String::new();
     println!("WARNING: Some NFC keys need to be power-cycled before you can authenticate.");
     println!("Press ENTER to authenticate, or Ctrl-C to abort");
@@ -279,6 +278,7 @@ async fn main() {
         u = provider
             .connect_provider(CableRequestType::GetAssertion, &ui)
             .await;
+
         let (chal, auth_state) = wan
             .new_challenge_authenticate_builder(vec![cred.clone()], None)
             .map(|builder| {
@@ -291,16 +291,10 @@ async fn main() {
             .and_then(|b| wan.generate_challenge_authenticate(b))
             .unwrap();
 
-        let r = u
-            .perform_auth(
-                Url::parse("https://localhost:8080").unwrap(),
-                chal.public_key,
-                60_000,
-            )
-            .map_err(|e| {
-                error!("Error -> {:x?}", e);
-                e
-            });
+        let r = u.do_authentication(origin.clone(), chal).map_err(|e| {
+            error!("Error -> {:x?}", e);
+            e
+        });
         trace!(?r);
 
         if let Ok(r) = r {
@@ -311,7 +305,6 @@ async fn main() {
             info!("auth_res -> {:x?}", auth_res);
         }
 
-        drop(u);
         let mut buf = String::new();
         println!("Press ENTER to try again, or Ctrl-C to abort");
         stdout().flush().ok();

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -195,13 +195,21 @@ pub use crate::authenticator_hashed::{
     perform_auth_with_request, perform_register_with_request, AuthenticatorBackendHashedClientData,
 };
 
-pub struct WebauthnAuthenticator<T>
-where
-    T: AuthenticatorBackend,
-{
-    backend: T,
+#[doc(hidden)]
+mod private {
+    /// Sealing trait for [crate::WebauthnAuthenticator].
+    pub trait WebauthnAuthenticator {}
+    impl<T: crate::AuthenticatorBackend + ?Sized> WebauthnAuthenticator for T {}
 }
 
+/// Trait for low-level WebAuthn operations.
+///
+/// **Warning:** implementors of this trait **might not** implement all security checks required by
+/// [the WebAuthn `PublicKeyCredential` interface][0].
+///
+/// The [`WebauthnAuthenticator`][] `trait` provides a safe interface.
+///
+/// [0]: https://www.w3.org/TR/webauthn-3/#iface-pkcredential
 pub trait AuthenticatorBackend {
     fn perform_register(
         &mut self,
@@ -218,25 +226,50 @@ pub trait AuthenticatorBackend {
     ) -> Result<PublicKeyCredential, WebauthnCError>;
 }
 
-impl<T> WebauthnAuthenticator<T>
-where
-    T: AuthenticatorBackend,
-{
-    pub fn new(backend: T) -> Self {
-        WebauthnAuthenticator { backend }
-    }
+/// High-level [WebAuthn `PublicKeyCredential`][0]-like trait for interfacing with an authenticator.
+///
+/// Unlike using [`AuthenticatorBackend`][] directly, this trait *always* provides security checks
+/// required by the WebAuthn specification.
+///
+/// This is a sealed trait that is only implemented for
+/// [`impl AuthenticatorBackend`][crate::AuthenticatorBackend].
+///
+/// [0]: https://www.w3.org/TR/webauthn-3/#iface-pkcredential
+pub trait WebauthnAuthenticator: private::WebauthnAuthenticator {
+    /// Perform a WebAuthn registration ceremony.
+    ///
+    /// ### References
+    ///
+    /// * [§ 5.1.3: Create a New Credential - PublicKeyCredential’s `[[Create]](origin, options, sameOriginWithAncestors)` Method][0]
+    /// * [§ 6.3.2: The authenticatorMakeCredential Operation][1]
+    ///
+    /// [0]: https://www.w3.org/TR/webauthn-3/#sctn-createCredential
+    /// [1]: https://www.w3.org/TR/webauthn-3/#sctn-op-make-cred
+    fn do_registration(
+        &mut self,
+        origin: Url,
+        options: CreationChallengeResponse,
+        // _same_origin_with_ancestors: bool,
+    ) -> Result<RegisterPublicKeyCredential, WebauthnCError>;
+
+    /// Perform a WebAuthn authentication ceremony.
+    ///
+    /// ### References
+    ///
+    /// * [§ 5.1.4: Use an Existing Credential to Make an Assertion - PublicKeyCredential’s `[[Get]](options)` Method][0]
+    /// * [§ 6.3.3: The authenticatorGetAssertion operation][1]
+    ///
+    /// [0]: https://www.w3.org/TR/webauthn-3/#sctn-getAssertion
+    /// [1]: https://www.w3.org/TR/webauthn-3/#sctn-op-get-assertion
+    fn do_authentication(
+        &mut self,
+        origin: Url,
+        options: RequestChallengeResponse,
+    ) -> Result<PublicKeyCredential, WebauthnCError>;
 }
 
-impl<T> WebauthnAuthenticator<T>
-where
-    T: AuthenticatorBackend,
-{
-    /// 5.1.3. Create a New Credential - PublicKeyCredential’s Create (origin, options, sameOriginWithAncestors) Method
-    /// <https://www.w3.org/TR/webauthn/#createCredential>
-    ///
-    /// 6.3.2. The authenticatorMakeCredential Operation
-    /// <https://www.w3.org/TR/webauthn/#op-make-cred>
-    pub fn do_registration(
+impl<T: AuthenticatorBackend + ?Sized> WebauthnAuthenticator for T {
+    fn do_registration(
         &mut self,
         origin: Url,
         options: CreationChallengeResponse,
@@ -294,11 +327,10 @@ where
             return Err(WebauthnCError::Security);
         }
 
-        self.backend.perform_register(origin, options, timeout_ms)
+        self.perform_register(origin, options, timeout_ms)
     }
 
-    /// <https://www.w3.org/TR/webauthn/#getAssertion>
-    pub fn do_authentication(
+    fn do_authentication(
         &mut self,
         origin: Url,
         options: RequestChallengeResponse,
@@ -355,6 +387,6 @@ where
             return Err(WebauthnCError::Security);
         }
 
-        self.backend.perform_auth(origin, options, timeout_ms)
+        self.perform_auth(origin, options, timeout_ms)
     }
 }

--- a/webauthn-authenticator-rs/src/softpasskey.rs
+++ b/webauthn-authenticator-rs/src/softpasskey.rs
@@ -549,7 +549,7 @@ mod tests {
 
         info!("🍿 challenge -> {:x?}", chal);
 
-        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
+        let mut wa = SoftPasskey::new(true);
         let r = wa
             .do_registration(Url::parse("https://localhost:8080").unwrap(), chal)
             .map_err(|e| {

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -856,7 +856,7 @@ mod tests {
 
         let (soft_token, ca_root) = SoftToken::new(true).unwrap();
 
-        let mut wa = WebauthnAuthenticator::new(soft_token);
+        let mut wa = soft_token;
 
         let unique_id = [
             158, 170, 228, 89, 68, 28, 73, 194, 134, 19, 227, 153, 107, 220, 150, 238,
@@ -926,10 +926,8 @@ mod tests {
 
         let (soft_token, ca_root) = SoftToken::new(true).unwrap();
         let file = tempfile().unwrap();
-        let soft_token = SoftTokenFile::new(soft_token, file);
-        assert_eq!(soft_token.token.tokens.len(), 0);
-
-        let mut wa = WebauthnAuthenticator::new(soft_token);
+        let mut wa = SoftTokenFile::new(soft_token, file);
+        assert_eq!(wa.token.tokens.len(), 0);
 
         let unique_id = [
             158, 170, 228, 89, 68, 28, 73, 194, 134, 19, 227, 153, 107, 220, 150, 238,
@@ -966,19 +964,17 @@ mod tests {
 
         info!("Credential -> {:?}", cred);
 
-        assert_eq!(wa.backend.token.tokens.len(), 1);
+        assert_eq!(wa.token.tokens.len(), 1);
 
         // Save the credential to disk
-        let mut file: File = wa.backend.try_into().unwrap();
+        let mut file: File = wa.try_into().unwrap();
         assert!(file.stream_position().unwrap() > 0);
 
         // Rewind and reload
         file.rewind().unwrap();
 
-        let soft_token = SoftTokenFile::open(file).unwrap();
-        assert_eq!(soft_token.token.tokens.len(), 1);
-
-        let mut wa = WebauthnAuthenticator::new(soft_token);
+        let mut wa = SoftTokenFile::open(file).unwrap();
+        assert_eq!(wa.token.tokens.len(), 1);
 
         let (chal, auth_state) = wan
             .new_challenge_authenticate_builder(vec![cred], None)


### PR DESCRIPTION
Change `WebauthnAuthenticator` from a `struct` to a (sealed) `trait`, and update local usage. Using a `trait` makes it easier to work with in `dyn` contexts where an application is built with support for multiple backends.

Because this is a breaking API change, it targets the 6.0 branch, even though it doesn't really touch OpenSSL.

When migrating the `authenticate` example to `WebauthnAuthenticator`, it failed Origin checks. I've updated this to use a custom Origin (`demo.webauthn-authenticator-rs.example`). I've also made it use a timestamped user name. This makes it easier to manage these entries in synchronised credential managers, and identify the source (rather than `localhost`).

I've also updated the docs for `WebauthnAuthenticator` and `AuthenticatorBackend` to describe their intended use cases.

Fixes #

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
