### PR TITLE
tutorials: inherit metadata from workspace, disable publishing

### DIFF
--- a/tutorial/server/actix_web/Cargo.toml
+++ b/tutorial/server/actix_web/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "actix_tutorial"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 authors = ["Niklas Pfister <git@omikron.dev>"]
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tutorial/server/axum/Cargo.toml
+++ b/tutorial/server/axum/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "axum_tutorial"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 authors = [
-    "William Brown <william@blackhats.net.au>, Ben Wishovich <ben@benw.is>",
+    "William Brown <william@blackhats.net.au>",
+    "Ben Wishovich <ben@benw.is>",
 ]
-license = "MPL-2.0"
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tutorial/wasm/Cargo.toml
+++ b/tutorial/wasm/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "wasm_tutorial"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 authors = ["William Brown <william@blackhats.net.au>"]
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Change summary

Makes the tutorials inherit metadata (like version and license information) from the workspace, fix a minor syntax issue, and disable package publishing.

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
