### PR TITLE
Move `WebauthnCore::origins_match` to `webauthn-rs-proto`, don't build `tide` docs in CI

### DIFF
--- a/.github/doc_manifest
+++ b/.github/doc_manifest
@@ -18,5 +18,4 @@ webauthn_rs/index.html
 webauthn_rs/interface/index.html
 
 webauthn_rs_core/index.html
-webauthn_rs_demo/index.html
 webauthn_rs_proto/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       - name: generate docs
         run: |
           cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all \
-            --exclude fido-key-manager webauthn-rs-demo \
+            --exclude fido-key-manager,webauthn-rs-demo \
             --no-deps \
             --document-private-items
         env:
@@ -275,6 +275,7 @@ jobs:
       - run: |
           cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc \
           --all \
+          --exclude webauthn-rs-demo \
           --no-deps \
           --document-private-items \
           --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,14 +248,15 @@ jobs:
       # but doesn't work for fido-key-manager which includes NFC and USB support
       # by default.
       #
-      # webauthn-rs-demo is excluded from doc builds because of
-      # https://github.com/bytecodealliance/rustix/issues/1620, which is broken
-      # on nightly.
+      # tide_tutorial and webauthn-rs-demo are excluded from doc builds because
+      # of https://github.com/bytecodealliance/rustix/issues/1620, which is
+      # broken on Rust nightly.
       - name: generate docs
         run: |
           cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc \
             --all \
             --exclude fido-key-manager \
+            --exclude tide_tutorial \
             --exclude webauthn-rs-demo \
             --no-deps \
             --document-private-items
@@ -276,11 +277,12 @@ jobs:
           sudo apt-get -y install libpcsclite-dev libusb-1.0-0-dev libdbus-1-dev
       - run: |
           cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc \
-          --all \
-          --exclude webauthn-rs-demo \
-          --no-deps \
-          --document-private-items \
-          --all-features
+            --all \
+            --exclude tide_tutorial \
+            --exclude webauthn-rs-demo \
+            --no-deps \
+            --document-private-items \
+            --all-features
         env:
           RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,8 +253,10 @@ jobs:
       # on nightly.
       - name: generate docs
         run: |
-          cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all \
-            --exclude fido-key-manager,webauthn-rs-demo \
+          cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc \
+            --all \
+            --exclude fido-key-manager \
+            --exclude webauthn-rs-demo \
             --no-deps \
             --document-private-items
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,14 @@ jobs:
       # This tests that all the stubs work properly for optional dependencies,
       # but doesn't work for fido-key-manager which includes NFC and USB support
       # by default.
+      #
+      # webauthn-rs-demo is excluded from doc builds because of
+      # https://github.com/bytecodealliance/rustix/issues/1620, which is broken
+      # on nightly.
       - name: generate docs
         run: |
           cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all \
-            --exclude fido-key-manager \
+            --exclude fido-key-manager webauthn-rs-demo \
             --no-deps \
             --document-private-items
         env:

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -72,7 +72,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 base64.workspace = true
 base64urlsafedata.workspace = true
-webauthn-rs-proto.workspace = true
+webauthn-rs-proto = { workspace = true, features = ["origin"] }
 webauthn-rs-core = { workspace = true, optional = true }
 
 tracing.workspace = true

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -103,16 +103,14 @@ extern crate num_derive;
 #[macro_use]
 extern crate tracing;
 
-use std::str::FromStr;
-
 use crate::error::WebauthnCError;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_ENGINE;
 use url::Url;
 
-use webauthn_rs_core::WebauthnCore;
 use webauthn_rs_proto::{
-    CreationChallengeResponse, PublicKeyCredential, PublicKeyCredentialCreationOptions,
-    PublicKeyCredentialRequestOptions, RegisterPublicKeyCredential, RequestChallengeResponse,
+    origin::origins_match, CreationChallengeResponse, PublicKeyCredential,
+    PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
+    RegisterPublicKeyCredential, RequestChallengeResponse,
 };
 
 pub mod prelude {
@@ -292,7 +290,7 @@ where
                 WebauthnCError::Security
             })?;
 
-        if !WebauthnCore::origins_match(true, true, &origin, &rp_id_url) {
+        if !origins_match(true, true, &origin, &rp_id_url) {
             error!(
                 "Relying party ID ({rp_id_url}) is not a suffix of the effective domain ({origin})"
             );
@@ -367,7 +365,7 @@ where
                 WebauthnCError::Security
             })?;
 
