### PR TITLE
6.0: Remove OpenSSL from Windows CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       # Some clap errors manifest as panics at runtime. Running tools with
       # --help should be enough to find an issue.
 
-      - run: cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},ui-cli -- --help
+      - run: cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},crypto,ui-cli -- --help
 
       # caBLE-specific examples.
       - if: contains(matrix.features, 'cable')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,6 @@ jobs:
           sudo apt-get update && \
           sudo apt-get -y install libdbus-1-dev libpcsclite-dev libudev-dev libusb-1.0-0-dev
 
-      - if: runner.os == 'windows'
-        uses: johnwason/vcpkg-action@v4
-        with:
-          pkgs: openssl
-          triplet: x64-windows-static-md
-          token: ${{ github.token }}
       # Transitive dependency of wasm-bindgen; works around https://github.com/rustwasm/wasm-bindgen/issues/3918
       - run: cargo update -p bumpalo --precise 3.14.0
       - run: cargo build --workspace --exclude webauthn-authenticator-rs --exclude actix_web --exclude web_authn --exclude tide-server
@@ -131,15 +125,6 @@ jobs:
       - if: contains(matrix.features, 'usb') && runner.os != 'windows'
         run: sudo apt-get -y install libusb-1.0-0-dev
 
-      # Don't try to install OpenSSL unless the "softtoken" feature is
-      # enabled. We should be able to operate without it.
-      - if: runner.os == 'windows' && contains(matrix.features, 'softtoken')
-        uses: johnwason/vcpkg-action@v4
-        with:
-          pkgs: openssl
-          triplet: x64-windows-static-md
-          token: ${{ github.token }}
-
       - run: cargo build -p webauthn-authenticator-rs --features ${{ matrix.features }}
 
       # Don't run clippy on Windows unless it is using a Windows-specific
@@ -160,13 +145,9 @@ jobs:
       # Some clap errors manifest as panics at runtime. Running tools with
       # --help should be enough to find an issue.
 
-      # authenticate example requires OpenSSL (via webauthn-rs-core), so don't
-      # run if features == 'win10'.
-      - if: runner.os != 'windows' || matrix.features != 'win10'
-        run: cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},ui-cli -- --help
+      - run: cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},ui-cli -- --help
 
-      # caBLE-specific examples. The "cable" feature requires OpenSSL, so this
-      # always OK to run on Windows.
+      # caBLE-specific examples.
       - if: contains(matrix.features, 'cable')
         run: cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},qrcode,ui-cli -- --help
       - if: contains(matrix.features, 'cable')
@@ -248,11 +229,5 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - if: runner.os == 'windows'
-        uses: johnwason/vcpkg-action@v4
-        with:
-          pkgs: openssl
-          triplet: x64-windows-static-md
-          token: ${{ github.token }}
 
       - run: cargo build -p actix_tutorial -p axum_tutorial -p tide_tutorial


### PR DESCRIPTION
OpenSSL shouldn't be needed anymore, so remove it from Windows CI builds.

#499

- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
