### PR TITLE
webauthn-authenticator-rs: Remove some `trace!` logs

### DIFF
--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -301,7 +301,6 @@ impl Eid {
             }
         };
 
-        trace!("Decrypting {:?} with key {:?}", advert, key);
         let signing_key = PKey::hmac(&key[32..64])?;
         let mut signer = Signer::new(MessageDigest::sha256(), &signing_key)?;
         let calculated_hmac = signer.sign_oneshot_to_vec(&advert[..16])?;

--- a/webauthn-authenticator-rs/src/cable/handshake.rs
+++ b/webauthn-authenticator-rs/src/cable/handshake.rs
@@ -81,7 +81,6 @@ impl TryFrom<BTreeMap<u32, Value>> for HandshakeV2 {
     type Error = WebauthnCError;
 
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        // trace!(?raw);
         let peer_identity = raw
             .remove(&0)
             .and_then(|v| value_to_vec_u8(v, "0x00"))

--- a/webauthn-authenticator-rs/src/cable/noise.rs
+++ b/webauthn-authenticator-rs/src/cable/noise.rs
@@ -414,8 +414,6 @@ impl CableNoise {
         // https://source.chromium.org/chromium/chromium/src/+/main:device/fido/cable/v2_handshake.cc;l=982;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29
         let (write_key, read_key) = self.traffic_keys()?;
 
-        trace!(?write_key);
-        trace!(?read_key);
         Ok(Crypter::new(read_key, write_key))
     }
 
@@ -512,8 +510,6 @@ impl CableNoise {
         response_message.extend_from_slice(&ct);
 
         let (read_key, write_key) = noise.traffic_keys()?;
-        trace!(?read_key);
-        trace!(?write_key);
         Ok((Crypter::new(read_key, write_key), response_message))
     }
 }