-        if !WebauthnCore::origins_match(true, true, &origin, &rp_id_url) {
+        if !origins_match(true, true, &origin, &rp_id_url) {
             error!(
                 "Relying party ID ({rp_id_url}) is not a suffix of the effective domain ({origin})"
             );

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -24,7 +24,7 @@ base64.workspace = true
 base64urlsafedata.workspace = true
 hex.workspace = true
 webauthn-attestation-ca.workspace = true
-webauthn-rs-proto.workspace = true
+webauthn-rs-proto = { workspace = true, features = ["origin"] }
 serde.workspace = true
 serde_cbor_2.workspace = true
 serde_json.workspace = true

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -1187,6 +1187,8 @@ impl WebauthnCore {
     }
 
     /// Check if a `request_origin` is an allowed suffix of `allowed_origin`.
+    ///
+    /// **Deprecated:** use [`webauthn_rs_proto::origin::origins_match()`][] instead.
     #[deprecated(note = "Use webauthn_rs_proto::origin::origins_match")]
     pub fn origins_match(
         allow_subdomains_origin: bool,
@@ -1194,7 +1196,12 @@ impl WebauthnCore {
         request_origin: &Url,
         allowed_origin: &Url,
     ) -> bool {
-        origins_match(allow_subdomains_origin, allow_any_port, request_origin, allowed_origin)
+        origins_match(
+            allow_subdomains_origin,
+            allow_any_port,
+            request_origin,
+            allowed_origin,
+        )
     }
 
     /// Returns the RP name

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -28,6 +28,7 @@ use crate::constants::CHALLENGE_SIZE_BYTES;
 use crate::crypto::compute_sha256;
 use crate::error::WebauthnError;
 use crate::internals::*;
+use crate::proto::origin::origins_match;
 use crate::proto::*;
 
 /// The Core Webauthn handler.
@@ -482,7 +483,7 @@ impl WebauthnCore {
 
         // Verify that the client's origin matches one of our allowed origins..
         if !self.allowed_origins.iter().any(|origin| {
-            Self::origins_match(
+            origins_match(
                 self.allow_subdomains_origin,
                 self.allow_any_port,
                 &data.client_data_json.origin,
@@ -807,7 +808,7 @@ impl WebauthnCore {
 
         // Verify that the value of C.origin matches one of our allowed origins.
         if !self.allowed_origins.iter().any(|origin| {
-            Self::origins_match(
+            origins_match(
                 self.allow_subdomains_origin,
                 self.allow_any_port,
                 &c.origin,
@@ -1186,86 +1187,14 @@ impl WebauthnCore {
     }
 
     /// Check if a `request_origin` is an allowed suffix of `allowed_origin`.
-    ///
-    /// If either `request_origin` or `allowed_origin` are opaque URLs, they must exactly match.
-    ///
-    /// ### Arguments
-    ///
-    /// * `allow_subdomains_origin`: if `true`, `request_origin` may be a subdomain of
-    ///   `allowed_origin`.
-    ///
-    ///   **Note:** this *does not* verify whether `allowed_origin` (or a parent of it) is a valid
-    ///   registerable domain.
-    ///
-    /// * `allow_any_port`: if `true`, `request_origin` may be a different port to `allowed_origin`. The
-    ///   URLs' schemes must still match.
-    ///
-    /// ### References
-    ///
-    /// * [HTML Standard §7.1.1.2, registerable domain suffix][0]
-    ///
-    /// [0]: https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to
+    #[deprecated(note = "Use webauthn_rs_proto::origin::origins_match")]
     pub fn origins_match(
         allow_subdomains_origin: bool,
         allow_any_port: bool,
         request_origin: &Url,
         allowed_origin: &Url,
     ) -> bool {
-        if allowed_origin == request_origin {
-            // Exact URL match
-            return true;
-        }
-
-        if allowed_origin.scheme() != request_origin.scheme() {
-            // Full URL scheme mismatch
-            return false;
-        }
-
-        // Check the Origin
-        match (allowed_origin.origin(), request_origin.origin()) {
-            (
-                url::Origin::Tuple(rp_id_scheme, rp_id_host, rp_id_port),
-                url::Origin::Tuple(request_scheme, request_host, request_port),
-            ) => {
-                if rp_id_scheme != request_scheme {
-                    // Origin scheme mismatch
-                    return false;
-                }
-
-                if !allow_any_port && rp_id_port != request_port {
-                    // Port mismatch
-                    return false;
-                }
-
-                match (rp_id_host, request_host) {
-                    // Both hosts are a domain
-                    (url::Host::Domain(rp_id_domain), url::Host::Domain(request_domain)) => {
-                        if rp_id_domain == request_domain {
-                            // Domains exactly match
-                            return true;
-                        }
-
-                        // Ensure "badexample.com" doesn't match "example.com", but
-                        // "sub.example.com" does.
-                        return allow_subdomains_origin
-                            && request_domain
-                                .strip_suffix(&rp_id_domain)
-                                .map(|prefix| prefix.ends_with('.'))
-                                .unwrap_or(false);
-                    }
-
-                    (rp_id_host, request_host) => {
-                        // At least one is a non-domain host, always require exact match.
-                        return rp_id_host == request_host;
-                    }
-                }
-            }
-
-            _ => {
-                // Opaque URL which isn't equal
-                false
-            }
-        }
+        origins_match(allow_subdomains_origin, allow_any_port, request_origin, allowed_origin)
     }
 
     /// Returns the RP name
@@ -3678,271 +3607,6 @@ mod tests {
             result,
             Err(WebauthnError::CredentialInsecureCryptography)
         ))
-    }
-
-    /// Test `origins_match` with simple case.
-    #[test]
-    fn test_origins_match_exact() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let request_origin = url::Url::parse("https://example.com").unwrap();
-        let allowed_origin = url::Url::parse("https://example.com").unwrap();
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-    }
-
-    /// Test `origins_match` with scheme changes, which should never match.
-    #[test]
-    fn test_origins_match_scheme() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let http_url = url::Url::parse("http://example.com").unwrap();
-        let https_url = url::Url::parse("https://example.com").unwrap();
-        let ws_url = url::Url::parse("ws://example.com").unwrap();
-        let wss_url = url::Url::parse("wss://example.com").unwrap();
-
-        for allow_subdomains_origin in [true, false] {
-            for allow_any_port in [true, false] {
-                for request_origin in [&http_url, &ws_url, &wss_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &https_url,
-                        ),
-                        "expected {https_url} to not match {request_origin}",
-                    );
-                }
-
-                for request_origin in [&https_url, &ws_url, &wss_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &http_url,
-                        ),
-                        "expected {http_url} to not match {request_origin}",
-                    );
-                }
-
-                for request_origin in [&http_url, &https_url, &wss_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &ws_url,
-                        ),
-                        "expected {ws_url} to not match {request_origin}",
-                    );
-                }
-
-                for request_origin in [&http_url, &https_url, &ws_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &wss_url,
-                        ),
-                        "expected {wss_url} to not match {request_origin}",
-                    );
-                }
-            }
-        }
-    }
-
-    /// Test `origins_match` with different ports on `localhost`
-    #[test]
-    fn test_origins_match_localhost_port() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let request_origin = url::Url::parse("http://localhost:8000").unwrap();
-        let allowed_origin = url::Url::parse("http://localhost:3000").unwrap();
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        // Differing ports should fail
-        assert!(!Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(!Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-    }
-
-    #[test]
-    fn test_origin_ios_matches() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        for allow_subdomains_origin in [true, false] {
-            for allow_any_port in [true, false] {
-                assert!(Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                ));
-
-                // Different package name shouldn't match
-                assert!(!Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.baz").unwrap(),
-                ));
-
-                // Prefixes and suffixes shouldn't match for opaque URLs
-                assert!(!Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
-                ));
-
-                assert!(!Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                ));
-            }
-        }
-    }
-
-    #[test]
-    fn test_origin_subdomain_suffix_boundary() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let allowed_origin = Url::parse("https://example.com").unwrap();
-
-        // Should always be allowed
-        let allowed_urls: [Url; 4] = [
-            allowed_origin.clone(),
-            Url::parse("https://example.com/hello").unwrap(),
-            Url::parse("https://user@example.com").unwrap(),
-            Url::parse("https://user@example.com/hello").unwrap(),
-        ];
-
-        // Should only be allowed when subdomains are allowed
-        let allowed_subdomains: [Url; 2] = [
-            Url::parse("https://sub.example.com").unwrap(),
-            Url::parse("https://deep.subdomain.example.com").unwrap(),
-        ];
-
-        let denied_urls: [Url; 4] = [
-            // Parent domain
-            Url::parse("https://com").unwrap(),
-            // Different TLD
-            Url::parse("https://example.net").unwrap(),
-            // Prefixed string
-            Url::parse("https://otherexample.com").unwrap(),
-            Url::parse("https://other-example.com").unwrap(),
-        ];
-
-        for request_origin in &allowed_urls {
-            for allow_subdomains_origin in [true, false] {
-                for allow_any_port in [true, false] {
-                    assert!(
-                        Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &allowed_origin,
-                        ),
-                        "{allowed_origin} allows {request_origin}"
-                    );
-                }
-            }
-        }
-
-        for request_origin in &allowed_subdomains {
-            // Legitimate subdomain must be accepted
-            assert!(
-                Webauthn::origins_match(true, false, request_origin, &allowed_origin),
-                "{allowed_origin} allows {request_origin}",
-            );
-
-            assert!(
-                Webauthn::origins_match(true, true, request_origin, &allowed_origin),
-                "{allowed_origin} allows {request_origin}",
-            );
-
-            // ...unless subdomains are disallowed
-            assert!(
-                !Webauthn::origins_match(false, false, request_origin, &allowed_origin),
-                "{allowed_origin} denies {request_origin}",
-            );
-
-            assert!(
-                !Webauthn::origins_match(false, true, request_origin, &allowed_origin),
-                "{allowed_origin} denies {request_origin}",
-            );
-        }
-
-        // Denied domains should never be accepted
-        for request_origin in &denied_urls {
-            for allow_subdomains_origin in [true, false] {
-                for allow_any_port in [true, false] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &allowed_origin,
-                        ),
-                        "{allowed_origin} denies {request_origin}"
-                    );
-                }
-            }
-        }
     }
 
     #[test]

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -17,6 +17,11 @@ repository = { workspace = true }
 
 [features]
 default = []
