### PR TITLE
6.0: Remove the `crypto` feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,10 +194,9 @@ jobs:
       # Some clap errors manifest as panics at runtime. Running tools with
       # --help should be enough to find an issue.
 
-      # authenticate example requires crypto.
       - name: "example: authenticate --help"
         run: |
-          cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},crypto,ui-cli -- --help
+          cargo run -p webauthn-authenticator-rs --example authenticate --features ${{ matrix.features }},ui-cli -- --help
 
       # caBLE-specific examples.
       - name: "example: authenticate --help +qrcode (caBLE only)"

--- a/webauthn-authenticator-rs/Cargo.toml
+++ b/webauthn-authenticator-rs/Cargo.toml
@@ -20,8 +20,6 @@ ui-cli = ["dep:rpassword"]
 # Add QR code support for `UiCallback`, useful with `cable` feature
 qrcode = ["dep:qrcode", "ui-cli"]
 
-crypto = []
-
 # Authenticator transports
 mozilla = ["dep:authenticator", "dep:rpassword"]
 u2fhid = ["mozilla"]
@@ -31,7 +29,6 @@ bluetooth = ["dep:btleplug", "ctap2"]
 # caBLE / hybrid authenticator
 cable = [
     "dep:btleplug",
-    "crypto",
     "ctap2",
     "dep:hex",
     "dep:tokio",
@@ -45,7 +42,6 @@ cable = [
 cable-override-tunnel = ["cable"]
 
 ctap2 = [
-    "crypto",
     "dep:hex",
     "dep:serde_bytes",
     "dep:tokio",
@@ -59,8 +55,8 @@ vendor-solokey = []
 vendor-yubikey = []
 nfc = ["ctap2", "dep:pcsc"]
 # TODO: allow running softpasskey without softtoken
-softpasskey = ["crypto", "softtoken"]
-softtoken = ["crypto", "ctap2"]
+softpasskey = ["softtoken"]
+softtoken = ["ctap2"]
 usb = ["ctap2", "dep:fido-hid-rs"]
 win10 = ["dep:windows"]
 
@@ -144,7 +140,7 @@ bluer = { version = "0.17.4", features = ["bluetoothd"] }
 
 [[example]]
 name = "authenticate"
-required-features = ["crypto", "ui-cli"]
+required-features = ["ui-cli"]
 
 [[example]]
 name = "cable_domain"

--- a/webauthn-authenticator-rs/examples/cable_tunnel.rs
+++ b/webauthn-authenticator-rs/examples/cable_tunnel.rs
@@ -17,13 +17,13 @@
 //! ```sh
 //! # Create a SoftToken file in /tmp
 //! cargo run --example softtoken \
-//!     --features crypto,ui-cli,softtoken \
+//!     --features ui-cli,softtoken \
 //!     -- \
 //!     create /tmp/softtoken.dat
 //!
 //! # Expose it to an initiator via its caBLE URL using Bluez (Linux)
 //! cargo run --example cable_tunnel \
-//!     --features cable,crypto,ui-cli,qrcode,softtoken \
+//!     --features cable,ui-cli,qrcode,softtoken \
 //!     -- \
 //!     --bluez \
 //!     --softtoken-path /tmp/softtoken.dat \

--- a/webauthn-authenticator-rs/src/authenticator_hashed.rs
+++ b/webauthn-authenticator-rs/src/authenticator_hashed.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 
 #[cfg(feature = "ctap2")]
 use serde_cbor_2::{ser::to_vec_packed, Value};
-#[cfg(any(all(doc, not(doctest)), feature = "crypto"))]
 use url::Url;
 #[cfg(feature = "ctap2")]
 use webauthn_rs_proto::PublicKeyCredentialDescriptor;
@@ -18,7 +17,6 @@ use crate::ctap2::commands::{
     GetAssertionRequest, GetAssertionResponse, MakeCredentialRequest, MakeCredentialResponse,
 };
 use crate::error::WebauthnCError;
-#[cfg(any(all(doc, not(doctest)), feature = "crypto"))]
 use crate::{
     crypto::compute_sha256,
     util::{creation_to_clientdata, get_to_clientdata},
@@ -84,7 +82,6 @@ pub trait AuthenticatorBackendHashedClientData {
     ) -> Result<PublicKeyCredential, WebauthnCError>;
 }
 
-#[cfg(any(all(doc, not(doctest)), feature = "crypto"))]
 /// This provides a [AuthenticatorBackend] implementation for
 /// [AuthenticatorBackendHashedClientData] implementations.
 ///

--- a/webauthn-authenticator-rs/src/authenticator_hashed.rs
+++ b/webauthn-authenticator-rs/src/authenticator_hashed.rs
@@ -16,9 +16,9 @@ use webauthn_rs_proto::{
 use crate::ctap2::commands::{
     GetAssertionRequest, GetAssertionResponse, MakeCredentialRequest, MakeCredentialResponse,
 };
-use crate::error::WebauthnCError;
 use crate::{
     crypto::compute_sha256,
+    error::WebauthnCError,
     util::{creation_to_clientdata, get_to_clientdata},
     AuthenticatorBackend,
 };

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -61,6 +61,15 @@
 //!
 //! * `ui-cli`: [Cli][] UI
 //!
+//! ## Migrating to v0.6
+//!
+//! `webauthn-authenticator-rs` v0.6 migrated cryptographic functionality from
+//! OpenSSL to RustCrypto. APIs that exposed or consumed `openssl-rs` types have
+//! been updated to equivalent RustCrypto types, and you no longer need to
+//! install OpenSSL!
+//!
+//! The `crypto` feature flag has been removed.
+//!
 //! [FIDO2 certified]: https://fidoalliance.org/fido-certified-showcase/
 //! [Bluetooth]: crate::bluetooth
 //! [cert]: https://fidoalliance.org/certification/authenticator-certification-levels/

--- a/webauthn-authenticator-rs/src/lib.rs
+++ b/webauthn-authenticator-rs/src/lib.rs
@@ -36,34 +36,25 @@
 //!
 //! ### Transports and backends
 //!
-//! * `bluetooth`: [Bluetooth][] [^rustcrypto]
-//! * `cable`: [caBLE / Hybrid Authenticator][cable] [^rustcrypto]
+//! * `bluetooth`: [Bluetooth][]
+//! * `cable`: [caBLE / Hybrid Authenticator][cable]
 //!   * `cable-override-tunnel`: [Override caBLE tunnel server URLs][cable-url]
 //! * `mozilla`: [Mozilla Authenticator][], formerly known as `u2fhid`
-//! * `nfc`: [NFC][] via PC/SC API  [^rustcrypto]
-//! * `softpasskey`: [SoftPasskey][] (for testing) [^rustcrypto]
-//! * `softtoken`: [SoftToken][] (for testing) [^rustcrypto]
-//! * `usb`: [USB HID][] [^rustcrypto]
+//! * `nfc`: [NFC][] via PC/SC API
+//! * `softpasskey`: [SoftPasskey][] (for testing)
+//! * `softtoken`: [SoftToken][] (for testing)
+//! * `usb`: [USB HID][]
 //! * `win10`: [Windows 10][] WebAuthn API
-//!
-//! [^rustcrypto]: Feature requires RustCrypto.
 //!
 //! ### Miscellaneous features
 //!
-//! * `ctap2`: [CTAP 2.0, 2.1 and 2.1-PRE implementation][crate::ctap2]
-//!   [^rustcrypto].
+//! * `ctap2`: [CTAP 2.0, 2.1 and 2.1-PRE implementation][crate::ctap2].
 //!
 //!   Automatically enabled by the `bluetooth`, `cable`, `ctap2-management`,
 //!   `nfc`, `softtoken` and `usb` features.
 //!
 //!   * `ctap2-management`: Adds support for configuring and managing CTAP 2.x
 //!     hardware authenticators to the [CTAP 2.x implementation][crate::ctap2].
-//!
-//! * `crypto`: Enables a dependency on RustCrypto [^rustcrypto].
-//!
-//!   [This will eventually replace all usages of OpenSSL][no-openssl].
-//!
-//!   Automatically enabled by the `ctap2` and `softpasskey` features.
 //!
 //! * `qrcode`: QR code display for the [Cli][] UI, recommended for use if the
 //!   `cable` and `ui-cli` features are both enabled
@@ -133,7 +124,6 @@ pub mod prelude {
 }
 
 mod authenticator_hashed;
-#[cfg(any(all(doc, not(doctest)), feature = "crypto"))]
 mod crypto;
 
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2"))]

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -1,26 +1,14 @@
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2-management"))]
 use unicode_normalization::UnicodeNormalization;
-#[cfg(any(
-    all(doc, not(doctest)),
-    feature = "ctap2",
-    feature = "win10"
-))]
+#[cfg(any(all(doc, not(doctest)), feature = "ctap2", feature = "win10"))]
 use url::Url;
-#[cfg(any(
-    all(doc, not(doctest)),
-    feature = "ctap2",
-    feature = "win10"
-))]
+#[cfg(any(all(doc, not(doctest)), feature = "ctap2", feature = "win10"))]
 use webauthn_rs_proto::CollectedClientData;
 
 #[cfg(any(all(doc, not(doctest)), feature = "ctap2-management"))]
 use crate::error::WebauthnCError;
 
