### PR TITLE
6.0: Move `WebauthnCore::origins_match` to `webauthn-rs-proto`, don't build `tide` docs in CI (#554 cherry-pick)

### DIFF
--- a/.github/doc_manifest
+++ b/.github/doc_manifest
@@ -17,5 +17,4 @@ webauthn_rs/index.html
 webauthn_rs/interface/index.html
 
 webauthn_rs_core/index.html
-webauthn_rs_demo/index.html
 webauthn_rs_proto/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,10 +240,17 @@ jobs:
       # This tests that all the stubs work properly for optional dependencies,
       # but doesn't work for fido-key-manager which includes NFC and USB support
       # by default.
+      #
+      # tide_tutorial and webauthn-rs-demo are excluded from doc builds because
+      # of https://github.com/bytecodealliance/rustix/issues/1620, which is
+      # broken on Rust nightly.
       - name: generate docs
         run: |
-          cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc --all \
+          cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc \
+            --all \
             --exclude fido-key-manager \
+            --exclude tide_tutorial \
+            --exclude webauthn-rs-demo \
             --no-deps \
             --document-private-items
         env:
@@ -263,10 +270,12 @@ jobs:
           sudo apt-get -y install libpcsclite-dev libusb-1.0-0-dev libdbus-1-dev
       - run: |
           cargo ${{ matrix.rust_version == 'nightly' && '+nightly' || '' }} doc \
-          --all \
-          --no-deps \
-          --document-private-items \
-          --all-features
+            --all \
+            --exclude tide_tutorial \
+            --exclude webauthn-rs-demo \
+            --no-deps \
+            --document-private-items \
+            --all-features
         env:
           RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
       - uses: actions/upload-artifact@v4

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -50,6 +50,7 @@ ctap2 = [
     "dep:serde_bytes",
     "dep:tokio",
     "dep:tokio-stream",
+    "dep:webauthn-rs-core",
 ]
 ctap2-management = ["ctap2"]
 # Support for SoloKey's vendor commands

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -71,8 +71,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 base64.workspace = true
-webauthn-rs-proto.workspace = true
-webauthn-rs-core = { workspace = true }
+webauthn-rs-proto = { workspace = true, features = ["origin"] }
+webauthn-rs-core = { workspace = true, optional = true }
 crypto-glue.workspace = true
 
 tracing.workspace = true

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -110,8 +110,6 @@ extern crate num_derive;
 #[macro_use]
 extern crate tracing;
 
-use std::str::FromStr;
-
 use crate::error::WebauthnCError;
 #[cfg(any(
     all(doc, not(doctest)),
@@ -124,10 +122,10 @@ use crate::error::WebauthnCError;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_ENGINE;
 use url::Url;
 
-use webauthn_rs_core::WebauthnCore;
 use webauthn_rs_proto::{
-    CreationChallengeResponse, PublicKeyCredential, PublicKeyCredentialCreationOptions,
-    PublicKeyCredentialRequestOptions, RegisterPublicKeyCredential, RequestChallengeResponse,
+    origin::origins_match, CreationChallengeResponse, PublicKeyCredential,
+    PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions,
+    RegisterPublicKeyCredential, RequestChallengeResponse,
 };
 
 pub mod prelude {
@@ -337,7 +335,7 @@ impl<T: AuthenticatorBackend + ?Sized> WebauthnAuthenticator for T {
                 WebauthnCError::Security
             })?;
 