+
+# Origin-checking, this is an internal implementation detail
+origin = []
+
+# WASM bindings
 wasm = ["wasm-bindgen", "web-sys", "js-sys", "serde-wasm-bindgen"]
 
 [package.metadata.docs.rs]

--- a/webauthn-rs-proto/src/lib.rs
+++ b/webauthn-rs-proto/src/lib.rs
@@ -12,6 +12,9 @@ pub mod cose;
 pub mod extensions;
 pub mod options;
 
+#[cfg(any(test, feature = "origin"))]
+pub mod origin;
+
 #[cfg(feature = "wasm")]
 pub mod wasm;
 

--- a/webauthn-rs-proto/src/origin.rs
+++ b/webauthn-rs-proto/src/origin.rs
@@ -63,16 +63,16 @@ pub fn origins_match(
 
                     // Ensure "badexample.com" doesn't match "example.com", but
                     // "sub.example.com" does.
-                    return allow_subdomains_origin
+                    allow_subdomains_origin
                         && request_domain
                             .strip_suffix(&rp_id_domain)
                             .map(|prefix| prefix.ends_with('.'))
-                            .unwrap_or(false);
+                            .unwrap_or(false)
                 }
 
                 (rp_id_host, request_host) => {
                     // At least one is a non-domain host, always require exact match.
-                    return rp_id_host == request_host;
+                    rp_id_host == request_host
                 }
             }
         }

