### PR TITLE
6.0: test / fix multiple credentials with Windows backend

### DIFF
--- a/fido-key-manager/src/main.rs
+++ b/fido-key-manager/src/main.rs
@@ -74,7 +74,7 @@ pub struct ChangePinOpt {
     ArgGroup::new("policy")
         .multiple(true)
         .required(true)
-        .args(&["length", "rpids", "force-change"])))]
+        .args(&["length", "rpids", "force_change"])))]
 pub struct SetPinPolicyOpt {
     /// Sets the minimum PIN length, in Unicode codepoints.
     #[clap(short, long)]

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -9,7 +9,10 @@ use std::time::{Duration, SystemTime};
 #[cfg(any(feature = "cable", feature = "softtoken"))]
 use clap::Args;
 use clap::{Parser, Subcommand, ValueEnum};
-use crypto_glue::rand::{rngs::ThreadRng, RngCore};
+use crypto_glue::{
+    ecdsa_p256::EcdsaP256PrivateKey,
+    rand::{rngs::ThreadRng, Rng, RngCore},
+};
 #[cfg(feature = "cable")]
 use tokio_tungstenite::tungstenite::http::uri::Builder;
 #[cfg(feature = "cable-override-tunnel")]
@@ -28,17 +31,20 @@ use webauthn_authenticator_rs::types::CableRequestType;
 use webauthn_authenticator_rs::ui::{Cli, UiCallback};
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 use webauthn_rs_core::proto::{
-    AttestationMetadata, COSEEC2Key, COSEKey, COSEKeyType, CredentialV5, ECDSACurve,
-    ParsedAttestation, ParsedAttestationData, RequestAuthenticationExtensions,
+    AttestationMetadata, CredentialV5, ParsedAttestation, ParsedAttestationData,
+    RequestAuthenticationExtensions,
 };
-use webauthn_rs_core::WebauthnCore as Webauthn;
+use webauthn_rs_core::{error::WebauthnResult, WebauthnCore as Webauthn};
 use webauthn_rs_proto::{
-    AttestationConveyancePreference, AttestationFormat, COSEAlgorithm, ExtnState,
-    RegisteredExtensions, UserVerificationPolicy,
+    AttestationConveyancePreference, AttestationFormat, ExtnState, RegisteredExtensions,
+    UserVerificationPolicy,
 };
 
+/// Performs a WebAuthn registration and authentication ceremony with a fake RP.
+///
+/// This is used to test authenticators and transports with `webauthn-authenticator-rs`.
 #[derive(Debug, clap::Parser)]
-#[clap(about = "Register and authenticate test")]
+#[clap(about = "Registration and authentication tester")]
 pub struct CliParser {
     /// Provider to use.
     #[clap(subcommand)]
@@ -47,9 +53,30 @@ pub struct CliParser {
     /// User verification policy for the request.
     #[clap(short, long, value_enum, default_value_t)]
     verification_policy: UvPolicy,
+
+    /// Don't perform a registration ceremony, and just present random fake credentials for
+    /// authentication.
+    #[clap(long)]
+    only_fakes: bool,
+
+    /// Send the fake credential IDs during the registration request as excluded credentials.
+    #[clap(long, conflicts_with = "only_fakes")]
+    fakes_in_registration: bool,
+
+    /// Number of fake credentials to place before the registered credential during the
+    /// authentication ceremony.
+    ///
+    /// Fake credential IDs contain a random length of random bytes.
+    #[clap(long, default_value_t)]
+    fakes_before: usize,
+
+    /// Number of fake credentials to place after the registered credential during the
+    /// authentication ceremony.
+    #[clap(long, default_value_t)]
+    fakes_after: usize,
 }
 
-#[derive(ValueEnum, Clone, Default, Debug)]
+#[derive(ValueEnum, Clone, Copy, Default, Debug)]
 pub enum UvPolicy {
     Discouraged,
     #[default]
@@ -220,6 +247,44 @@ impl Provider {
     }
 }
 
+/// Generate a fake credential that matches the verification policy.
+fn fake_credential(
+    rng: &mut ThreadRng,
+    verification_policy: UvPolicy,
+) -> WebauthnResult<CredentialV5> {
+    let cred_len = rng.gen_range(16..=64);
+    let mut cred_id: Vec<u8> = vec![0; cred_len];
+    rng.fill_bytes(&mut cred_id);
+
+    let key = EcdsaP256PrivateKey::random(rng);
+    let cred = (&key.public_key()).try_into()?;
+
+    Ok(CredentialV5 {
+        cred_id,
+        cred,
+        counter: 0,
+        transports: None,
+        user_verified: matches!(
+            verification_policy,
+            UvPolicy::Preferred | UvPolicy::Required
+        ),
+        backup_eligible: false,
+        backup_state: false,
+        registration_policy: verification_policy.into(),
+        extensions: RegisteredExtensions {
+            cred_protect: ExtnState::NotRequested,
+            hmac_create_secret: ExtnState::NotRequested,
+            appid: ExtnState::NotRequested,
+            cred_props: ExtnState::Ignored,
+        },
+        attestation: ParsedAttestation {
+            data: ParsedAttestationData::None,
+            metadata: AttestationMetadata::None,
+        },
+        attestation_format: AttestationFormat::None,
+    })
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -235,9 +300,7 @@ async fn main() {
     let opt = CliParser::parse();
     let ui = Cli {};
     let provider = opt.provider;
-    let mut u = provider
-        .connect_provider(CableRequestType::MakeCredential, &ui)
-        .await;
+    let mut u: Box<dyn AuthenticatorBackend>;
 
     let origin = Url::parse("https://demo.webauthn-authenticator-rs.example").unwrap();
 
@@ -251,61 +314,60 @@ async fn main() {
         None,
     );
 
-    let mut unique_id = [0u8; 16];
-    rng.fill_bytes(&mut unique_id);
-    let now = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default();
-    let user_name = format!("demo-{}", now.as_secs());
-    let display_name = format!("Authenticate Demo {}", now.as_secs());
+    let mut creds =
+        Vec::with_capacity(opt.fakes_before + opt.fakes_after + if opt.only_fakes { 0 } else { 1 });
+    for _ in 0..(opt.fakes_before + opt.fakes_after) {
+        creds.push(
+            fake_credential(&mut rng, opt.verification_policy).expect("Cannot generate fake"),
+        );
+    }
 
-    let builder = wan
-        .new_challenge_register_builder(&unique_id, &user_name, &display_name)
-        .unwrap()
-        .attestation(AttestationConveyancePreference::None)
-        .user_verification_policy(opt.verification_policy.clone().into());
+    if !opt.only_fakes {
+        u = provider
+            .connect_provider(CableRequestType::MakeCredential, &ui)
+            .await;
 
-    let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
+        let mut unique_id = [0u8; 16];
+        rng.fill_bytes(&mut unique_id);
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default();
+        let user_name = format!("demo-{}", now.as_secs());
+        let display_name = format!("Authenticate Demo {}", now.as_secs());
 
-    info!("🍿 challenge -> {:x?}", chal);
+        let mut builder = wan
+            .new_challenge_register_builder(&unique_id, &user_name, &display_name)
+            .unwrap()
+            .attestation(AttestationConveyancePreference::None)
+            .user_verification_policy(opt.verification_policy.into());
 
-    let r = u.do_registration(origin.clone(), chal).unwrap();
+        if opt.fakes_in_registration {
+            builder = builder.exclude_credentials(Some(
+                creds.iter().map(|cred| cred.cred_id.clone()).collect(),
+            ))
+        }
 
-    let cred = wan.register_credential(&r, &reg_state, None).unwrap();
-    let fake = CredentialV5 {
-        cred_id: vec![0x67; 20],
-        cred: COSEKey {
-            type_: COSEAlgorithm::ES256,
-            key: COSEKeyType::EC_EC2(COSEEC2Key {
-                curve: ECDSACurve::SECP256R1,
-                x: vec![1; 32],
-                y: vec![202; 32],
-            }),
-        },
-        counter: 0,
-        transports: None,
-        user_verified: true,
-        backup_eligible: false,
-        backup_state: false,
-        registration_policy: opt.verification_policy.into(),
-        extensions: RegisteredExtensions {
-            cred_protect: ExtnState::NotRequested,
-            hmac_create_secret: ExtnState::NotRequested,
-            appid: ExtnState::NotRequested,
-            cred_props: ExtnState::Ignored,
-        },
-        attestation: ParsedAttestation {
-            data: ParsedAttestationData::None,
-            metadata: AttestationMetadata::None,
-        },
-        attestation_format: AttestationFormat::None,
-    };
+        let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
-    trace!(?cred);
-    let mut buf = String::new();
-    println!("WARNING: Some NFC keys need to be power-cycled before you can authenticate.");
+        info!("🍿 challenge -> {chal:x?}");
+
+        let r = u.do_registration(origin.clone(), chal).unwrap();
+
+        let cred = wan.register_credential(&r, &reg_state, None).unwrap();
+        trace!(?cred);
+
+        creds.insert(opt.fakes_before, cred);
+        println!("WARNING: Some NFC keys need to be power-cycled before you can authenticate.");
+    }
+
+    if creds.is_empty() {
+        panic!("No credentials available to authenticate with.");
+    }
+
     println!("Press ENTER to authenticate, or Ctrl-C to abort");
     stdout().flush().ok();
+
+    let mut buf = String::new();
     stdin().read_line(&mut buf).expect("Cannot read stdin");
 
     loop {
@@ -314,7 +376,7 @@ async fn main() {
             .await;
 
         let (chal, auth_state) = wan
-            .new_challenge_authenticate_builder(vec![fake.clone(), cred.clone()], None)
+            .new_challenge_authenticate_builder(creds.clone(), None)
             .map(|builder| {
                 builder.extensions(Some(RequestAuthenticationExtensions {
                     appid: Some("example.app.id".to_string()),

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -27,9 +27,9 @@ use webauthn_authenticator_rs::transport::*;
 use webauthn_authenticator_rs::types::CableRequestType;
 use webauthn_authenticator_rs::ui::{Cli, UiCallback};
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
-use webauthn_rs_core::proto::RequestAuthenticationExtensions;
+use webauthn_rs_core::proto::{AttestationMetadata, COSEEC2Key, COSEKey, COSEKeyType, CredentialV5, ECDSACurve, ParsedAttestation, ParsedAttestationData, RequestAuthenticationExtensions};
 use webauthn_rs_core::WebauthnCore as Webauthn;
-use webauthn_rs_proto::{AttestationConveyancePreference, UserVerificationPolicy};
+use webauthn_rs_proto::{AttestationConveyancePreference, AttestationFormat, COSEAlgorithm, ExtnState, RegisteredExtensions, UserVerificationPolicy};
 
 #[derive(Debug, clap::Parser)]
 #[clap(about = "Register and authenticate test")]
@@ -257,7 +257,7 @@ async fn main() {
         .new_challenge_register_builder(&unique_id, &user_name, &display_name)
         .unwrap()
         .attestation(AttestationConveyancePreference::None)
-        .user_verification_policy(opt.verification_policy.into());
+        .user_verification_policy(opt.verification_policy.clone().into());
 
     let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
@@ -266,6 +266,34 @@ async fn main() {
     let r = u.do_registration(origin.clone(), chal).unwrap();
 
     let cred = wan.register_credential(&r, &reg_state, None).unwrap();
+    let fake = CredentialV5 {
+        cred_id: vec![0x67; 20],
+        cred: COSEKey {
+            type_: COSEAlgorithm::ES256,
+            key: COSEKeyType::EC_EC2(COSEEC2Key {
+                curve: ECDSACurve::SECP256R1,
+                x: vec![1; 32],
+                y: vec![202; 32],
+            }),
+        },
+        counter: 0,
+        transports: None,
+        user_verified: true,
+        backup_eligible: false,
+        backup_state: false,
+        registration_policy: opt.verification_policy.into(),
+        extensions: RegisteredExtensions {
+            cred_protect: ExtnState::NotRequested,
+            hmac_create_secret: ExtnState::NotRequested,
+            appid: ExtnState::NotRequested,
+            cred_props: ExtnState::Ignored,
+        },
+        attestation: ParsedAttestation {
+            data: ParsedAttestationData::None,
+            metadata: AttestationMetadata::None,
+        },
+        attestation_format: AttestationFormat::None,
+    };
 
     trace!(?cred);
     let mut buf = String::new();
@@ -280,7 +308,7 @@ async fn main() {
             .await;
 
         let (chal, auth_state) = wan
-            .new_challenge_authenticate_builder(vec![cred.clone()], None)
+            .new_challenge_authenticate_builder(vec![fake.clone(), cred.clone()], None)
             .map(|builder| {
                 builder.extensions(Some(RequestAuthenticationExtensions {
                     appid: Some("example.app.id".to_string()),

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -36,8 +36,8 @@ use webauthn_rs_core::proto::{
 };
 use webauthn_rs_core::{error::WebauthnResult, WebauthnCore as Webauthn};
 use webauthn_rs_proto::{
-    AttestationConveyancePreference, AttestationFormat, ExtnState, RegisteredExtensions,
-    UserVerificationPolicy,
+    AttestationConveyancePreference, AttestationFormat, CredProtect, CredentialProtectionPolicy,
+    ExtnState, RegisteredExtensions, RequestRegistrationExtensions, UserVerificationPolicy,
 };
 
 /// Performs a WebAuthn registration and authentication ceremony with a fake RP.
@@ -53,6 +53,21 @@ pub struct CliParser {
     /// User verification policy for the request.
     #[clap(short, long, value_enum, default_value_t)]
     verification_policy: UvPolicy,
+
+    /// Credential protection policy at registration time.
+    #[clap(short, long, value_enum, default_value_t)]
+    credential_protection_policy: CredProtectPolicy,
+
+    /// If set, registration fails if the authenticator cannot enforce the provided credential
+    /// protection policy.
+    #[clap(long)]
+    enforce_credential_protection_policy: bool,
+
+    /// If set, requests the authenticator's minimum PIN length at registration time. This only
+    /// works if the authenticator has a configured `setMinPINLength` and
+    /// `demo.webauthn-authenticator-rs.example` is in its `minPinLengthRPIDs`.
+    #[clap(long)]
+    min_pin_length: bool,
 
     /// Don't perform a registration ceremony, and just present random fake credentials for
     /// authentication.
@@ -90,6 +105,43 @@ impl From<UvPolicy> for UserVerificationPolicy {
             UvPolicy::Discouraged => UserVerificationPolicy::Discouraged_DO_NOT_USE,
             UvPolicy::Preferred => UserVerificationPolicy::Preferred,
             UvPolicy::Required => UserVerificationPolicy::Required,
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Copy, Default, Debug)]
+pub enum CredProtectPolicy {
+    /// No explicit credential protection policy is set.
+    #[default]
+    Unset,
+
+    /// This reflects `FIDO_2_0` semantics. In this configuration, performing some form of user
+    /// verification at authentication time is OPTIONAL with or without `credentialID` list.
+    Optional,
+
+    /// User verification at authentication time is OPTIONAL when providing a `credentialID` list
+    /// (ie: required for resident keys, optional for non-resident keys). This demo always provides
+    /// a credential ID list and discourages the use of resident keys, so this is essentially the
+    /// same as `optional`.
+    OptionalWithCredIdList,
+
+    /// User verification at authentication time is REQUIRED.
+    Required,
+}
+
+impl From<CredProtectPolicy> for Option<CredentialProtectionPolicy> {
+    fn from(value: CredProtectPolicy) -> Self {
+        match value {
+            CredProtectPolicy::Unset => None,
+            CredProtectPolicy::Optional => {
+                Some(CredentialProtectionPolicy::UserVerificationOptional)
+            }
+            CredProtectPolicy::OptionalWithCredIdList => {
+                Some(CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIDList)
+            }
+            CredProtectPolicy::Required => {
+                Some(CredentialProtectionPolicy::UserVerificationRequired)
+            }
         }
     }
 }
@@ -335,6 +387,23 @@ async fn main() {
         let user_name = format!("demo-{}", now.as_secs());
         let display_name = format!("Authenticate Demo {}", now.as_secs());
 
+        let mut extensions: Option<RequestRegistrationExtensions> = None;
+
+        if let Some(credential_protection_policy) = opt.credential_protection_policy.into() {
+            let extensions = extensions.get_or_insert_default();
+            extensions.cred_protect = Some(CredProtect {
+                credential_protection_policy,
+                enforce_credential_protection_policy: Some(
+                    opt.enforce_credential_protection_policy,
+                ),
+            });
+        }
+
+        if opt.min_pin_length {
+            let extensions = extensions.get_or_insert_default();
+            extensions.min_pin_length = Some(true);
+        }
+
         let mut builder = wan
             .new_challenge_register_builder(&unique_id, &user_name, &display_name)
             .unwrap()
@@ -347,16 +416,21 @@ async fn main() {
             ))
         }
 
+        if let Some(extensions) = extensions {
+            builder = builder.extensions(Some(extensions));
+        }
+
         let (chal, reg_state) = wan.generate_challenge_register(builder).unwrap();
 
         info!("🍿 challenge -> {chal:x?}");
 
         // Do registration on the authenticator side (navigator.credentials.create)
         let r = u.do_registration(origin.clone(), chal).unwrap();
+        info!("Registering: {r:?}");
 
         // Register with the RP.
         let cred = wan.register_credential(&r, &reg_state, None).unwrap();
-        trace!(?cred);
+        info!("Registered: {cred:?}");
 
         creds.insert(opt.fakes_before, cred);
         println!("WARNING: Some NFC keys need to be power-cycled before you can authenticate.");

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -27,9 +27,15 @@ use webauthn_authenticator_rs::transport::*;
 use webauthn_authenticator_rs::types::CableRequestType;
 use webauthn_authenticator_rs::ui::{Cli, UiCallback};
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
-use webauthn_rs_core::proto::{AttestationMetadata, COSEEC2Key, COSEKey, COSEKeyType, CredentialV5, ECDSACurve, ParsedAttestation, ParsedAttestationData, RequestAuthenticationExtensions};
+use webauthn_rs_core::proto::{
+    AttestationMetadata, COSEEC2Key, COSEKey, COSEKeyType, CredentialV5, ECDSACurve,
+    ParsedAttestation, ParsedAttestationData, RequestAuthenticationExtensions,
+};
 use webauthn_rs_core::WebauthnCore as Webauthn;
-use webauthn_rs_proto::{AttestationConveyancePreference, AttestationFormat, COSEAlgorithm, ExtnState, RegisteredExtensions, UserVerificationPolicy};
+use webauthn_rs_proto::{
+    AttestationConveyancePreference, AttestationFormat, COSEAlgorithm, ExtnState,
+    RegisteredExtensions, UserVerificationPolicy,
+};
 
 #[derive(Debug, clap::Parser)]
 #[clap(about = "Register and authenticate test")]

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -18,23 +18,26 @@ use tokio_tungstenite::tungstenite::http::uri::Builder;
 #[cfg(feature = "cable-override-tunnel")]
 use tokio_tungstenite::tungstenite::http::{uri::Parts, Uri};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
-#[cfg(feature = "ctap2")]
-use webauthn_authenticator_rs::ctap2::CtapAuthenticator;
-use webauthn_authenticator_rs::prelude::Url;
 #[cfg(feature = "cable")]
 use webauthn_authenticator_rs::prelude::WebauthnCError;
 #[cfg(feature = "softtoken")]
 use webauthn_authenticator_rs::softtoken::{SoftToken, SoftTokenFile};
 #[cfg(feature = "ctap2")]
-use webauthn_authenticator_rs::transport::*;
-use webauthn_authenticator_rs::types::CableRequestType;
-use webauthn_authenticator_rs::ui::{Cli, UiCallback};
-use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
-use webauthn_rs_core::proto::{
-    AttestationMetadata, CredentialV5, ParsedAttestation, ParsedAttestationData,
-    RequestAuthenticationExtensions,
+use webauthn_authenticator_rs::{ctap2::CtapAuthenticator, transport::*};
+use webauthn_authenticator_rs::{
+    prelude::Url,
+    types::CableRequestType,
+    ui::{Cli, UiCallback},
+    AuthenticatorBackend, WebauthnAuthenticator,
 };
-use webauthn_rs_core::{error::WebauthnResult, WebauthnCore as Webauthn};
+use webauthn_rs_core::{
+    error::WebauthnResult,
+    proto::{
+        AttestationMetadata, CredentialV5, ParsedAttestation, ParsedAttestationData,
+        RequestAuthenticationExtensions,
+    },
+    WebauthnCore as Webauthn,
+};
 use webauthn_rs_proto::{
     AttestationConveyancePreference, AttestationFormat, CredProtect, CredentialProtectionPolicy,
     ExtnState, RegisteredExtensions, RequestRegistrationExtensions, UserVerificationPolicy,

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -12,6 +12,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use crypto_glue::{
     ecdsa_p256::EcdsaP256PrivateKey,
     rand::{rngs::ThreadRng, Rng, RngCore},
+    x509::Certificate,
 };
 #[cfg(feature = "cable")]
 use tokio_tungstenite::tungstenite::http::uri::Builder;
@@ -340,6 +341,17 @@ fn fake_credential(
     })
 }
 
+fn print_certs(certs: &[Certificate]) {
+    for (i, cert) in certs.iter().enumerate() {
+        println!("### Certificate {}", i + 1);
+        println!("Issuer: {}", cert.tbs_certificate.issuer);
+        println!("Subject: {}", cert.tbs_certificate.subject);
+        println!("Serial: {}", cert.tbs_certificate.serial_number);
+
+        println!("");
+    }
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -429,11 +441,54 @@ async fn main() {
 
         // Do registration on the authenticator side (navigator.credentials.create)
         let r = u.do_registration(origin.clone(), chal).unwrap();
-        info!("Registering: {r:?}");
+        trace!("Registering: {r:?}");
 
         // Register with the RP.
         let cred = wan.register_credential(&r, &reg_state, None).unwrap();
-        info!("Registered: {cred:?}");
+        trace!("Registered: {cred:?}");
+
+        match &cred.attestation.data {
+            ParsedAttestationData::None => {
+                println!("## No attestation data");
+            }
+            ParsedAttestationData::Self_ => {
+                println!("## Self-attestation");
+            }
+            ParsedAttestationData::ECDAA => {
+                println!("## ECDAA attestation (not yet implemented)");
+            }
+            ParsedAttestationData::Uncertain => {
+                println!("## Uncertain attestation (not trustworthy)");
+            }
+            ParsedAttestationData::Basic(certs) => {
+                println!(
+                    "## Basic attestation, {} certificate{}",
+                    certs.len(),
+                    if certs.len() == 1 { "" } else { "s" },
+                );
+
+                print_certs(certs);
+            }
+            ParsedAttestationData::AttCa(certs) => {
+                println!(
+                    "## CA attestation, {} certificate{}",
+                    certs.len(),
+                    if certs.len() == 1 { "" } else { "s" },
+                );
+                print_certs(certs);
+            }
+            ParsedAttestationData::AnonCa(certs) => {
+                println!(
+                    "## Anonymous CA attestation, {} certificate{}",
+                    certs.len(),
+                    if certs.len() == 1 { "" } else { "s" },
+                );
+                print_certs(certs);
+            }
+        }
+
+        println!("## Extensions");
+        println!("credProtect: {:?}", cred.extensions.cred_protect);
 
         creds.insert(opt.fakes_before, cred);
         println!("WARNING: Some NFC keys need to be power-cycled before you can authenticate.");

--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -351,8 +351,10 @@ async fn main() {
 
         info!("🍿 challenge -> {chal:x?}");
 
+        // Do registration on the authenticator side (navigator.credentials.create)
         let r = u.do_registration(origin.clone(), chal).unwrap();
 
+        // Register with the RP.
         let cred = wan.register_credential(&r, &reg_state, None).unwrap();
         trace!(?cred);
 
@@ -387,23 +389,32 @@ async fn main() {
             .and_then(|b| wan.generate_challenge_authenticate(b))
             .unwrap();
 
-        let r = u.do_authentication(origin.clone(), chal).map_err(|e| {
-            error!("Error -> {:x?}", e);
-            e
-        });
-        trace!(?r);
+        // Do authentication on the authenticator side (ie: navigator.credentials.get)
+        match u.do_authentication(origin.clone(), chal) {
+            Ok(cred) => {
+                info!("Authenticator response: {cred:x?}");
 
-        if let Ok(r) = r {
-            let auth_res = wan
-                .authenticate_credential(&r, &auth_state)
-                .expect("webauth authentication denied");
+                // Authenticate with the RP
+                match wan.authenticate_credential(&cred, &auth_state) {
+                    Ok(auth_res) => {
+                        info!("RP auth success: {auth_res:x?}");
+                    }
 
-            info!("auth_res -> {:x?}", auth_res);
+                    Err(e) => {
+                        error!("RP auth failure: {e}");
+                    }
+                }
+            }
+
+            Err(e) => {
+                error!("Authenticator error: {e:?}");
+            }
         }
 
-        let mut buf = String::new();
         println!("Press ENTER to try again, or Ctrl-C to abort");
         stdout().flush().ok();
+
+        let mut buf = String::new();
         stdin().read_line(&mut buf).expect("Cannot read stdin");
     }
 }

--- a/webauthn-authenticator-rs/src/win10/clientdata.rs
+++ b/webauthn-authenticator-rs/src/win10/clientdata.rs
@@ -19,43 +19,36 @@ const SHA_256: &HSTRING = w!("SHA-256");
 
 /// Wrapper for [WEBAUTHN_CLIENT_DATA] to ensure pointer lifetime.
 pub struct WinClientData {
-    native: WEBAUTHN_CLIENT_DATA,
-    client_data_json: String,
+    native: Pin<Box<WEBAUTHN_CLIENT_DATA>>,
+    client_data_json: Pin<String>,
 }
 
 impl WinClientData {
-    pub fn client_data_json(&self) -> &String {
+    pub fn client_data_json(&self) -> &str {
         &self.client_data_json
     }
 }
 
 impl WinWrapper<CollectedClientData> for WinClientData {
     type NativeType = WEBAUTHN_CLIENT_DATA;
-    fn new(clientdata: CollectedClientData) -> Result<Pin<Box<Self>>, WebauthnCError> {
+    fn new(clientdata: CollectedClientData) -> Result<Self, WebauthnCError> {
         // Construct an incomplete type first, so that all the pointers are fixed.
-        let res = Self {
-            native: WEBAUTHN_CLIENT_DATA::default(),
-            client_data_json: serde_json::to_string(&clientdata)
-                .map_err(|_| WebauthnCError::Json)?,
+        let mut res = Self {
+            native: Default::default(),
+            client_data_json: Pin::new(
+                serde_json::to_string(&clientdata).map_err(|_| WebauthnCError::Json)?,
+            ),
         };
-
-        let mut boxed = Box::pin(res);
 
         // Create the real native type, which contains bare pointers.
-        let native = WEBAUTHN_CLIENT_DATA {
+        res.native = Box::pin(WEBAUTHN_CLIENT_DATA {
             dwVersion: WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
-            cbClientDataJSON: boxed.client_data_json.len() as u32,
-            pbClientDataJSON: boxed.client_data_json.as_ptr() as *mut _,
+            cbClientDataJSON: res.client_data_json.len() as u32,
+            pbClientDataJSON: res.client_data_json.as_mut_ptr(),
             pwszHashAlgId: SHA_256.into(),
-        };
+        });
 
-        // Update the boxed type with the proper native object.
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        Ok(boxed)
+        Ok(res)
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_CLIENT_DATA {

--- a/webauthn-authenticator-rs/src/win10/clientdata.rs
+++ b/webauthn-authenticator-rs/src/win10/clientdata.rs
@@ -1,10 +1,8 @@
 //! Wrappers for [CollectedClientData].
-use std::pin::Pin;
-use webauthn_rs_proto::CollectedClientData;
 
-use super::WinWrapper;
 use crate::error::WebauthnCError;
-
+use std::{marker::PhantomPinned, pin::Pin};
+use webauthn_rs_proto::CollectedClientData;
 use windows::{
     core::HSTRING,
     w,
@@ -12,6 +10,8 @@ use windows::{
         WEBAUTHN_CLIENT_DATA, WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
     },
 };
+
+use super::WinWrapper;
 // Most constants are `&str`, but APIs expect `HSTRING`... there's no good work-around.
 // https://github.com/microsoft/windows-rs/issues/2049
 /// [windows::Win32::Networking::WindowsWebServices::WEBAUTHN_HASH_ALGORITHM_SHA_256]
@@ -19,8 +19,9 @@ const SHA_256: &HSTRING = w!("SHA-256");
 
 /// Wrapper for [WEBAUTHN_CLIENT_DATA] to ensure pointer lifetime.
 pub struct WinClientData {
-    native: Pin<Box<WEBAUTHN_CLIENT_DATA>>,
-    client_data_json: Pin<String>,
+    native: WEBAUTHN_CLIENT_DATA,
+    client_data_json: String,
+    _pin: PhantomPinned,
 }
 
 impl WinClientData {
@@ -31,24 +32,26 @@ impl WinClientData {
 
 impl WinWrapper<CollectedClientData> for WinClientData {
     type NativeType = WEBAUTHN_CLIENT_DATA;
-    fn new(clientdata: CollectedClientData) -> Result<Self, WebauthnCError> {
-        // Construct an incomplete type first, so that all the pointers are fixed.
-        let mut res = Self {
-            native: Default::default(),
-            client_data_json: Pin::new(
-                serde_json::to_string(&clientdata).map_err(|_| WebauthnCError::Json)?,
-            ),
+    fn new(clientdata: CollectedClientData) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        let client_data_json =
+            serde_json::to_string(&clientdata).map_err(|_| WebauthnCError::Json)?;
+
+        let res = Self {
+            native: WEBAUTHN_CLIENT_DATA {
+                dwVersion: WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
+                cbClientDataJSON: client_data_json.len() as u32,
+                pbClientDataJSON: std::ptr::null_mut(),
+                pwszHashAlgId: SHA_256.into(),
+            },
+            client_data_json,
+            _pin: PhantomPinned,
         };
 
-        // Create the real native type, which contains bare pointers.
-        res.native = Box::pin(WEBAUTHN_CLIENT_DATA {
-            dwVersion: WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
-            cbClientDataJSON: res.client_data_json.len() as u32,
-            pbClientDataJSON: res.client_data_json.as_mut_ptr(),
-            pwszHashAlgId: SHA_256.into(),
-        });
+        let mut boxed = Box::new(res);
+        // Add internal pointer now that `client_data_json` is in place.
+        boxed.native.pbClientDataJSON = boxed.client_data_json.as_mut_ptr();
 
-        Ok(res)
+        Ok(Box::into_pin(boxed))
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_CLIENT_DATA {

--- a/webauthn-authenticator-rs/src/win10/constants.rs
+++ b/webauthn-authenticator-rs/src/win10/constants.rs
@@ -1,0 +1,6 @@
+use windows::{core::HSTRING, w};
+
+// Most constants are `&str`, but APIs expect `HSTRING`... there's no good work-around.
+// https://github.com/microsoft/windows-rs/issues/2049
+/// [windows::Win32::Networking::WindowsWebServices::WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY]
+pub const CREDENTIAL_TYPE_PUBLIC_KEY: &HSTRING = w!("public-key");

--- a/webauthn-authenticator-rs/src/win10/cose.rs
+++ b/webauthn-authenticator-rs/src/win10/cose.rs
@@ -2,80 +2,80 @@
 use crate::prelude::WebauthnCError;
 use std::pin::Pin;
 use webauthn_rs_proto::PubKeyCredParams;
-
-use super::WinWrapper;
-
 use windows::{
-    core::{HSTRING, PCWSTR},
+    core::HSTRING,
     Win32::Networking::WindowsWebServices::{
         WEBAUTHN_COSE_CREDENTIAL_PARAMETER, WEBAUTHN_COSE_CREDENTIAL_PARAMETERS,
-        WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
+        WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION, WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY,
     },
 };
 
-/// Wrapper for [WEBAUTHN_COSE_CREDENTIAL_PARAMETER] to ensure pointer lifetime.
-struct WinCoseCredentialParameter {
-    native: WEBAUTHN_COSE_CREDENTIAL_PARAMETER,
-    _typ: Pin<Box<HSTRING>>,
-}
-
-impl WinCoseCredentialParameter {
-    fn from(p: PubKeyCredParams) -> Self {
-        let mut res = Self {
-            native: Default::default(),
-            _typ: Box::pin(p.type_.into()),
-        };
-
-        res.native = WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
-            dwVersion: WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
-            pwszCredentialType: PCWSTR::from_raw(res._typ.as_ptr()),
-            lAlg: p.alg as i32,
-        };
-
-        res
-    }
-}
+use super::{constants::CREDENTIAL_TYPE_PUBLIC_KEY, WinWrapper};
 
 pub struct WinCoseCredentialParameters {
-    native: Pin<Box<WEBAUTHN_COSE_CREDENTIAL_PARAMETERS>>,
-    l: Pin<Box<Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER>>>,
-    params: Pin<Box<Vec<Pin<Box<WinCoseCredentialParameter>>>>>,
+    /// Wrapper structure, points to `params`.
+    native: WEBAUTHN_COSE_CREDENTIAL_PARAMETERS,
+
+    /// Array of all parameters, each points to an entry in `types`.
+    ///
+    /// [`WEBAUTHN_COSE_CREDENTIAL_PARAMETERS::pCredentialParameters`][] is a pointer to the first
+    /// [`WEBAUTHN_COSE_CREDENTIAL_PARAMETER`][], so this needs to be a contiguous block of memory.
+    params: Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER>,
+
+    /// Credential type identifiers used in `params`.
+    ///
+    /// The string buffer of the [`HSTRING`] is heap allocated and effectively pinned.
+    types: Vec<HSTRING>,
 }
 
 impl WinWrapper<Vec<PubKeyCredParams>> for WinCoseCredentialParameters {
     type NativeType = WEBAUTHN_COSE_CREDENTIAL_PARAMETERS;
 
-    fn new(params: Vec<PubKeyCredParams>) -> Result<Self, WebauthnCError> {
-        let params: Vec<Pin<Box<WinCoseCredentialParameter>>> = params
-            .into_iter()
-            .map(WinCoseCredentialParameter::from)
-            .map(Box::pin)
-            .collect();
-        Ok(WinCoseCredentialParameters::from_wrapped(params))
+    fn new(params: Vec<PubKeyCredParams>) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        let res = Self {
+            native: WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
+                cCredentialParameters: params.len() as u32,
+                pCredentialParameters: std::ptr::null_mut(),
+            },
+            params: Vec::with_capacity(params.len()),
+            types: Vec::with_capacity(
+                params
+                    .iter()
+                    .filter(|p| p.type_ != WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY)
+                    .count(),
+            ),
+        };
+
+        let mut boxed = Box::new(res);
+
+        for param in params {
+            let pwsz_credential_type = if param.type_ == WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY {
+                CREDENTIAL_TYPE_PUBLIC_KEY.into()
+            } else {
+                // Unlikely path, as WebAuthn L3 doesn't specify this.
+                let typ = HSTRING::from(param.type_);
+
+                // Even though the `HSTRING` is moved when pushed into the `Vec` (and potentially
+                // many times if the `Vec` reallocates), its header and string buffer are heap
+                // allocated and don't move.
+                let ptr = (&typ).into();
+                boxed.types.push(typ);
+                ptr
+            };
+
+            boxed.params.push(WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
+                dwVersion: WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
+                pwszCredentialType: pwsz_credential_type,
+                lAlg: param.alg as i32,
+            });
+        }
+
+        boxed.native.pCredentialParameters = Vec::as_mut_ptr(&mut boxed.params);
+
+        Ok(Box::into_pin(boxed))
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
         &self.native
-    }
-}
-
-impl WinCoseCredentialParameters {
-    fn from_wrapped(params: Vec<Pin<Box<WinCoseCredentialParameter>>>) -> Self {
-        // pCredentialParams is a pointer to an array of contiguous COSE_CREDENTIAL_PARAMETER structures.
-        // But we've got another wrapper type that's a bit longer to store the `type`, so we have to reorganise this.
-        // TODO: Consider removing the intermediate step for PubKeyCredParams -> WinCoseCredentialParameter
-        // so we can have a proper memory layout the first time.
-        let mut res = Self {
-            native: Default::default(),
-            l: Box::pin(params.iter().map(|p| p.native.clone()).collect()),
-            params: Box::pin(params),
-        };
-
-        res.native = Box::pin(WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
-            cCredentialParameters: res.params.len() as u32,
-            pCredentialParameters: Vec::as_mut_ptr(&mut res.l) as *mut _,
-        });
-
-        res
     }
 }

--- a/webauthn-authenticator-rs/src/win10/cose.rs
+++ b/webauthn-authenticator-rs/src/win10/cose.rs
@@ -6,7 +6,7 @@ use webauthn_rs_proto::PubKeyCredParams;
 use super::WinWrapper;
 
 use windows::{
-    core::HSTRING,
+    core::{HSTRING, PCWSTR},
     Win32::Networking::WindowsWebServices::{
         WEBAUTHN_COSE_CREDENTIAL_PARAMETER, WEBAUTHN_COSE_CREDENTIAL_PARAMETERS,
         WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
@@ -16,46 +16,40 @@ use windows::{
 /// Wrapper for [WEBAUTHN_COSE_CREDENTIAL_PARAMETER] to ensure pointer lifetime.
 struct WinCoseCredentialParameter {
     native: WEBAUTHN_COSE_CREDENTIAL_PARAMETER,
-    _typ: HSTRING,
+    _typ: Pin<Box<HSTRING>>,
 }
 
 impl WinCoseCredentialParameter {
-    fn from(p: PubKeyCredParams) -> Pin<Box<Self>> {
-        let res = Self {
+    fn from(p: PubKeyCredParams) -> Self {
+        let mut res = Self {
             native: Default::default(),
-            _typ: p.type_.into(),
+            _typ: Box::pin(p.type_.into()),
         };
 
-        let mut boxed = Box::pin(res);
-
-        let native = WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
+        res.native = WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
             dwVersion: WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
-            pwszCredentialType: (&boxed._typ).into(),
+            pwszCredentialType: PCWSTR::from_raw(res._typ.as_ptr()),
             lAlg: p.alg as i32,
         };
 
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        boxed
+        res
     }
 }
 
 pub struct WinCoseCredentialParameters {
-    native: WEBAUTHN_COSE_CREDENTIAL_PARAMETERS,
-    _params: Vec<Pin<Box<WinCoseCredentialParameter>>>,
-    _l: Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER>,
+    native: Pin<Box<WEBAUTHN_COSE_CREDENTIAL_PARAMETERS>>,
+    l: Pin<Box<Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER>>>,
+    params: Pin<Box<Vec<Pin<Box<WinCoseCredentialParameter>>>>>,
 }
 
 impl WinWrapper<Vec<PubKeyCredParams>> for WinCoseCredentialParameters {
     type NativeType = WEBAUTHN_COSE_CREDENTIAL_PARAMETERS;
 
-    fn new(params: Vec<PubKeyCredParams>) -> Result<Pin<Box<Self>>, WebauthnCError> {
+    fn new(params: Vec<PubKeyCredParams>) -> Result<Self, WebauthnCError> {
         let params: Vec<Pin<Box<WinCoseCredentialParameter>>> = params
             .into_iter()
             .map(WinCoseCredentialParameter::from)
+            .map(Box::pin)
             .collect();
         Ok(WinCoseCredentialParameters::from_wrapped(params))
     }
@@ -66,43 +60,22 @@ impl WinWrapper<Vec<PubKeyCredParams>> for WinCoseCredentialParameters {
 }
 
 impl WinCoseCredentialParameters {
-    fn from_wrapped(params: Vec<Pin<Box<WinCoseCredentialParameter>>>) -> Pin<Box<Self>> {
-        let len = params.len();
-        let res = Self {
+    fn from_wrapped(params: Vec<Pin<Box<WinCoseCredentialParameter>>>) -> Self {
+        // pCredentialParams is a pointer to an array of contiguous COSE_CREDENTIAL_PARAMETER structures.
+        // But we've got another wrapper type that's a bit longer to store the `type`, so we have to reorganise this.
+        // TODO: Consider removing the intermediate step for PubKeyCredParams -> WinCoseCredentialParameter
+        // so we can have a proper memory layout the first time.
+        let mut res = Self {
             native: Default::default(),
-            _l: Vec::with_capacity(len),
-            _params: params,
+            l: Box::pin(params.iter().map(|p| p.native.clone()).collect()),
+            params: Box::pin(params),
         };
 
-        // Box and pin the struct so it's on the heap and doesn't move.
-        let mut boxed = Box::pin(res);
+        res.native = Box::pin(WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
+            cCredentialParameters: res.params.len() as u32,
+            pCredentialParameters: Vec::as_mut_ptr(&mut res.l) as *mut _,
+        });
 
-        // Put in all the "native" values
-        let p_ptr = boxed._params.as_ptr();
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            let l = &mut Pin::get_unchecked_mut(mut_ref)._l;
-            let l_ptr = l.as_mut_ptr();
-            for i in 0..len {
-                *l_ptr.add(i) = (&(*p_ptr.add(i))).native;
-            }
-
-            l.set_len(len);
-        }
-
-        // let mut l: Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER> =
-        //     params.iter().map(|p| p.native).collect();
-
-        let native = WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
-            cCredentialParameters: boxed._l.len() as u32,
-            pCredentialParameters: boxed._l.as_mut_ptr() as *mut _,
-        };
-
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        boxed
+        res
     }
 }

--- a/webauthn-authenticator-rs/src/win10/credential.rs
+++ b/webauthn-authenticator-rs/src/win10/credential.rs
@@ -69,12 +69,10 @@ fn transports_to_bitmask(transports: &Option<Vec<AuthenticatorTransport>>) -> u3
 pub struct WinCredentialList {
     /// Native structure, which points to everything else here.
     pub(crate) native: WEBAUTHN_CREDENTIAL_LIST,
-    /// Pointer to _l, because [WEBAUTHN_CREDENTIAL_LIST::ppCredentials] is a double-pointer.
-    _p: *const WEBAUTHN_CREDENTIAL_EX,
     /// List of credentials
-    _l: Vec<WEBAUTHN_CREDENTIAL_EX>,
+    l: Pin<Box<Vec<Pin<Box<WEBAUTHN_CREDENTIAL_EX>>>>>,
     /// List of credential IDs, referenced by [WEBAUTHN_CREDENTIAL_EX::pbId]
-    _ids: Vec<Vec<u8>>,
+    ids: Pin<Box<Vec<Vec<u8>>>>,
 }
 
 /// Trait to make [PublicKeyCredentialDescriptor] and [AllowCredentials] look the same.
@@ -110,7 +108,7 @@ impl CredentialType for AllowCredentials {
 
 impl<T: CredentialType> WinWrapper<Vec<T>> for WinCredentialList {
     type NativeType = WEBAUTHN_CREDENTIAL_LIST;
-    fn new(credentials: Vec<T>) -> Result<Pin<Box<Self>>, WebauthnCError> {
+    fn new(credentials: Vec<T>) -> Result<Self, WebauthnCError> {
         // Check that all the credential types are supported.
         for c in credentials.iter() {
             let typ = c.type_();
@@ -121,57 +119,30 @@ impl<T: CredentialType> WinWrapper<Vec<T>> for WinCredentialList {
         }
 
         let len = credentials.len();
-        let res = Self {
+        let mut res = Self {
             native: Default::default(),
-            _p: std::ptr::null(),
-            _l: Vec::with_capacity(len),
-            _ids: credentials.iter().map(|c| c.id()).collect(),
+            l: Box::pin(Vec::with_capacity(len)),
+            ids: Box::pin(credentials.iter().map(|c| c.id()).collect()),
         };
-
-        // Box the struct so it doesn't move.
-        let mut boxed = Box::pin(res);
 
         // Put in all the "native" values
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            let mut_ptr = Pin::get_unchecked_mut(mut_ref);
-            let l = &mut mut_ptr._l;
-            let l_ptr = l.as_mut_ptr();
-            for (i, credential) in credentials.iter().enumerate() {
-                let id = &mut mut_ptr._ids[i];
-                *l_ptr.add(i) = WEBAUTHN_CREDENTIAL_EX {
-                    dwVersion: WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION,
-                    cbId: id.len() as u32,
-                    pbId: id.as_mut_ptr() as *mut _,
-                    pwszCredentialType: CREDENTIAL_TYPE_PUBLIC_KEY.into(),
-                    dwTransports: credential.transports(),
-                };
-            }
-
-            l.set_len(len);
+        for (i, credential) in credentials.iter().enumerate() {
+            let id = &mut res.ids[i];
+            res.l.push(Box::pin(WEBAUTHN_CREDENTIAL_EX {
+                dwVersion: WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION,
+                cbId: id.len() as u32,
+                pbId: id.as_mut_ptr() as *mut _,
+                pwszCredentialType: CREDENTIAL_TYPE_PUBLIC_KEY.into(),
+                dwTransports: credential.transports(),
+            }));
         }
 
-        // Add a pointer to the pointer...
-        let p = boxed._l.as_ptr();
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref)._p = p;
-        }
-
-        let native = WEBAUTHN_CREDENTIAL_LIST {
+        res.native = WEBAUTHN_CREDENTIAL_LIST {
             cCredentials: len as u32,
-            ppCredentials: std::ptr::addr_of_mut!(boxed._p) as *mut *mut _,
+            ppCredentials: Vec::as_mut_ptr(&mut res.l) as *mut _,
         };
 
-        // Drop in the native struct
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        // trace!(?boxed.native);
-
-        Ok(boxed)
+        Ok(res)
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_CREDENTIAL_LIST {

--- a/webauthn-authenticator-rs/src/win10/credential.rs
+++ b/webauthn-authenticator-rs/src/win10/credential.rs
@@ -1,24 +1,15 @@
 //! Wrappers for [AllowCredentials] and [PublicKeyCredentialDescriptor].
 use crate::prelude::WebauthnCError;
-use std::pin::Pin;
+use std::{marker::PhantomPinned, pin::Pin};
 use webauthn_rs_proto::{AllowCredentials, AuthenticatorTransport, PublicKeyCredentialDescriptor};
-
-use super::WinWrapper;
-
-use windows::{
-    core::HSTRING,
-    w,
-    Win32::Networking::WindowsWebServices::{
-        WEBAUTHN_CREDENTIAL_EX, WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION, WEBAUTHN_CREDENTIAL_LIST,
-        WEBAUTHN_CTAP_TRANSPORT_BLE, WEBAUTHN_CTAP_TRANSPORT_INTERNAL, WEBAUTHN_CTAP_TRANSPORT_NFC,
-        WEBAUTHN_CTAP_TRANSPORT_TEST, WEBAUTHN_CTAP_TRANSPORT_USB,
-    },
+use windows::Win32::Networking::WindowsWebServices::{
+    WEBAUTHN_CREDENTIAL_EX, WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION, WEBAUTHN_CREDENTIAL_LIST,
+    WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY, WEBAUTHN_CTAP_TRANSPORT_BLE,
+    WEBAUTHN_CTAP_TRANSPORT_INTERNAL, WEBAUTHN_CTAP_TRANSPORT_NFC, WEBAUTHN_CTAP_TRANSPORT_TEST,
+    WEBAUTHN_CTAP_TRANSPORT_USB,
 };
 
-// Most constants are `&str`, but APIs expect `HSTRING`... there's no good work-around.
-// https://github.com/microsoft/windows-rs/issues/2049
-/// [windows::Win32::Networking::WindowsWebServices::WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY]
-const CREDENTIAL_TYPE_PUBLIC_KEY: &HSTRING = w!("public-key");
+use super::{constants::CREDENTIAL_TYPE_PUBLIC_KEY, WinWrapper};
 
 /// Converts an [AuthenticatorTransport] into a value for
 /// [WEBAUTHN_CREDENTIAL_EX::dwTransports]
@@ -68,11 +59,12 @@ fn transports_to_bitmask(transports: &Option<Vec<AuthenticatorTransport>>) -> u3
 /// [PublicKeyCredentialDescriptor] and [AllowCredentials].
 pub struct WinCredentialList {
     /// Native structure, which points to everything else here.
-    pub(crate) native: WEBAUTHN_CREDENTIAL_LIST,
+    pub(super) native: WEBAUTHN_CREDENTIAL_LIST,
     /// List of credentials
-    l: Pin<Box<Vec<Pin<Box<WEBAUTHN_CREDENTIAL_EX>>>>>,
+    l: Vec<Pin<Box<WEBAUTHN_CREDENTIAL_EX>>>,
     /// List of credential IDs, referenced by [WEBAUTHN_CREDENTIAL_EX::pbId]
-    ids: Pin<Box<Vec<Vec<u8>>>>,
+    ids: Vec<Vec<u8>>,
+    _pin: PhantomPinned,
 }
 
 /// Trait to make [PublicKeyCredentialDescriptor] and [AllowCredentials] look the same.
@@ -108,44 +100,57 @@ impl CredentialType for AllowCredentials {
 
 impl<T: CredentialType> WinWrapper<Vec<T>> for WinCredentialList {
     type NativeType = WEBAUTHN_CREDENTIAL_LIST;
-    fn new(credentials: Vec<T>) -> Result<Self, WebauthnCError> {
+
+    fn new(credentials: Vec<T>) -> Result<Pin<Box<Self>>, WebauthnCError> {
         // Check that all the credential types are supported.
         for c in credentials.iter() {
             let typ = c.type_();
-            if typ != *"public-key" {
-                error!("Unsupported credential type: {:?}", c);
+            if typ != WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY {
+                error!("Unsupported credential type: {c:?}");
                 return Err(WebauthnCError::Internal);
             }
         }
 
         let len = credentials.len();
-        let mut res = Self {
-            native: Default::default(),
-            l: Box::pin(Vec::with_capacity(len)),
-            ids: Box::pin(credentials.iter().map(|c| c.id()).collect()),
+
+        let res = Self {
+            ids: credentials.iter().map(|c| c.id()).collect(),
+            native: WEBAUTHN_CREDENTIAL_LIST {
+                cCredentials: len as u32,
+                ppCredentials: std::ptr::null_mut(),
+            },
+            l: Vec::with_capacity(len),
+            _pin: PhantomPinned,
         };
 
+        let mut boxed = Box::new(res);
+
         // Put in all the "native" values
-        for (i, credential) in credentials.iter().enumerate() {
-            let id = &mut res.ids[i];
-            res.l.push(Box::pin(WEBAUTHN_CREDENTIAL_EX {
+        for (credential, id) in credentials.iter().zip(boxed.ids.iter_mut()) {
+            boxed.l.push(Box::pin(WEBAUTHN_CREDENTIAL_EX {
                 dwVersion: WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION,
                 cbId: id.len() as u32,
-                pbId: id.as_mut_ptr() as *mut _,
+                pbId: id.as_mut_ptr(),
                 pwszCredentialType: CREDENTIAL_TYPE_PUBLIC_KEY.into(),
                 dwTransports: credential.transports(),
             }));
         }
 
-        res.native = WEBAUTHN_CREDENTIAL_LIST {
-            cCredentials: len as u32,
-            ppCredentials: Vec::as_mut_ptr(&mut res.l) as *mut _,
-        };
+        // Each entry is in a `Box`, so C can treat the parent `Vec` an array of pointers to
+        // `WEBAUTHN_CREDENTIAL_EX`.
+        boxed.native.ppCredentials =
+            Vec::as_mut_ptr(&mut boxed.l) as *mut *mut WEBAUTHN_CREDENTIAL_EX;
 
-        Ok(res)
+        Ok(Box::into_pin(boxed))
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_CREDENTIAL_LIST {
+        &self.native
+    }
+}
+
+impl WinCredentialList {
+    pub fn native(&self) -> *const WEBAUTHN_CREDENTIAL_LIST {
         &self.native
     }
 }

--- a/webauthn-authenticator-rs/src/win10/extensions.rs
+++ b/webauthn-authenticator-rs/src/win10/extensions.rs
@@ -35,7 +35,7 @@ where
     /// Pointer to the native data structure.
     fn ptr(&mut self) -> *mut c_void;
     /// The `webauthn-authenticator-rs` type which this wraps.
-    type WrappedType: Send;
+    type WrappedType;
     /// Converts the [Self::WrappedType] to a [Vec] of Windows API types.
     fn to_native(e: Self::WrappedType) -> Vec<Self>;
 }

--- a/webauthn-authenticator-rs/src/win10/extensions.rs
+++ b/webauthn-authenticator-rs/src/win10/extensions.rs
@@ -1,7 +1,6 @@
 //! Wrappers for extensions.
 use crate::prelude::WebauthnCError;
-use std::ffi::c_void;
-use std::pin::Pin;
+use std::{ffi::c_void, marker::PhantomPinned, pin::Pin};
 use webauthn_rs_proto::{
     AuthenticationExtensionsClientOutputs, CredProtect, RegistrationExtensionsClientOutputs,
     RequestRegistrationExtensions,
@@ -23,11 +22,6 @@ pub(crate) enum WinExtensionMakeCredentialRequest {
     MinPinLength(BOOL),
 }
 
-/// Represents a single extension for GetAssertion requests, analogous to a
-/// single [RequestAuthenticationExtensions] field.
-#[derive(Debug)]
-pub(crate) enum WinExtensionGetAssertionRequest {}
-
 /// Generic request extension trait, for abstracting between
 /// [WinExtensionMakeCredentialRequest] and [WinExtensionGetAssertionRequest].
 pub(crate) trait WinExtensionRequestType
@@ -41,7 +35,7 @@ where
     /// Pointer to the native data structure.
     fn ptr(&mut self) -> *mut c_void;
     /// The `webauthn-authenticator-rs` type which this wraps.
-    type WrappedType;
+    type WrappedType: Send;
     /// Converts the [Self::WrappedType] to a [Vec] of Windows API types.
     fn to_native(e: Self::WrappedType) -> Vec<Self>;
 }
@@ -73,7 +67,7 @@ impl WinExtensionRequestType for WinExtensionMakeCredentialRequest {
 
     type WrappedType = RequestRegistrationExtensions;
 
-    fn to_native(e: Self::WrappedType) -> Vec<Self> {
+    fn to_native(e: RequestRegistrationExtensions) -> Vec<Self> {
         let mut o: Vec<Self> = Vec::new();
         if let Some(c) = &e.cred_protect {
             o.push(c.into());
@@ -284,10 +278,11 @@ pub(crate) struct WinExtensionsRequest<T>
 where
     T: WinExtensionRequestType + std::fmt::Debug,
 {
-    native: Pin<Box<WEBAUTHN_EXTENSIONS>>,
-    native_list: Pin<Box<Vec<Pin<Box<WEBAUTHN_EXTENSION>>>>>,
-    ids: Pin<Box<Vec<Pin<Box<HSTRING>>>>>,
+    native: WEBAUTHN_EXTENSIONS,
+    native_list: Vec<WEBAUTHN_EXTENSION>,
+    ids: Vec<HSTRING>,
     extensions: Vec<T>,
+    _pin: PhantomPinned,
 }
 
 impl<T> Default for WinExtensionsRequest<T>
@@ -300,6 +295,7 @@ where
             native_list: Default::default(),
             ids: Default::default(),
             extensions: vec![],
+            _pin: PhantomPinned,
         }
     }
 }
@@ -314,41 +310,36 @@ where
         &self.native
     }
 
-    fn new(e: T::WrappedType) -> Result<Self, WebauthnCError> {
+    fn new(e: T::WrappedType) -> Result<Pin<Box<Self>>, WebauthnCError> {
         // Convert the extensions to a Windows-ish type
         // trace!(?e);
-        // TODO: need to pin extension types
         let extensions = T::to_native(e);
         let len = extensions.len();
 
-        let mut res = Self {
-            native: Default::default(),
-            native_list: Box::pin(Vec::with_capacity(len)),
-            ids: Box::pin(
-                extensions
-                    .iter()
-                    .map(|e| Box::pin(e.identifier().into()))
-                    .collect(),
-            ),
+        let res = Self {
+            native: WEBAUTHN_EXTENSIONS {
+                cExtensions: len as u32,
+                pExtensions: std::ptr::null_mut(),
+            },
+            native_list: Vec::with_capacity(len),
+            ids: extensions.iter().map(|e| e.identifier().into()).collect(),
             extensions,
+            _pin: PhantomPinned,
         };
 
+        let mut boxed = Box::new(res);
+
         // trace!(?res.extensions);
-        for (i, extension) in res.extensions.iter_mut().enumerate() {
-            let id = &res.ids[i];
-            res.native_list.push(Box::pin(WEBAUTHN_EXTENSION {
+        for (extension, id) in boxed.extensions.iter_mut().zip(boxed.ids.iter()) {
+            boxed.native_list.push(WEBAUTHN_EXTENSION {
                 pwszExtensionIdentifier: PCWSTR::from_raw(id.as_ptr()),
                 cbExtension: extension.len(),
                 pvExtension: extension.ptr(),
-            }));
+            });
         }
 
-        // Create the native list element
-        res.native = Box::pin(WEBAUTHN_EXTENSIONS {
-            cExtensions: len as u32,
-            pExtensions: res.native_list.as_ptr() as *mut _,
-        });
+        boxed.native.pExtensions = Vec::as_mut_ptr(&mut boxed.native_list);
 
-        Ok(res)
+        Ok(Box::into_pin(boxed))
     }
 }

--- a/webauthn-authenticator-rs/src/win10/extensions.rs
+++ b/webauthn-authenticator-rs/src/win10/extensions.rs
@@ -1,6 +1,6 @@
-//! Wrappers for extensions.
-use crate::prelude::WebauthnCError;
-use std::{ffi::c_void, marker::PhantomPinned, pin::Pin};
+//! Wrappers for extensions that use Windows' [`WEBAUTHN_EXTENSION`][] type.
+use crate::{prelude::WebauthnCError, win10::Win10};
+use std::{ffi::c_void, marker::PhantomPinned, pin::Pin, result::Result};
 use webauthn_rs_proto::{
     AuthenticationExtensionsClientOutputs, CredProtect, RegistrationExtensionsClientOutputs,
     RequestRegistrationExtensions,
@@ -23,7 +23,7 @@ pub(crate) enum WinExtensionMakeCredentialRequest {
 }
 
 /// Generic request extension trait, for abstracting between
-/// [WinExtensionMakeCredentialRequest] and [WinExtensionGetAssertionRequest].
+/// [WinExtensionMakeCredentialRequest] and (a future) `WinExtensionGetAssertionRequest`.
 pub(crate) trait WinExtensionRequestType
 where
     Self: Sized,
@@ -37,7 +37,7 @@ where
     /// The `webauthn-authenticator-rs` type which this wraps.
     type WrappedType;
     /// Converts the [Self::WrappedType] to a [Vec] of Windows API types.
-    fn to_native(e: Self::WrappedType) -> Vec<Self>;
+    fn to_native(e: Self::WrappedType) -> Result<Vec<Self>, WebauthnCError>;
 }
 
 impl WinExtensionRequestType for WinExtensionMakeCredentialRequest {
@@ -67,19 +67,33 @@ impl WinExtensionRequestType for WinExtensionMakeCredentialRequest {
 
     type WrappedType = RequestRegistrationExtensions;
 
-    fn to_native(e: RequestRegistrationExtensions) -> Vec<Self> {
+    fn to_native(
+        e: RequestRegistrationExtensions,
+    ) -> Result<Vec<WinExtensionMakeCredentialRequest>, WebauthnCError> {
         let mut o: Vec<Self> = Vec::new();
+        let api_version = Win10::api_version();
         if let Some(c) = &e.cred_protect {
+            if api_version < 2 {
+                if c.enforce_credential_protection_policy == Some(true) {
+                    error!("Credential protection policy enforcement was requested, but it is not supported by this version of Windows");
+                    return Err(WebauthnCError::UnexpectedState);
+                }
+
+                warn!("Credential protection policy is not supported by this version of Windows");
+            }
             o.push(c.into());
         }
         if let Some(h) = &e.hmac_create_secret {
             o.push(Self::HmacSecret(h.into()))
         }
         if let Some(x) = &e.min_pin_length {
+            if api_version < 3 {
+                warn!("Minimum PIN length request is not supported by this version of Windows");
+            }
             o.push(Self::MinPinLength(x.into()));
         }
 
-        o
+        Ok(o)
     }
 }
 
@@ -313,7 +327,7 @@ where
     fn new(e: T::WrappedType) -> Result<Pin<Box<Self>>, WebauthnCError> {
         // Convert the extensions to a Windows-ish type
         // trace!(?e);
-        let extensions = T::to_native(e);
+        let extensions = T::to_native(e)?;
         let len = extensions.len();
 
         let res = Self {

--- a/webauthn-authenticator-rs/src/win10/extensions.rs
+++ b/webauthn-authenticator-rs/src/win10/extensions.rs
@@ -10,7 +10,7 @@ use webauthn_rs_proto::{
 use super::WinWrapper;
 
 use windows::{
-    core::HSTRING,
+    core::{HSTRING, PCWSTR},
     Win32::{Foundation::BOOL, Networking::WindowsWebServices::*},
 };
 
@@ -284,9 +284,9 @@ pub(crate) struct WinExtensionsRequest<T>
 where
     T: WinExtensionRequestType + std::fmt::Debug,
 {
-    native: WEBAUTHN_EXTENSIONS,
-    native_list: Vec<WEBAUTHN_EXTENSION>,
-    ids: Vec<HSTRING>,
+    native: Pin<Box<WEBAUTHN_EXTENSIONS>>,
+    native_list: Pin<Box<Vec<Pin<Box<WEBAUTHN_EXTENSION>>>>>,
+    ids: Pin<Box<Vec<Pin<Box<HSTRING>>>>>,
     extensions: Vec<T>,
 }
 
@@ -297,8 +297,8 @@ where
     fn default() -> Self {
         Self {
             native: Default::default(),
-            native_list: vec![],
-            ids: vec![],
+            native_list: Default::default(),
+            ids: Default::default(),
             extensions: vec![],
         }
     }
@@ -314,53 +314,41 @@ where
         &self.native
     }
 
-    fn new(e: T::WrappedType) -> Result<Pin<Box<Self>>, WebauthnCError> {
+    fn new(e: T::WrappedType) -> Result<Self, WebauthnCError> {
         // Convert the extensions to a Windows-ish type
         // trace!(?e);
+        // TODO: need to pin extension types
         let extensions = T::to_native(e);
         let len = extensions.len();
 
-        let res = Self {
+        let mut res = Self {
             native: Default::default(),
-            native_list: Vec::with_capacity(len),
-            ids: extensions.iter().map(|e| e.identifier().into()).collect(),
+            native_list: Box::pin(Vec::with_capacity(len)),
+            ids: Box::pin(
+                extensions
+                    .iter()
+                    .map(|e| Box::pin(e.identifier().into()))
+                    .collect(),
+            ),
             extensions,
         };
 
         // trace!(?res.extensions);
-        // Put our final struct on the heap
-        let mut boxed = Box::pin(res);
-
-        // Put in all the "native" values
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            let mut_ptr = Pin::get_unchecked_mut(mut_ref);
-
-            let l = &mut mut_ptr.native_list;
-            let l_ptr = l.as_mut_ptr();
-            for (i, extension) in mut_ptr.extensions.iter_mut().enumerate() {
-                let id = &mut_ptr.ids[i];
-                *l_ptr.add(i) = WEBAUTHN_EXTENSION {
-                    pwszExtensionIdentifier: id.into(),
-                    cbExtension: extension.len(),
-                    pvExtension: extension.ptr(),
-                };
-            }
-
-            l.set_len(len);
+        for (i, extension) in res.extensions.iter_mut().enumerate() {
+            let id = &res.ids[i];
+            res.native_list.push(Box::pin(WEBAUTHN_EXTENSION {
+                pwszExtensionIdentifier: PCWSTR::from_raw(id.as_ptr()),
+                cbExtension: extension.len(),
+                pvExtension: extension.ptr(),
+            }));
         }
 
         // Create the native list element
-        let native = WEBAUTHN_EXTENSIONS {
+        res.native = Box::pin(WEBAUTHN_EXTENSIONS {
             cExtensions: len as u32,
-            pExtensions: boxed.native_list.as_ptr() as *mut _,
-        };
+            pExtensions: res.native_list.as_ptr() as *mut _,
+        });
 
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        Ok(boxed)
+        Ok(res)
     }
 }

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -24,6 +24,8 @@
 #[cfg(feature = "win10")]
 mod clientdata;
 #[cfg(feature = "win10")]
+mod constants;
+#[cfg(feature = "win10")]
 mod cose;
 #[cfg(feature = "win10")]
 mod credential;
@@ -71,7 +73,7 @@ use windows::{
     Win32::{Foundation::BOOL, Networking::WindowsWebServices::*},
 };
 
-use std::slice::from_raw_parts;
+use std::{pin::Pin, slice::from_raw_parts};
 
 /// Authenticator backend for Windows Hello WebAuthn API.
 pub struct Win10 {}
@@ -134,10 +136,11 @@ impl AuthenticatorBackend for Win10 {
         } else {
             None
         };
-        let extensions = match options.extensions {
-            Some(e) => WinExtensionsRequest::new(e)?,
-            None => WinExtensionsRequest::<WinExtensionMakeCredentialRequest>::default(),
-        };
+        let extensions: Pin<Box<WinExtensionsRequest<WinExtensionMakeCredentialRequest>>> =
+            match options.extensions {
+                Some(e) => WinExtensionsRequest::new(e)?,
+                None => Default::default(),
+            };
         // trace!("native extn: {:?}", extensions.native_ptr());
 
         let makecredopts = WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
@@ -259,7 +262,7 @@ impl AuthenticatorBackend for Win10 {
         let rp_id: HSTRING = options.rp_id.clone().into();
         let clientdata = WinClientData::new(get_to_clientdata(origin, options.challenge.clone()))?;
 
-        let mut allow_credentials = WinCredentialList::new(options.allow_credentials)?;
+        let allow_credentials = WinCredentialList::new(options.allow_credentials)?;
 
         let app_id: Option<HSTRING> = options
             .extensions
@@ -314,7 +317,7 @@ impl AuthenticatorBackend for Win10 {
             },
             pbU2fAppId: std::ptr::addr_of_mut!(app_id_used),
             pCancellationId: std::ptr::null_mut(),
-            pAllowCredentialList: &mut allow_credentials.native,
+            pAllowCredentialList: allow_credentials.native() as *mut WEBAUTHN_CREDENTIAL_LIST,
             dwCredLargeBlobOperation: 0,
             cbCredLargeBlob: 0,
             pbCredLargeBlob: std::ptr::null_mut(),

--- a/webauthn-authenticator-rs/src/win10/mod.rs
+++ b/webauthn-authenticator-rs/src/win10/mod.rs
@@ -136,7 +136,7 @@ impl AuthenticatorBackend for Win10 {
         };
         let extensions = match options.extensions {
             Some(e) => WinExtensionsRequest::new(e)?,
-            None => Box::pin(WinExtensionsRequest::<WinExtensionMakeCredentialRequest>::default()),
+            None => WinExtensionsRequest::<WinExtensionMakeCredentialRequest>::default(),
         };
         // trace!("native extn: {:?}", extensions.native_ptr());
 

--- a/webauthn-authenticator-rs/src/win10/native.rs
+++ b/webauthn-authenticator-rs/src/win10/native.rs
@@ -54,7 +54,9 @@ pub trait WinWrapper<T> {
     /// Windows equivalent type for `T`
     type NativeType;
     /// Converts a `webauthn-authenticator-rs` type to a Windows type
-    fn new(v: T) -> Result<Pin<Box<Self>>, WebauthnCError>;
+    fn new(v: T) -> Result<Self, WebauthnCError>
+    where
+        Self: Sized;
     /// Returns a pointer to the Windows equivalent type
     fn native_ptr(&self) -> &Self::NativeType;
 }

--- a/webauthn-authenticator-rs/src/win10/native.rs
+++ b/webauthn-authenticator-rs/src/win10/native.rs
@@ -54,7 +54,7 @@ pub trait WinWrapper<T> {
     /// Windows equivalent type for `T`
     type NativeType;
     /// Converts a `webauthn-authenticator-rs` type to a Windows type
-    fn new(v: T) -> Result<Self, WebauthnCError>
+    fn new(v: T) -> Result<Pin<Box<Self>>, WebauthnCError>
     where
         Self: Sized;
     /// Returns a pointer to the Windows equivalent type

--- a/webauthn-authenticator-rs/src/win10/rp.rs
+++ b/webauthn-authenticator-rs/src/win10/rp.rs
@@ -14,36 +14,28 @@ use crate::error::WebauthnCError;
 
 /// Wrapper for [WEBAUTHN_RP_ENTITY_INFORMATION] to ensure pointer lifetime.
 pub struct WinRpEntityInformation {
-    native: WEBAUTHN_RP_ENTITY_INFORMATION,
-    id: HSTRING,
-    name: HSTRING,
+    native: Pin<Box<WEBAUTHN_RP_ENTITY_INFORMATION>>,
+    id: Pin<Box<HSTRING>>,
+    name: Pin<Box<HSTRING>>,
 }
 
 impl WinWrapper<RelyingParty> for WinRpEntityInformation {
     type NativeType = WEBAUTHN_RP_ENTITY_INFORMATION;
-    fn new(rp: RelyingParty) -> Result<Pin<Box<Self>>, WebauthnCError> {
-        let res = Self {
+    fn new(rp: RelyingParty) -> Result<Self, WebauthnCError> {
+        let mut res = Self {
             native: Default::default(),
-            id: rp.id.into(),
-            name: rp.name.into(),
+            id: Box::pin(rp.id.into()),
+            name: Box::pin(rp.name.into()),
         };
 
-        let mut boxed = Box::pin(res);
-
-        let native = WEBAUTHN_RP_ENTITY_INFORMATION {
+        res.native = Box::pin(WEBAUTHN_RP_ENTITY_INFORMATION {
             dwVersion: WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
-            pwszId: (&boxed.id).into(),
-            pwszName: (&boxed.name).into(),
+            pwszId: PCWSTR::from_raw(res.id.as_ptr()),
+            pwszName: PCWSTR::from_raw(res.name.as_ptr()),
             pwszIcon: PCWSTR::null(),
-        };
+        });
 
-        // Update the boxed type with the proper native object.
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        Ok(boxed)
+        Ok(res)
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_RP_ENTITY_INFORMATION {

--- a/webauthn-authenticator-rs/src/win10/rp.rs
+++ b/webauthn-authenticator-rs/src/win10/rp.rs
@@ -1,5 +1,5 @@
 //! Wrappers for [RelyingParty].
-use std::pin::Pin;
+use std::{marker::PhantomPinned, pin::Pin};
 
 use webauthn_rs_proto::RelyingParty;
 use windows::{
@@ -14,28 +14,31 @@ use crate::error::WebauthnCError;
 
 /// Wrapper for [WEBAUTHN_RP_ENTITY_INFORMATION] to ensure pointer lifetime.
 pub struct WinRpEntityInformation {
-    native: Pin<Box<WEBAUTHN_RP_ENTITY_INFORMATION>>,
-    id: Pin<Box<HSTRING>>,
-    name: Pin<Box<HSTRING>>,
+    native: WEBAUTHN_RP_ENTITY_INFORMATION,
+    id: HSTRING,
+    name: HSTRING,
+    _pin: PhantomPinned,
 }
 
 impl WinWrapper<RelyingParty> for WinRpEntityInformation {
     type NativeType = WEBAUTHN_RP_ENTITY_INFORMATION;
-    fn new(rp: RelyingParty) -> Result<Self, WebauthnCError> {
-        let mut res = Self {
-            native: Default::default(),
-            id: Box::pin(rp.id.into()),
-            name: Box::pin(rp.name.into()),
+    fn new(rp: RelyingParty) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        let res = Self {
+            id: rp.id.into(),
+            name: rp.name.into(),
+            native: WEBAUTHN_RP_ENTITY_INFORMATION {
+                dwVersion: WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
+                ..Default::default()
+            },
+            _pin: PhantomPinned,
         };
 
-        res.native = Box::pin(WEBAUTHN_RP_ENTITY_INFORMATION {
-            dwVersion: WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
-            pwszId: PCWSTR::from_raw(res.id.as_ptr()),
-            pwszName: PCWSTR::from_raw(res.name.as_ptr()),
-            pwszIcon: PCWSTR::null(),
-        });
+        let mut boxed = Box::new(res);
 
-        Ok(res)
+        boxed.native.pwszId = PCWSTR::from(&boxed.id);
+        boxed.native.pwszName = PCWSTR::from(&boxed.name);
+
+        Ok(Box::into_pin(boxed))
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_RP_ENTITY_INFORMATION {

--- a/webauthn-authenticator-rs/src/win10/user.rs
+++ b/webauthn-authenticator-rs/src/win10/user.rs
@@ -14,42 +14,33 @@ use crate::error::WebauthnCError;
 
 /// Wrapper for [WEBAUTHN_USER_ENTITY_INFORMATION] to ensure pointer lifetime, analgous to [User].
 pub struct WinUserEntityInformation {
-    native: WEBAUTHN_USER_ENTITY_INFORMATION,
-    _id: Vec<u8>,
-    _name: HSTRING,
-    _display_name: HSTRING,
+    native: Pin<Box<WEBAUTHN_USER_ENTITY_INFORMATION>>,
+    id: Pin<Vec<u8>>,
+    name: Pin<Box<HSTRING>>,
+    display_name: Pin<Box<HSTRING>>,
 }
 
 impl WinWrapper<User> for WinUserEntityInformation {
     type NativeType = WEBAUTHN_USER_ENTITY_INFORMATION;
-    fn new(u: User) -> Result<Pin<Box<Self>>, WebauthnCError> {
-        // Construct an incomplete type first, so that all the pointers are fixed.
-        let res = Self {
-            native: WEBAUTHN_USER_ENTITY_INFORMATION::default(),
-            _id: u.id.into(),
-            _name: u.name.into(),
-            _display_name: u.display_name.into(),
+    fn new(u: User) -> Result<Self, WebauthnCError> {
+        let mut res = Self {
+            native: Default::default(),
+            id: Pin::new(u.id.into()),
+            name: Box::pin(u.name.into()),
+            display_name: Box::pin(u.display_name.into()),
         };
-
-        let mut boxed = Box::pin(res);
 
         // Create the real native type, which contains bare pointers.
-        let native = WEBAUTHN_USER_ENTITY_INFORMATION {
+        res.native = Box::pin(WEBAUTHN_USER_ENTITY_INFORMATION {
             dwVersion: WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
-            cbId: boxed._id.len() as u32,
-            pbId: boxed._id.as_ptr() as *mut _,
-            pwszName: (&boxed._name).into(),
+            cbId: res.id.len() as u32,
+            pbId: res.id.as_ptr() as *mut _,
+            pwszName: PCWSTR::from_raw(res.name.as_ptr()),
             pwszIcon: PCWSTR::null(),
-            pwszDisplayName: (&boxed._display_name).into(),
-        };
+            pwszDisplayName: PCWSTR::from_raw(res.display_name.as_ptr()),
+        });
 
-        // Update the boxed type with the proper native object.
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            Pin::get_unchecked_mut(mut_ref).native = native;
-        }
-
-        Ok(boxed)
+        Ok(res)
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_USER_ENTITY_INFORMATION {

--- a/webauthn-authenticator-rs/src/win10/user.rs
+++ b/webauthn-authenticator-rs/src/win10/user.rs
@@ -1,46 +1,47 @@
 //! Wrappers for [User].
-use std::pin::Pin;
-
+use crate::error::WebauthnCError;
+use std::{marker::PhantomPinned, pin::Pin};
 use webauthn_rs_proto::User;
 use windows::{
-    core::{HSTRING, PCWSTR},
+    core::HSTRING,
     Win32::Networking::WindowsWebServices::{
         WEBAUTHN_USER_ENTITY_INFORMATION, WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
     },
 };
 
 use super::WinWrapper;
-use crate::error::WebauthnCError;
 
 /// Wrapper for [WEBAUTHN_USER_ENTITY_INFORMATION] to ensure pointer lifetime, analgous to [User].
 pub struct WinUserEntityInformation {
-    native: Pin<Box<WEBAUTHN_USER_ENTITY_INFORMATION>>,
-    id: Pin<Vec<u8>>,
-    name: Pin<Box<HSTRING>>,
-    display_name: Pin<Box<HSTRING>>,
+    native: WEBAUTHN_USER_ENTITY_INFORMATION,
+    id: Vec<u8>,
+    name: HSTRING,
+    display_name: HSTRING,
+    _pin: PhantomPinned,
 }
 
 impl WinWrapper<User> for WinUserEntityInformation {
     type NativeType = WEBAUTHN_USER_ENTITY_INFORMATION;
-    fn new(u: User) -> Result<Self, WebauthnCError> {
-        let mut res = Self {
-            native: Default::default(),
-            id: Pin::new(u.id.into()),
-            name: Box::pin(u.name.into()),
-            display_name: Box::pin(u.display_name.into()),
+    fn new(u: User) -> Result<Pin<Box<Self>>, WebauthnCError> {
+        let res = Self {
+            native: WEBAUTHN_USER_ENTITY_INFORMATION {
+                dwVersion: WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
+                cbId: u.id.len() as u32,
+                ..Default::default()
+            },
+            id: u.id,
+            name: u.name.into(),
+            display_name: u.display_name.into(),
+            _pin: PhantomPinned,
         };
 
-        // Create the real native type, which contains bare pointers.
-        res.native = Box::pin(WEBAUTHN_USER_ENTITY_INFORMATION {
-            dwVersion: WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
-            cbId: res.id.len() as u32,
-            pbId: res.id.as_ptr() as *mut _,
-            pwszName: PCWSTR::from_raw(res.name.as_ptr()),
-            pwszIcon: PCWSTR::null(),
-            pwszDisplayName: PCWSTR::from_raw(res.display_name.as_ptr()),
-        });
+        let mut boxed = Box::new(res);
 
-        Ok(res)
+        boxed.native.pbId = boxed.id.as_mut_ptr();
+        boxed.native.pwszName = (&boxed.name).into();
+        boxed.native.pwszDisplayName = (&boxed.display_name).into();
+
+        Ok(Box::into_pin(boxed))
     }
 
     fn native_ptr(&self) -> &WEBAUTHN_USER_ENTITY_INFORMATION {


### PR DESCRIPTION
## Change summary

This is mainly fix #566 and add a test for this into the `authenticate` example, but I ended up reviewing a bunch of the `win10` backend for similar issues.

I've tested this with Windows 10 (on `x86_64`) and 11 (on `aarch64` and `x86_64`).

- `authenticate` example:
  - Optionally include fake credentials to be used during the authentication and registration ceremonies (reproduction for #566).
  - Allow skipping the registration ceremony if there are fake credentials (ie: for only testing the authentication ceremony).
  - Don't `panic!` if the RP fails to authenticate the credential.
  - Add flags to use the `credProtect` and `minPinLength` registration extensions.

- `win10` backend:
  - Pass a pointer to a contiguous array of pointers to `WEBAUTHN_CREDENTIAL_EX` (ie: `Vec<Pin<Box<WEBAUTHN_CREDENTIAL_EX>>>::as_mut_ptr`) in `WEBAUTHN_CREDENTIAL_LIST`, rather than a pointer to a pointer to the first `WEBAUTHN_CREDENTIAL_EX` (fixes #566).
  - Remove `WinCoseCredentialParameter`, as `WEBAUTHN_COSE_CREDENTIAL_PARAMETERS` needs a contiguous array of `WEBAUTHN_COSE_CREDENTIAL_PARAMETER`, so there's no sense in storing that twice.
  - Use references to a static `w!("public-key")` (`HSTRING`/`PCWSTR`) where possible.
  - Refactor wrappers for self-referential native structures to use `PhantomPinned`, and avoid copies during construction (https://doc.rust-lang.org/std/pin/index.html#a-self-referential-struct).
  - Remove a bunch of `unsafe` blocks.
  - Warn when Windows doesn't support optional extensions.
  - Error on registration when the current version of Windows (or its `webauthn.dll`) doesn't support `credProtect`, and `enforce_credential_protection_policy` is `true`.

- `fido-key-manager`: fix incorrect name for `SetPinPolicyOpt::force_change`, that prevented setting a PIN policy

## Known issues / untested paths

I haven't tested any of the extension features with the `ctap` backend. I'll look at these later.

The `credProtect` extension seems to work correctly with Windows, but doesn't work with a TPM.

It doesn't look like the `minPinLength` extension can be used with a TPM.

Unfortunately, the only authenticator I have which supports the `minPinLength` extension (Token2) returns an empty `authData` when an _allowed_ RP ID requests this extension on registration. This then triggers a CBOR parse failure in Windows' `webauthn.dll`, and a registration failure. **This is a firmware bug.**


## TODO

- [x] Simple test case using the `authenticate` example which reproduces the issue with the `win10` backend
- [x] Actually fix the bug 😉 
- [x] Make the example use random data
- [x] Test `credProtect` extension
- [x] Investigate Windows CBOR parse failure with `minPinLength` extension
- [x] Test multiple versions of Windows

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)