-        if !WebauthnCore::origins_match(true, true, &origin, &rp_id_url) {
+        if !origins_match(true, true, &origin, &rp_id_url) {
             error!(
                 "Relying party ID ({rp_id_url}) is not a suffix of the effective domain ({origin})"
             );
@@ -411,7 +409,7 @@ impl<T: AuthenticatorBackend + ?Sized> WebauthnAuthenticator for T {
                 WebauthnCError::Security
             })?;
 
-        if !WebauthnCore::origins_match(true, true, &origin, &rp_id_url) {
+        if !origins_match(true, true, &origin, &rp_id_url) {
             error!(
                 "Relying party ID ({rp_id_url}) is not a suffix of the effective domain ({origin})"
             );

--- a/webauthn-authenticator-rs/src/softtoken.rs
+++ b/webauthn-authenticator-rs/src/softtoken.rs
@@ -831,6 +831,7 @@ mod tests {
     use std::time::Duration;
     use tempfile::tempfile;
     use webauthn_rs_core::{
+        error::WebauthnError,
         proto::{AttestationCaList, AttestationCaListBuilder, COSEKey},
         WebauthnCore as Webauthn,
     };

--- a/webauthn-authenticator-rs/src/stubs.rs
+++ b/webauthn-authenticator-rs/src/stubs.rs
@@ -202,7 +202,7 @@ pub mod openssl {
     }
 }
 
-#[cfg(not(feature = "crypto"))]
+#[cfg(not(feature = "ctap2"))]
 pub mod webauthn_rs_core {
     pub mod proto {
         pub struct COSEEC2Key {}

--- a/webauthn-rs-core/Cargo.toml
+++ b/webauthn-rs-core/Cargo.toml
@@ -24,7 +24,7 @@ base64.workspace = true
 crypto-glue.workspace = true
 hex.workspace = true
 webauthn-attestation-ca.workspace = true
-webauthn-rs-proto.workspace = true
+webauthn-rs-proto = { workspace = true, features = ["origin"] }
 serde.workspace = true
 serde_cbor_2.workspace = true
 serde_json.workspace = true

--- a/webauthn-rs-core/src/core.rs
+++ b/webauthn-rs-core/src/core.rs
@@ -24,6 +24,7 @@ use crate::constants::CHALLENGE_SIZE_BYTES;
 use crate::crypto::compute_sha256;
 use crate::error::WebauthnError;
 use crate::internals::*;
+use crate::proto::origin::origins_match;
 use crate::proto::*;
 use rand::prelude::*;
 use std::time::{Duration, SystemTime};
@@ -482,7 +483,7 @@ impl WebauthnCore {
 
         // Verify that the client's origin matches one of our allowed origins..
         if !self.allowed_origins.iter().any(|origin| {
-            Self::origins_match(
+            origins_match(
                 self.allow_subdomains_origin,
                 self.allow_any_port,
                 &data.client_data_json.origin,
@@ -804,7 +805,7 @@ impl WebauthnCore {
 
         // Verify that the value of C.origin matches one of our allowed origins.
         if !self.allowed_origins.iter().any(|origin| {
-            Self::origins_match(
+            origins_match(
                 self.allow_subdomains_origin,
                 self.allow_any_port,
                 &c.origin,
@@ -1184,85 +1185,20 @@ impl WebauthnCore {
 
     /// Check if a `request_origin` is an allowed suffix of `allowed_origin`.
     ///
-    /// If either `request_origin` or `allowed_origin` are opaque URLs, they must exactly match.
-    ///
-    /// ### Arguments
-    ///
-    /// * `allow_subdomains_origin`: if `true`, `request_origin` may be a subdomain of
-    ///   `allowed_origin`.
-    ///
-    ///   **Note:** this *does not* verify whether `allowed_origin` (or a parent of it) is a valid
-    ///   registerable domain.
-    ///
-    /// * `allow_any_port`: if `true`, `request_origin` may be a different port to `allowed_origin`. The
-    ///   URLs' schemes must still match.
-    ///
-    /// ### References
-    ///
-    /// * [HTML Standard §7.1.1.2, registerable domain suffix][0]
-    ///
-    /// [0]: https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to
+    /// **Deprecated:** use [`webauthn_rs_proto::origin::origins_match()`][] instead.
+    #[deprecated(note = "Use webauthn_rs_proto::origin::origins_match")]
     pub fn origins_match(
         allow_subdomains_origin: bool,
         allow_any_port: bool,
         request_origin: &Url,
         allowed_origin: &Url,
     ) -> bool {
-        if allowed_origin == request_origin {
-            // Exact URL match
-            return true;
-        }
-
-        if allowed_origin.scheme() != request_origin.scheme() {
-            // Full URL scheme mismatch
-            return false;
-        }
-
-        // Check the Origin
-        match (allowed_origin.origin(), request_origin.origin()) {
-            (
-                url::Origin::Tuple(rp_id_scheme, rp_id_host, rp_id_port),
-                url::Origin::Tuple(request_scheme, request_host, request_port),
-            ) => {
-                if rp_id_scheme != request_scheme {
-                    // Origin scheme mismatch
-                    return false;
-                }
-
-                if !allow_any_port && rp_id_port != request_port {
-                    // Port mismatch
-                    return false;
-                }
-
-                match (rp_id_host, request_host) {
-                    // Both hosts are a domain
-                    (url::Host::Domain(rp_id_domain), url::Host::Domain(request_domain)) => {
-                        if rp_id_domain == request_domain {
-                            // Domains exactly match
-                            return true;
-                        }
-
-                        // Ensure "badexample.com" doesn't match "example.com", but
-                        // "sub.example.com" does.
-                        return allow_subdomains_origin
-                            && request_domain
-                                .strip_suffix(&rp_id_domain)
-                                .map(|prefix| prefix.ends_with('.'))
-                                .unwrap_or(false);
-                    }
-
-                    (rp_id_host, request_host) => {
-                        // At least one is a non-domain host, always require exact match.
-                        return rp_id_host == request_host;
-                    }
-                }
-            }
-
-            _ => {
-                // Opaque URL which isn't equal
-                false
-            }
-        }
+        origins_match(
+            allow_subdomains_origin,
+            allow_any_port,
+            request_origin,
+            allowed_origin,
+        )
     }
 
     /// Returns the RP name
@@ -3666,271 +3602,6 @@ mod tests {
             result,
             Err(WebauthnError::CredentialInsecureCryptography)
         ))
-    }
-
-    /// Test `origins_match` with simple case.
-    #[test]
-    fn test_origins_match_exact() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let request_origin = url::Url::parse("https://example.com").unwrap();
-        let allowed_origin = url::Url::parse("https://example.com").unwrap();
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-    }
-
-    /// Test `origins_match` with scheme changes, which should never match.
-    #[test]
-    fn test_origins_match_scheme() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let http_url = url::Url::parse("http://example.com").unwrap();
-        let https_url = url::Url::parse("https://example.com").unwrap();
-        let ws_url = url::Url::parse("ws://example.com").unwrap();
-        let wss_url = url::Url::parse("wss://example.com").unwrap();
-
-        for allow_subdomains_origin in [true, false] {
-            for allow_any_port in [true, false] {
-                for request_origin in [&http_url, &ws_url, &wss_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &https_url,
-                        ),
-                        "expected {https_url} to not match {request_origin}",
-                    );
-                }
-
-                for request_origin in [&https_url, &ws_url, &wss_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &http_url,
-                        ),
-                        "expected {http_url} to not match {request_origin}",
-                    );
-                }
-
-                for request_origin in [&http_url, &https_url, &wss_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &ws_url,
-                        ),
-                        "expected {ws_url} to not match {request_origin}",
-                    );
-                }
-
-                for request_origin in [&http_url, &https_url, &ws_url] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &wss_url,
-                        ),
-                        "expected {wss_url} to not match {request_origin}",
-                    );
-                }
-            }
-        }
-    }
-
-    /// Test `origins_match` with different ports on `localhost`
-    #[test]
-    fn test_origins_match_localhost_port() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let request_origin = url::Url::parse("http://localhost:8000").unwrap();
-        let allowed_origin = url::Url::parse("http://localhost:3000").unwrap();
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ true,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        // Differing ports should fail
-        assert!(!Webauthn::origins_match(
-            /* subdomains */ true,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-
-        assert!(!Webauthn::origins_match(
-            /* subdomains */ false,
-            /* any port */ false,
-            &request_origin,
-            &allowed_origin,
-        ));
-    }
-
-    #[test]
-    fn test_origin_ios_matches() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        for allow_subdomains_origin in [true, false] {
-            for allow_any_port in [true, false] {
-                assert!(Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                ));
-
-                // Different package name shouldn't match
-                assert!(!Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.baz").unwrap(),
-                ));
-
-                // Prefixes and suffixes shouldn't match for opaque URLs
-                assert!(!Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
-                ));
-
-                assert!(!Webauthn::origins_match(
-                    allow_subdomains_origin,
-                    allow_any_port,
-                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
-                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
-                ));
-            }
-        }
-    }
-
-    #[test]
-    fn test_origin_subdomain_suffix_boundary() {
-        let _ = tracing_subscriber::fmt::try_init();
-
-        let allowed_origin = Url::parse("https://example.com").unwrap();
-
-        // Should always be allowed
-        let allowed_urls: [Url; 4] = [
-            allowed_origin.clone(),
-            Url::parse("https://example.com/hello").unwrap(),
-            Url::parse("https://user@example.com").unwrap(),
-            Url::parse("https://user@example.com/hello").unwrap(),
-        ];
-
-        // Should only be allowed when subdomains are allowed
-        let allowed_subdomains: [Url; 2] = [
-            Url::parse("https://sub.example.com").unwrap(),
-            Url::parse("https://deep.subdomain.example.com").unwrap(),
-        ];
-
-        let denied_urls: [Url; 4] = [
-            // Parent domain
-            Url::parse("https://com").unwrap(),
-            // Different TLD
-            Url::parse("https://example.net").unwrap(),
-            // Prefixed string
-            Url::parse("https://otherexample.com").unwrap(),
-            Url::parse("https://other-example.com").unwrap(),
-        ];
-
-        for request_origin in &allowed_urls {
-            for allow_subdomains_origin in [true, false] {
-                for allow_any_port in [true, false] {
-                    assert!(
-                        Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &allowed_origin,
-                        ),
-                        "{allowed_origin} allows {request_origin}"
-                    );
-                }
-            }
-        }
-
-        for request_origin in &allowed_subdomains {
-            // Legitimate subdomain must be accepted
-            assert!(
-                Webauthn::origins_match(true, false, request_origin, &allowed_origin),
-                "{allowed_origin} allows {request_origin}",
-            );
-
-            assert!(
-                Webauthn::origins_match(true, true, request_origin, &allowed_origin),
-                "{allowed_origin} allows {request_origin}",
-            );
-
-            // ...unless subdomains are disallowed
-            assert!(
-                !Webauthn::origins_match(false, false, request_origin, &allowed_origin),
-                "{allowed_origin} denies {request_origin}",
-            );
-
-            assert!(
-                !Webauthn::origins_match(false, true, request_origin, &allowed_origin),
-                "{allowed_origin} denies {request_origin}",
-            );
-        }
-
-        // Denied domains should never be accepted
-        for request_origin in &denied_urls {
-            for allow_subdomains_origin in [true, false] {
-                for allow_any_port in [true, false] {
-                    assert!(
-                        !Webauthn::origins_match(
-                            allow_subdomains_origin,
-                            allow_any_port,
-                            request_origin,
-                            &allowed_origin,
-                        ),
-                        "{allowed_origin} denies {request_origin}"
-                    );
-                }
-            }
-        }
     }
 
     #[test]

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -17,6 +17,11 @@ repository = { workspace = true }
 
 [features]
 default = []