--- a/webauthn-rs-proto/src/origin.rs
+++ b/webauthn-rs-proto/src/origin.rs
@@ -1,0 +1,345 @@
+//! WebAuthn Origin checks
+use url::Url;
+
+/// Check if a `request_origin` is an allowed suffix of `allowed_origin`.
+///
+/// If either `request_origin` or `allowed_origin` are opaque URLs, they must exactly match.
+///
+/// ### Arguments
+///
+/// * `allow_subdomains_origin`: if `true`, `request_origin` may be a subdomain of
+///   `allowed_origin`.
+///
+///   **Note:** this *does not* verify whether `allowed_origin` (or a parent of it) is a valid
+///   registerable domain.
+///
+/// * `allow_any_port`: if `true`, `request_origin` may be a different port to `allowed_origin`. The
+///   URLs' schemes must still match.
+///
+/// ### References
+///
+/// * [HTML Standard §7.1.1.2, registerable domain suffix][0]
+///
+/// [0]: https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to
+pub fn origins_match(
+    allow_subdomains_origin: bool,
+    allow_any_port: bool,
+    request_origin: &Url,
+    allowed_origin: &Url,
+) -> bool {
+    if allowed_origin == request_origin {
+        // Exact URL match
+        return true;
+    }
+
+    if allowed_origin.scheme() != request_origin.scheme() {
+        // Full URL scheme mismatch
+        return false;
+    }
+
+    // Check the Origin
+    match (allowed_origin.origin(), request_origin.origin()) {
+        (
+            url::Origin::Tuple(rp_id_scheme, rp_id_host, rp_id_port),
+            url::Origin::Tuple(request_scheme, request_host, request_port),
+        ) => {
+            if rp_id_scheme != request_scheme {
+                // Origin scheme mismatch
+                return false;
+            }
+
+            if !allow_any_port && rp_id_port != request_port {
+                // Port mismatch
+                return false;
+            }
+
+            match (rp_id_host, request_host) {
+                // Both hosts are a domain
+                (url::Host::Domain(rp_id_domain), url::Host::Domain(request_domain)) => {
+                    if rp_id_domain == request_domain {
+                        // Domains exactly match
+                        return true;
+                    }
+
+                    // Ensure "badexample.com" doesn't match "example.com", but
+                    // "sub.example.com" does.
+                    return allow_subdomains_origin
+                        && request_domain
+                            .strip_suffix(&rp_id_domain)
+                            .map(|prefix| prefix.ends_with('.'))
+                            .unwrap_or(false);
+                }
+
+                (rp_id_host, request_host) => {
+                    // At least one is a non-domain host, always require exact match.
+                    return rp_id_host == request_host;
+                }
+            }
+        }
+
+        _ => {
+            // Opaque URL which isn't equal
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test `origins_match` with simple case.
+    #[test]
+    fn test_origins_match_exact() {
+        let request_origin = url::Url::parse("https://example.com").unwrap();
+        let allowed_origin = url::Url::parse("https://example.com").unwrap();
+
+        assert!(origins_match(
+            /* subdomains */ true,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ false,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ true,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ false,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+    }
+
+    /// Test `origins_match` with scheme changes, which should never match.
+    #[test]
+    fn test_origins_match_scheme() {
+        let http_url = url::Url::parse("http://example.com").unwrap();
+        let https_url = url::Url::parse("https://example.com").unwrap();
+        let ws_url = url::Url::parse("ws://example.com").unwrap();
+        let wss_url = url::Url::parse("wss://example.com").unwrap();
+
+        for allow_subdomains_origin in [true, false] {
+            for allow_any_port in [true, false] {
+                for request_origin in [&http_url, &ws_url, &wss_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &https_url,
+                        ),
+                        "expected {https_url} to not match {request_origin}",
+                    );
+                }
+
+                for request_origin in [&https_url, &ws_url, &wss_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &http_url,
+                        ),
+                        "expected {http_url} to not match {request_origin}",
+                    );
+                }
+
+                for request_origin in [&http_url, &https_url, &wss_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &ws_url,
+                        ),
+                        "expected {ws_url} to not match {request_origin}",
+                    );
+                }
+
+                for request_origin in [&http_url, &https_url, &ws_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &wss_url,
+                        ),
+                        "expected {wss_url} to not match {request_origin}",
+                    );
+                }
+            }
+        }
+    }
+
+    /// Test `origins_match` with different ports on `localhost`
+    #[test]
+    fn test_origins_match_localhost_port() {
+        let request_origin = url::Url::parse("http://localhost:8000").unwrap();
+        let allowed_origin = url::Url::parse("http://localhost:3000").unwrap();
+
+        assert!(origins_match(
+            /* subdomains */ true,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ false,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        // Differing ports should fail
+        assert!(!origins_match(
+            /* subdomains */ true,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(!origins_match(
+            /* subdomains */ false,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+    }
+
+    #[test]
+    fn test_origin_ios_matches() {
+        for allow_subdomains_origin in [true, false] {
+            for allow_any_port in [true, false] {
+                assert!(origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                ));
+
+                // Different package name shouldn't match
+                assert!(!origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.baz").unwrap(),
+                ));
+
+                // Prefixes and suffixes shouldn't match for opaque URLs
+                assert!(!origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
+                ));
+
+                assert!(!origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn test_origin_subdomain_suffix_boundary() {
+        let allowed_origin = Url::parse("https://example.com").unwrap();
+
+        // Should always be allowed
+        let allowed_urls: [Url; 4] = [
+            allowed_origin.clone(),
+            Url::parse("https://example.com/hello").unwrap(),
+            Url::parse("https://user@example.com").unwrap(),
+            Url::parse("https://user@example.com/hello").unwrap(),
+        ];
+
+        // Should only be allowed when subdomains are allowed
+        let allowed_subdomains: [Url; 2] = [
+            Url::parse("https://sub.example.com").unwrap(),
+            Url::parse("https://deep.subdomain.example.com").unwrap(),
+        ];
+
+        let denied_urls: [Url; 4] = [
+            // Parent domain
+            Url::parse("https://com").unwrap(),
+            // Different TLD
+            Url::parse("https://example.net").unwrap(),
+            // Prefixed string
+            Url::parse("https://otherexample.com").unwrap(),
+            Url::parse("https://other-example.com").unwrap(),
+        ];
+
+        for request_origin in &allowed_urls {
+            for allow_subdomains_origin in [true, false] {
+                for allow_any_port in [true, false] {
+                    assert!(
+                        origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &allowed_origin,
+                        ),
+                        "{allowed_origin} allows {request_origin}"
+                    );
+                }
+            }
+        }
+
+        for request_origin in &allowed_subdomains {
+            // Legitimate subdomain must be accepted
+            assert!(
+                origins_match(true, false, request_origin, &allowed_origin),
+                "{allowed_origin} allows {request_origin}",
+            );
+
+            assert!(
+                origins_match(true, true, request_origin, &allowed_origin),
+                "{allowed_origin} allows {request_origin}",
+            );
+
+            // ...unless subdomains are disallowed
+            assert!(
+                !origins_match(false, false, request_origin, &allowed_origin),
+                "{allowed_origin} denies {request_origin}",
+            );
+
+            assert!(
+                !origins_match(false, true, request_origin, &allowed_origin),
+                "{allowed_origin} denies {request_origin}",
+            );
+        }
+
+        // Denied domains should never be accepted
+        for request_origin in &denied_urls {
+            for allow_subdomains_origin in [true, false] {
+                for allow_any_port in [true, false] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &allowed_origin,
+                        ),
+                        "{allowed_origin} denies {request_origin}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Change summary

This fixes a couple of build issues that have recently popped up in CI.

### Move `origins_match()` to `webauthn-rs-proto`

The fix for https://github.com/kanidm/webauthn-rs/security/advisories/GHSA-22w3-693w-x895 in `webauthn-authenticator-rs` made `webauthn-rs-core` a required dependency. However, [this was still marked as an optional dependency](https://github.com/kanidm/webauthn-rs/blob/d2c10d53ca5ef033d37ee6462e936e9eb72ad98c/webauthn-authenticator-rs/Cargo.toml#L76), breaking the build when the `crypto` feature was not enabled.

`webauthn-rs-core` was made a non-optional dependency on the 6.0 branch (https://github.com/kanidm/webauthn-rs/commit/f52f315f756f4c181526f1821534cd95b767869b), but this can't be applied to the 5.x branch because `webauthn-rs-core` _always_ depends on OpenSSL, and some `webauthn-authenticator-rs` configurations do not (eg: Windows 10 WebAuthn API).

Nothing about the fix for that bug actually requires cryptography libraries, so this PR resolves the issue by moving `WebauthnCore::origins_match()` to `webauthn-rs-proto::origin::origins_match`, which is an existing dependency of both `webauthn-rs-core` and `webauthn-authenticator-rs`.

I've put the module behind an `origin` feature flag, so that it isn't included unless actually needed for size-sensitive targets (like WASM), even though it should be optimised out automatically by the compiler.

This also fixes a couple of clippy lints.

A similar change will need to be applied to the 6.0 branch.

### Don't build docs in CI for `tide` related targets

`tide` has a transitive dependency on `rustix@0.37.28` (old version), which doesn't build on Linux with Rust nightly due to it depending on now-removed compiler internals: https://github.com/bytecodealliance/rustix/issues/1620.

I don't think there's a lot of value in building docs of the tutorials in CI anyway.

There are many other paths to _newer_ versions of `rustix` in this codebase, but these don't seem to be impacted by that issue.

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
