### PR TITLE
6.0: remove `openssl` from Windows CI runners, webauthn-authenticator-rs CI cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
             --all-features
         env:
           RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: docs-${{ matrix.rust_version }}-all_features
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -43,12 +43,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - if: runner.os != 'windows'
         run: |
@@ -143,12 +143,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       # Linux-only dependencies
       - if: runner.os != 'windows'
@@ -227,11 +227,11 @@ jobs:
         rust_version: [stable, nightly]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - run: |
           sudo apt-get update && \
           sudo apt-get -y install libudev-dev
@@ -301,11 +301,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - run: cargo build -p actix_tutorial -p axum_tutorial -p tide_tutorial

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,10 +194,10 @@ jobs:
       # Some clap errors manifest as panics at runtime. Running tools with
       # --help should be enough to find an issue.
 
-      # authenticate example should work without OpenSSL on any platform.
+      # authenticate example requires crypto.
       - name: "example: authenticate --help"
         run: |
-          cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},ui-cli -- --help
+          cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},crypto,ui-cli -- --help
 
       # caBLE-specific examples.
       - name: "example: authenticate --help +qrcode (caBLE only)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
             --document-private-items
         env:
           RUSTDOCFLAGS: ${{ matrix.rust_version == 'nightly' && '--cfg docsrs' || '' }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: docs-${{ matrix.rust_version }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
 
+      # Linux-only dependencies
       - if: runner.os != 'windows'
         run: |
           sudo apt-get update && \
@@ -159,62 +160,62 @@ jobs:
       - if: contains(matrix.features, 'usb') && runner.os != 'windows'
         run: sudo apt-get -y install libusb-1.0-0-dev
 
-      # Don't try to install OpenSSL when there's only the "win10" feature
-      # enabled. We should be able to operate without it.
-      - if: runner.os == 'windows' && matrix.features != 'win10'
-        uses: johnwason/vcpkg-action@v4
-        with:
-          pkgs: openssl
-          triplet: x64-windows-static-md
-          token: ${{ github.token }}
-
-      - run: cargo build -p webauthn-authenticator-rs --features ${{ matrix.features }}
+      - name: "build"
+        run: cargo build -p webauthn-authenticator-rs --features ${{ matrix.features }}
 
       # Don't run clippy on Windows unless it is using a Windows-specific
       # feature which wasn't checked on Linux.
-      - if: runner.os != 'windows' || contains(matrix.features, 'win10')
+      - name: "clippy: webauthn-authenticator-rs"
+        if: runner.os != 'windows' || contains(matrix.features, 'win10')
         run: |
           cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets --features ${{ matrix.features }}
-      - if: runner.os != 'windows' || contains(matrix.features, 'win10')
+      - name: "clippy: webauthn-authenticator-rs +ui-cli"
+        if: runner.os != 'windows' || contains(matrix.features, 'win10')
         run: |
           cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets --features ${{ matrix.features }},ui-cli
-      - if: runner.os != 'windows' || contains(matrix.features, 'win10')
+      - name: "clippy: webauthn-authenticator-rs +qrcode +ui-cli"
+        if: runner.os != 'windows' || contains(matrix.features, 'win10')
         run: |
           cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets --features ${{ matrix.features }},qrcode,ui-cli
 
-      # "ctap2-management" requires OpenSSL, which we won't have if built with
-      # only "win10" feature on Windows.
-      - if: runner.os != 'windows' || (contains(matrix.features, 'win10') && matrix.features != 'win10')
+      # "ctap2-management" requires a `ctap2` backend
+      - name: "clippy: webauthn-authenticator-rs +ctap2-management"
+        if: runner.os != 'windows' || (contains(matrix.features, 'win10') && matrix.features != 'win10')
         run: |
           cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets --features ${{ matrix.features }},ctap2-management
-      - if: runner.os != 'windows' || (contains(matrix.features, 'win10') && matrix.features != 'win10')
+      - name: "clippy: webauthn-authenticator-rs +ctap2-management +qrcode +ui-cli"
+        if: runner.os != 'windows' || (contains(matrix.features, 'win10') && matrix.features != 'win10')
         run: |
           cargo clippy --no-deps -p webauthn-authenticator-rs --all-targets --features ${{ matrix.features }},ctap2-management,qrcode,ui-cli
 
-      - run: cargo test -p webauthn-authenticator-rs --features ${{ matrix.features }}
+      - name: "unit tests"
+        run: cargo test -p webauthn-authenticator-rs --features ${{ matrix.features }}
 
       # Some clap errors manifest as panics at runtime. Running tools with
       # --help should be enough to find an issue.
 
-      # authenticate example requires OpenSSL (via webauthn-rs-core), so don't
-      # run if features == 'win10'.
-      - if: runner.os != 'windows' || matrix.features != 'win10'
+      # authenticate example should work without OpenSSL on any platform.
+      - name: "example: authenticate --help"
         run: |
           cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},ui-cli -- --help
 
       # caBLE-specific examples.
-      - if: contains(matrix.features, 'cable')
+      - name: "example: authenticate --help +qrcode (caBLE only)"
+        if: contains(matrix.features, 'cable')
         run: |
           cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},qrcode,ui-cli -- --help
-      - if: contains(matrix.features, 'cable')
+      - name: "example: cable_domain --help (caBLE only)"
+        if: contains(matrix.features, 'cable')
         run: |
           cargo run -p webauthn-authenticator-rs --example cable_domain --features ${{ matrix.features }} -- --help
-      - if: contains(matrix.features, 'cable')
+      - name: "example: cable_tunnel --help (caBLE only)"
+        if: contains(matrix.features, 'cable')
         run: |
           cargo run -p webauthn-authenticator-rs --example cable_tunnel --features ${{ matrix.features }},ui-cli -- --help
 
       # SoftToken-specific examples.
-      - if: contains(matrix.features, 'softtoken')
+      - name: "example: softtoken --help (softtoken only)"
+        if: contains(matrix.features, 'softtoken')
         run: |
           cargo run -p webauthn-authenticator-rs --example softtoken --features ${{ matrix.features }} -- --help
 

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -127,6 +127,7 @@ clap.workspace = true
 tokio.workspace = true
 tempfile = { version = "3.23.0" }
 hex = { workspace = true }
+webauthn-rs-core = { workspace = true }
 
 # cable_tunnel - used for connecting to Bluetooth HCI controller over serial
 serialport = { version = "4.8.1" }


### PR DESCRIPTION
## Change summary

CI related cleanups, targetting the #504 branch:

* Don't install the `openssl` package on Windows CI runners for all crates (as we now use RustCrypto).

* Update `actions/checkout`, `actions/upload-artifact` and `mozilla-actions/sccache-action` to current versions (due to NodeJS deprecations).

* `webauthn-authenticator-rs`:

  * Label build steps.

  * Run the `authenticate` example with `--help` example on Windows CI runners, as this no longer requires OpenSSL.

    (If we're able to test the Windows platform APIs in future, then we could do something more in depth than this.)

  * Make `webauthn-rs-core` a `dev-dependency`, so that the `authenticate` example works without the `ctap2` feature

    (In future, I'd like to split out these examples with their own dependency trees, because they come with a lot of baggage that slows down the main unit tests.)

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