-#[cfg(any(
-    all(doc, not(doctest)),
-    feature = "ctap2",
-    feature = "win10"
-))]
+#[cfg(any(all(doc, not(doctest)), feature = "ctap2", feature = "win10"))]
 pub fn creation_to_clientdata(origin: Url, challenge: Vec<u8>) -> CollectedClientData {
     // Let collectedClientData be a new CollectedClientData instance whose fields are:
     //    type
@@ -43,11 +31,7 @@ pub fn creation_to_clientdata(origin: Url, challenge: Vec<u8>) -> CollectedClien
     }
 }
 
-#[cfg(any(
-    all(doc, not(doctest)),
-    feature = "ctap2",
-    feature = "win10"
-))]
+#[cfg(any(all(doc, not(doctest)), feature = "ctap2", feature = "win10"))]
 pub fn get_to_clientdata(origin: Url, challenge: Vec<u8>) -> CollectedClientData {
     CollectedClientData {
         type_: "webauthn.get".to_string(),

--- a/webauthn-authenticator-rs/src/util.rs
+++ b/webauthn-authenticator-rs/src/util.rs
@@ -2,14 +2,12 @@
 use unicode_normalization::UnicodeNormalization;
 #[cfg(any(
     all(doc, not(doctest)),
-    feature = "crypto",
     feature = "ctap2",
     feature = "win10"
 ))]
 use url::Url;
 #[cfg(any(
     all(doc, not(doctest)),
-    feature = "crypto",
     feature = "ctap2",
     feature = "win10"
 ))]
@@ -20,7 +18,6 @@ use crate::error::WebauthnCError;
 
 #[cfg(any(
     all(doc, not(doctest)),
-    feature = "crypto",
     feature = "ctap2",
     feature = "win10"
 ))]
@@ -48,7 +45,6 @@ pub fn creation_to_clientdata(origin: Url, challenge: Vec<u8>) -> CollectedClien
 
 #[cfg(any(
     all(doc, not(doctest)),
-    feature = "crypto",
     feature = "ctap2",
     feature = "win10"
 ))]


### PR DESCRIPTION
## Change summary

Remove the `crypto` feature flag, and unconditionally enable all functionality that depended on it.

Per discussion on https://github.com/kanidm/webauthn-rs/issues/499#issuecomment-4552452686

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
