### PR TITLE
Workaround `openssl-rs` panic on `iv: None`, new clippy lints

### DIFF
--- a/webauthn-authenticator-rs/src/crypto.rs
+++ b/webauthn-authenticator-rs/src/crypto.rs
@@ -44,10 +44,14 @@ pub fn get_group() -> Result<EcGroup, WebauthnCError> {
 /// Encrypts some data using AES-256-CBC, with no padding.
 ///
 /// `plaintext.len()` must be a multiple of the cipher's blocksize.
+///
+/// If `iv` is `None`, use an IV of all zeroes.
 pub fn encrypt(key: &[u8], iv: Option<&[u8]>, plaintext: &[u8]) -> Result<Vec<u8>, WebauthnCError> {
     let cipher = Cipher::aes_256_cbc();
     let mut ct = vec![0; plaintext.len() + cipher.block_size()];
-    let mut c = Crypter::new(cipher, Mode::Encrypt, key, iv)?;
+    // https://github.com/rust-openssl/rust-openssl/pull/2596/
+    let iv = iv.unwrap_or(&[0; 16]);
+    let mut c = Crypter::new(cipher, Mode::Encrypt, key, Some(iv))?;
     c.pad(false);
     let l = c.update(plaintext, &mut ct)?;
     let l = l + c.finalize(&mut ct[l..])?;
@@ -56,6 +60,8 @@ pub fn encrypt(key: &[u8], iv: Option<&[u8]>, plaintext: &[u8]) -> Result<Vec<u8
 }
 
 /// Decrypts some data using AES-256-CBC, with no padding.
+///
+/// If `iv` is `None`, use an IV of all zeroes.
 pub fn decrypt(
     key: &[u8],
     iv: Option<&[u8]>,
@@ -72,7 +78,9 @@ pub fn decrypt(
     }
 
     let mut pt = vec![0; ciphertext.len() + cipher.block_size()];
-    let mut c = Crypter::new(cipher, Mode::Decrypt, key, iv)?;
+    // https://github.com/rust-openssl/rust-openssl/pull/2596/
+    let iv = iv.unwrap_or(&[0; 16]);
+    let mut c = Crypter::new(cipher, Mode::Decrypt, key, Some(iv))?;
     c.pad(false);
     let l = c.update(ciphertext, &mut pt)?;
     let l = l + c.finalize(&mut pt[l..])?;

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -850,20 +850,22 @@ impl WebauthnCore {
         // We also check the historical policy too. See designs/authentication-use-cases.md
 
         match (&policy, &cred.registration_policy) {
-            (_, UserVerificationPolicy::Required) | (UserVerificationPolicy::Required, _) => {
-                // If we requested required at registration or now, enforce that.
-                if !data.authenticator_data.user_verified {
-                    return Err(WebauthnError::UserNotVerified);
-                }
+            // If we requested required at registration or now, enforce that.
+            (_, UserVerificationPolicy::Required) | (UserVerificationPolicy::Required, _)
+                if !data.authenticator_data.user_verified =>
+            {
+                return Err(WebauthnError::UserNotVerified);
             }
-            (_, UserVerificationPolicy::Preferred) => {
-                // If we asked for Preferred at registration, we MAY have established to the user
-                // that they are required to enter a pin, so we SHOULD enforce this.
-                if cred.user_verified && !data.authenticator_data.user_verified {
-                    debug!("Token registered UV=preferred, enforcing UV policy.");
-                    return Err(WebauthnError::UserNotVerified);
-                }
+
+            // If we asked for Preferred at registration, we MAY have established to the user
+            // that they are required to enter a pin, so we SHOULD enforce this.
+            (_, UserVerificationPolicy::Preferred)
+                if cred.user_verified && !data.authenticator_data.user_verified =>
+            {
+                debug!("Token registered UV=preferred, enforcing UV policy.");
+                return Err(WebauthnError::UserNotVerified);
             }
+
             // Pass - we can not know if verification was requested to the client in the past correctly.
             // This means we can't know what it's behaviour is at the moment.
             // We must allow unverified tokens now.


### PR DESCRIPTION
## Change summary

### `openssl-rs` with `iv: None`

OpenSSL treats using a `nullptr` IV as an all-zero IV.

However, `openssl-rs` _documented_ `openssl::Crypter::new()` as panicing with an `iv` of `None` if an IV is required, but didn't actually panic.

https://github.com/rust-openssl/rust-openssl/pull/2596/ corrected this inconsistency, by making it actually panic. Unfortunately, `webauthn-authenticator-rs` relied on the _previous_ behaviour (#547).

This change effectively emulates the previous behaviour of `openssl-rs` in our wrappers. All of will be replaced "real soon now" by #499 (dropping OpenSSL), so I want to change as little as possible.

`rustcrypto` has better typing information (different traits for whether cipher requires an IV), so #504 changed all callsites to provide an explicit all-zero IV where needed.

### clippy lint

There's [a new `clippy` lint in Rust stable which wants to squash `if` statements into their parent `match` arm if that's the only thing they contain](https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match).

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