--- a/webauthn-authenticator-rs/src/cable/tunnel.rs
+++ b/webauthn-authenticator-rs/src/cable/tunnel.rs
@@ -457,7 +457,6 @@ impl TryFrom<BTreeMap<u32, Value>> for CablePostHandshake {
     type Error = WebauthnCError;
 
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        // trace!("raw = {:?}", raw);
         let info = raw
             .remove(&0x01)
             .and_then(|v| value_to_vec_u8(v, "0x01"))

--- a/webauthn-authenticator-rs/src/ctap2/commands/bio_enrollment.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/bio_enrollment.rs
@@ -199,7 +199,6 @@ pub struct TemplateInfo {
 impl TryFrom<BTreeMap<Value, Value>> for TemplateInfo {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<Value, Value>) -> Result<Self, Self::Error> {
-        // trace!(?raw);
         Ok(Self {
             id: raw
                 .remove(&Value::Integer(0x01))
@@ -435,7 +434,6 @@ impl BioEnrollmentResponse {
 impl TryFrom<BTreeMap<u32, Value>> for BioEnrollmentResponse {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!(?raw);
         Ok(Self {
             modality: raw
                 .remove(&0x01)

--- a/webauthn-authenticator-rs/src/ctap2/commands/client_pin.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/client_pin.rs
@@ -162,7 +162,6 @@ impl From<ClientPinRequest> for BTreeMap<u32, Value> {
 impl TryFrom<BTreeMap<u32, Value>> for ClientPinResponse {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!(?raw);
         Ok(Self {
             key_agreement: raw
                 .remove(&0x01)

--- a/webauthn-authenticator-rs/src/ctap2/commands/credential_management.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/credential_management.rs
@@ -362,8 +362,6 @@ pub struct CredentialManagementResponse {
 impl TryFrom<BTreeMap<u32, Value>> for CredentialManagementResponse {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!(?raw);
-
         // Parse the relying party field if present.
         let mut rp: Option<RelyingPartyCM> = if let Some(v) = raw.remove(&0x03) {
             Some(from_value(v).map_err(|e| {

--- a/webauthn-authenticator-rs/src/ctap2/commands/get_assertion.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/get_assertion.rs
@@ -122,7 +122,6 @@ impl From<GetAssertionRequest> for BTreeMap<u32, Value> {
 impl TryFrom<BTreeMap<u32, Value>> for GetAssertionRequest {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!("raw: {:?}", raw);
         Ok(Self {
             rp_id: raw
                 .remove(&0x01)
@@ -230,7 +229,6 @@ impl From<GetAssertionResponse> for BTreeMap<u32, Value> {
 impl TryFrom<BTreeMap<u32, Value>> for GetAssertionResponse {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!(?raw);
         Ok(Self {
             credential: raw.remove(&0x01).and_then(|v| {
                 if let Value::Map(mut v) = v {

--- a/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/get_info.rs
@@ -310,7 +310,6 @@ impl TryFrom<BTreeMap<u32, Value>> for GetInfoResponse {
     type Error = &'static str;
 
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!("raw = {:?}", raw);
         let versions = raw
             .remove(&0x01)
             .and_then(|v| value_to_set_string(v, "0x01"))

--- a/webauthn-authenticator-rs/src/ctap2/commands/make_credential.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/make_credential.rs
@@ -186,7 +186,6 @@ impl From<MakeCredentialRequest> for BTreeMap<u32, Value> {
 impl TryFrom<BTreeMap<u32, Value>> for MakeCredentialRequest {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!("raw: {:?}", raw);
         Ok(Self {
             client_data_hash: raw
                 .remove(&0x01)
@@ -273,7 +272,6 @@ impl From<MakeCredentialResponse> for BTreeMap<u32, Value> {
 impl TryFrom<BTreeMap<u32, Value>> for MakeCredentialResponse {
     type Error = &'static str;
     fn try_from(mut raw: BTreeMap<u32, Value>) -> Result<Self, Self::Error> {
-        trace!(?raw);
         Ok(Self {
             fmt: raw.remove(&0x01).and_then(|v| value_to_string(v, "0x01")),
             auth_data: raw.remove(&0x02),

--- a/webauthn-authenticator-rs/src/ctap2/ctap20.rs
+++ b/webauthn-authenticator-rs/src/ctap2/ctap20.rs
@@ -124,12 +124,10 @@ impl<'a, T: Token, U: UiCallback> Ctap20Authenticator<'a, T, U> {
         let p = iface.get_key_agreement_cmd();
         let ret = self.token.transmit(p, ui_callback).await?;
         let key_agreement = ret.key_agreement.ok_or(WebauthnCError::Internal)?;
-        trace!(?key_agreement);
 
         // The platform calls encapsulate with the public key that the authenticator
         // returned in order to generate the platform key-agreement key and the shared secret.
         let shared_secret = iface.encapsulate(key_agreement)?;
-        trace!(?shared_secret);
 
         let set_pin = iface.set_pin_cmd(padded_pin, shared_secret.as_slice())?;
         let ret = self.token.transmit(set_pin, ui_callback).await?;
@@ -385,12 +383,10 @@ impl<'a, T: Token, U: UiCallback> Ctap20Authenticator<'a, T, U> {
             let p = iface.get_key_agreement_cmd();
             let ret = self.token.transmit(p, ui_callback).await?;
             let key_agreement = ret.key_agreement.ok_or(WebauthnCError::Internal)?;
-            trace!(?key_agreement);
 
             // The platform calls encapsulate with the public key that the authenticator
             // returned in order to generate the platform key-agreement key and the shared secret.
             let shared_secret = iface.encapsulate(key_agreement)?;
-            trace!(?shared_secret);
 
             // Then the platform obtains a pinUvAuthToken from the
             // authenticator, with the mc (and likely also with the ga)

--- a/webauthn-authenticator-rs/src/nfc/atr.rs
+++ b/webauthn-authenticator-rs/src/nfc/atr.rs
@@ -186,7 +186,6 @@ impl TryFrom<&[u8]> for Atr {
             } else {
                 let tlv = CompactTlv::new(tlv_payload);
                 for (t, v) in tlv {
-                    // trace!("tlv: {:02x?} = {:02x?}", t, v);
                     if t == 7 {
                         // 7816-4 §8.1.1.2.7 Card capabilities
                         if v.len() >= 3 {

--- a/webauthn-authenticator-rs/src/nfc/mod.rs
+++ b/webauthn-authenticator-rs/src/nfc/mod.rs
@@ -157,11 +157,6 @@ impl NFCDeviceWatcher {
                 vec![ReaderState::new(PNP_NOTIFICATION(), State::UNAWARE)];
 
             'main: while !tx.is_closed() {
-                // trace!(
-                //     "{} known reader(s), pruning ignored readers",
-                //     reader_states.len()
-                // );
-
                 // Remove all disconnected readers
                 reader_states.retain(|state| {
                     !state
@@ -169,15 +164,8 @@ impl NFCDeviceWatcher {
                         .intersects(State::UNKNOWN | State::IGNORE)
                 });
 
-                // trace!("{} reader(s) remain after pruning", reader_states.len());
-
                 // Get a list of readers right now
                 let readers = ctx.list_readers_owned()?;
-                // trace!(
-                //     "{} reader(s) currently connected: {:?}",
-                //     readers.len(),
-                //     readers
-                // );
 
                 if readers.is_empty() && !enumeration_complete {
                     // When there are no real readers connected (ie: other than
@@ -217,7 +205,6 @@ impl NFCDeviceWatcher {
                 }
 
                 // Update view of current states
-                // trace!("Updating {} reader states", reader_states.len());
                 for state in &mut reader_states {
                     state.sync_current_state();
                 }
@@ -239,7 +226,6 @@ impl NFCDeviceWatcher {
                     }
                 }
 
-                // trace!("Updated reader states");
                 let mut tasks = Vec::new();
                 for state in &reader_states {
                     if state.name() == PNP_NOTIFICATION()


### PR DESCRIPTION
## Change summary

`trace` logs are normally disabled by default. This change removes a bunch of `trace` logs in `webauthn-authenticator-rs` that either:

- are commented out
- are noisy and/or limited utility
- directly expose key material (which is both noisy and of limited utility)

I've left in `trace` logs for decrypted forms of encrypted messages, because they're very useful for debugging.

While this smells security-sensitive, if an attacker _could_ enable `trace` logs and cause them to be logged somewhere they could read, then there are probably many other things that an attacker could do to recover the keys or decrypt data.

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