+
+# Origin-checking, this is an internal implementation detail
+origin = []
+
+# WASM bindings
 wasm = ["wasm-bindgen", "web-sys", "js-sys", "serde-wasm-bindgen"]
 
 [package.metadata.docs.rs]

--- a/webauthn-rs-proto/src/lib.rs
+++ b/webauthn-rs-proto/src/lib.rs
@@ -12,6 +12,9 @@ pub mod cose;
 pub mod extensions;
 pub mod options;
 
+#[cfg(any(test, feature = "origin"))]
+pub mod origin;
+
 #[cfg(feature = "wasm")]
 pub mod wasm;
 

--- a/webauthn-rs-proto/src/origin.rs
+++ b/webauthn-rs-proto/src/origin.rs
@@ -1,0 +1,345 @@
+//! WebAuthn Origin checks
+use url::Url;
+
+/// Check if a `request_origin` is an allowed suffix of `allowed_origin`.
+///
+/// If either `request_origin` or `allowed_origin` are opaque URLs, they must exactly match.
+///
+/// ### Arguments
+///
+/// * `allow_subdomains_origin`: if `true`, `request_origin` may be a subdomain of
+///   `allowed_origin`.
+///
+///   **Note:** this *does not* verify whether `allowed_origin` (or a parent of it) is a valid
+///   registerable domain.
+///
+/// * `allow_any_port`: if `true`, `request_origin` may be a different port to `allowed_origin`. The
+///   URLs' schemes must still match.
+///
+/// ### References
+///
+/// * [HTML Standard §7.1.1.2, registerable domain suffix][0]
+///
+/// [0]: https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to
+pub fn origins_match(
+    allow_subdomains_origin: bool,
+    allow_any_port: bool,
+    request_origin: &Url,
+    allowed_origin: &Url,
+) -> bool {
+    if allowed_origin == request_origin {
+        // Exact URL match
+        return true;
+    }
+
+    if allowed_origin.scheme() != request_origin.scheme() {
+        // Full URL scheme mismatch
+        return false;
+    }
+
+    // Check the Origin
+    match (allowed_origin.origin(), request_origin.origin()) {
+        (
+            url::Origin::Tuple(rp_id_scheme, rp_id_host, rp_id_port),
+            url::Origin::Tuple(request_scheme, request_host, request_port),
+        ) => {
+            if rp_id_scheme != request_scheme {
+                // Origin scheme mismatch
+                return false;
+            }
+
+            if !allow_any_port && rp_id_port != request_port {
+                // Port mismatch
+                return false;
+            }
+
+            match (rp_id_host, request_host) {
+                // Both hosts are a domain
+                (url::Host::Domain(rp_id_domain), url::Host::Domain(request_domain)) => {
+                    if rp_id_domain == request_domain {
+                        // Domains exactly match
+                        return true;
+                    }
+
+                    // Ensure "badexample.com" doesn't match "example.com", but
+                    // "sub.example.com" does.
+                    allow_subdomains_origin
+                        && request_domain
+                            .strip_suffix(&rp_id_domain)
+                            .map(|prefix| prefix.ends_with('.'))
+                            .unwrap_or(false)
+                }
+
+                (rp_id_host, request_host) => {
+                    // At least one is a non-domain host, always require exact match.
+                    rp_id_host == request_host
+                }
+            }
+        }
+
+        _ => {
+            // Opaque URL which isn't equal
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test `origins_match` with simple case.
+    #[test]
+    fn test_origins_match_exact() {
+        let request_origin = url::Url::parse("https://example.com").unwrap();
+        let allowed_origin = url::Url::parse("https://example.com").unwrap();
+
+        assert!(origins_match(
+            /* subdomains */ true,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ false,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ true,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ false,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+    }
+
+    /// Test `origins_match` with scheme changes, which should never match.
+    #[test]
+    fn test_origins_match_scheme() {
+        let http_url = url::Url::parse("http://example.com").unwrap();
+        let https_url = url::Url::parse("https://example.com").unwrap();
+        let ws_url = url::Url::parse("ws://example.com").unwrap();
+        let wss_url = url::Url::parse("wss://example.com").unwrap();
+
+        for allow_subdomains_origin in [true, false] {
+            for allow_any_port in [true, false] {
+                for request_origin in [&http_url, &ws_url, &wss_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &https_url,
+                        ),
+                        "expected {https_url} to not match {request_origin}",
+                    );
+                }
+
+                for request_origin in [&https_url, &ws_url, &wss_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &http_url,
+                        ),
+                        "expected {http_url} to not match {request_origin}",
+                    );
+                }
+
+                for request_origin in [&http_url, &https_url, &wss_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &ws_url,
+                        ),
+                        "expected {ws_url} to not match {request_origin}",
+                    );
+                }
+
+                for request_origin in [&http_url, &https_url, &ws_url] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &wss_url,
+                        ),
+                        "expected {wss_url} to not match {request_origin}",
+                    );
+                }
+            }
+        }
+    }
+
+    /// Test `origins_match` with different ports on `localhost`
+    #[test]
+    fn test_origins_match_localhost_port() {
+        let request_origin = url::Url::parse("http://localhost:8000").unwrap();
+        let allowed_origin = url::Url::parse("http://localhost:3000").unwrap();
+
+        assert!(origins_match(
+            /* subdomains */ true,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(origins_match(
+            /* subdomains */ false,
+            /* any port */ true,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        // Differing ports should fail
+        assert!(!origins_match(
+            /* subdomains */ true,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+
+        assert!(!origins_match(
+            /* subdomains */ false,
+            /* any port */ false,
+            &request_origin,
+            &allowed_origin,
+        ));
+    }
+
+    #[test]
+    fn test_origin_ios_matches() {
+        for allow_subdomains_origin in [true, false] {
+            for allow_any_port in [true, false] {
+                assert!(origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                ));
+
+                // Different package name shouldn't match
+                assert!(!origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.baz").unwrap(),
+                ));
+
+                // Prefixes and suffixes shouldn't match for opaque URLs
+                assert!(!origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
+                ));
+
+                assert!(!origins_match(
+                    allow_subdomains_origin,
+                    allow_any_port,
+                    &Url::parse("ios:bundle-id:com.foo.bar.other").unwrap(),
+                    &Url::parse("ios:bundle-id:com.foo.bar").unwrap(),
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn test_origin_subdomain_suffix_boundary() {
+        let allowed_origin = Url::parse("https://example.com").unwrap();
+
+        // Should always be allowed
+        let allowed_urls: [Url; 4] = [
+            allowed_origin.clone(),
+            Url::parse("https://example.com/hello").unwrap(),
+            Url::parse("https://user@example.com").unwrap(),
+            Url::parse("https://user@example.com/hello").unwrap(),
+        ];
+
+        // Should only be allowed when subdomains are allowed
+        let allowed_subdomains: [Url; 2] = [
+            Url::parse("https://sub.example.com").unwrap(),
+            Url::parse("https://deep.subdomain.example.com").unwrap(),
+        ];
+
+        let denied_urls: [Url; 4] = [
+            // Parent domain
+            Url::parse("https://com").unwrap(),
+            // Different TLD
+            Url::parse("https://example.net").unwrap(),
+            // Prefixed string
+            Url::parse("https://otherexample.com").unwrap(),
+            Url::parse("https://other-example.com").unwrap(),
+        ];
+
+        for request_origin in &allowed_urls {
+            for allow_subdomains_origin in [true, false] {
+                for allow_any_port in [true, false] {
+                    assert!(
+                        origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &allowed_origin,
+                        ),
+                        "{allowed_origin} allows {request_origin}"
+                    );
+                }
+            }
+        }
+
+        for request_origin in &allowed_subdomains {
+            // Legitimate subdomain must be accepted
+            assert!(
+                origins_match(true, false, request_origin, &allowed_origin),
+                "{allowed_origin} allows {request_origin}",
+            );
+
+            assert!(
+                origins_match(true, true, request_origin, &allowed_origin),
+                "{allowed_origin} allows {request_origin}",
+            );
+
+            // ...unless subdomains are disallowed
+            assert!(
+                !origins_match(false, false, request_origin, &allowed_origin),
+                "{allowed_origin} denies {request_origin}",
+            );
+
+            assert!(
+                !origins_match(false, true, request_origin, &allowed_origin),
+                "{allowed_origin} denies {request_origin}",
+            );
+        }
+
+        // Denied domains should never be accepted
+        for request_origin in &denied_urls {
+            for allow_subdomains_origin in [true, false] {
+                for allow_any_port in [true, false] {
+                    assert!(
+                        !origins_match(
+                            allow_subdomains_origin,
+                            allow_any_port,
+                            request_origin,
+                            &allowed_origin,
+                        ),
+                        "{allowed_origin} denies {request_origin}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Change summary

Cherry-pick of #554 on the 6.0 branch, and some extra build fixes for `webauthn-authenticator-rs`:

- Make `webauthn-rs-core` an optional dependency again, used when the `ctap2` feature is enabled (reverting https://github.com/kanidm/webauthn-rs/commit/f52f315f756f4c181526f1821534cd95b767869b)
- Provide `webauthn-rs-core` documentation stubs when `ctap2` is disabled (rather than `crypto`).
- Add missing `use` for `softtoken` tests.

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
