### PR TITLE
WIP: 0.6: CTAP 2.2/2.3 caBLE updates

### DIFF
--- a/webauthn-authenticator-rs/src/cable/discovery.rs
+++ b/webauthn-authenticator-rs/src/cable/discovery.rs
@@ -524,8 +524,7 @@ mod test {
         ];
 
         let discovery =
-            Discovery::new_with_qr_secret(CableRequestType::DiscoverableMakeCredential, qr_secret)
-                .unwrap();
+            Discovery::new_with_qr_secret(CableRequestType::MakeCredential, qr_secret).unwrap();
 
         assert_eq!(
             "wss://cable.ua5v.com/cable/new/367CBBF5F5085DF4098476AFE4B9B1D2",

--- a/webauthn-authenticator-rs/src/cable/handshake.rs
+++ b/webauthn-authenticator-rs/src/cable/handshake.rs
@@ -13,7 +13,8 @@ use crate::{
     cable::{base10, discovery::Discovery, tunnel::ASSIGNED_DOMAINS_COUNT, CableRequestType},
     crypto::public_key_from_bytes,
     ctap2::commands::{
-        value_to_bool, value_to_string, value_to_u32, value_to_u64, value_to_vec_u8,
+        value_to_bool, value_to_string, value_to_u32, value_to_u64, value_to_vec_u32,
+        value_to_vec_u8,
     },
     error::WebauthnCError,
 };
@@ -29,7 +30,7 @@ pub struct HandshakeV2 {
     timestamp: SystemTime,
     supports_linking_info: bool,
     pub(super) request_type: CableRequestType,
-    supports_non_discoverable_make_credential: bool,
+    supported_transports: Vec<u32>,
 }
 
 impl From<HandshakeV2> for BTreeMap<u32, Value> {
@@ -41,7 +42,7 @@ impl From<HandshakeV2> for BTreeMap<u32, Value> {
             timestamp,
             supports_linking_info,
             request_type,
-            supports_non_discoverable_make_credential,
+            supported_transports,
         } = value;
 
         let mut o = BTreeMap::from([
@@ -64,13 +65,22 @@ impl From<HandshakeV2> for BTreeMap<u32, Value> {
             // Chrome omits this field when false, but Safari always includes it.
             // Presence of this field = v2.1, missing = v2.0
             (4, Value::Bool(supports_linking_info)),
-            (5, Value::Text(request_type.to_cable_string())),
         ]);
 
-        if supports_non_discoverable_make_credential
-            && request_type == CableRequestType::MakeCredential
-        {
-            o.insert(6, Value::Bool(true));
+        if let Some(request_type) = request_type.to_cable_string() {
+            o.insert(5, Value::Text(request_type.to_string()));
+        }
+
+        if !supported_transports.is_empty() {
+            o.insert(
+                6,
+                Value::Array(
+                    supported_transports
+                        .into_iter()
+                        .map(|v: u32| Value::Integer(v.into()))
+                        .collect(),
+                ),
+            );
         }
 
         o
@@ -86,7 +96,17 @@ impl TryFrom<BTreeMap<u32, Value>> for HandshakeV2 {
             .and_then(|v| value_to_vec_u8(v, "0x00"))
             .ok_or(WebauthnCError::MissingRequiredField)?;
 
-        let peer_identity = public_key_from_bytes(&peer_identity)?;
+        let peer_identity: &[u8; 33] = peer_identity
+            .as_slice()
+            .try_into()
+            .map_err(|_| WebauthnCError::CryptographyPublicKey)?;
+
+        if peer_identity[0] != 2 && peer_identity[0] != 3 {
+            // Must be compressed public key
+            return Err(WebauthnCError::CryptographyPublicKey);
+        }
+
+        let peer_identity = public_key_from_bytes(peer_identity)?;
 
         let secret = raw
             .remove(&1)
@@ -111,20 +131,15 @@ impl TryFrom<BTreeMap<u32, Value>> for HandshakeV2 {
             .and_then(|v| value_to_bool(&v, "0x04"))
             .unwrap_or_default();
 
-        let supports_non_discoverable_make_credential = raw
+        let supported_transports = raw
             .remove(&6)
-            .and_then(|v| value_to_bool(&v, "0x06"))
+            .and_then(|v| value_to_vec_u32(v, "0x06"))
             .unwrap_or_default();
 
         let request_type = raw
             .remove(&5)
             .and_then(|v| value_to_string(v, "0x05"))
-            .and_then(|v| {
-                CableRequestType::from_cable_string(
-                    v.as_str(),
-                    supports_non_discoverable_make_credential,
-                )
-            })
+            .map(|v| CableRequestType::from_cable_string(v.as_str()))
             .unwrap_or_default();
 
         Ok(Self {
@@ -134,7 +149,7 @@ impl TryFrom<BTreeMap<u32, Value>> for HandshakeV2 {
             timestamp,
             supports_linking_info,
             request_type,
-            supports_non_discoverable_make_credential,
+            supported_transports,
         })
     }
 }
@@ -152,7 +167,7 @@ impl HandshakeV2 {
             timestamp: SystemTime::now(),
             supports_linking_info: false,
             request_type,
-            supports_non_discoverable_make_credential: false,
+            supported_transports: vec![],
         })
     }
 

--- a/webauthn-authenticator-rs/src/cable/mod.rs
+++ b/webauthn-authenticator-rs/src/cable/mod.rs
@@ -344,28 +344,26 @@ use crate::{
 type Psk = [u8; 32];
 
 impl CableRequestType {
-    fn to_cable_string(self) -> String {
+    fn to_cable_string(self) -> Option<&'static str> {
         use CableRequestType::*;
+        #[allow(deprecated)]
         match self {
-            GetAssertion => String::from("ga"),
-            DiscoverableMakeCredential => String::from("mc"),
-            MakeCredential => String::from("mc"),
+            GetAssertion => Some("ga"),
+            MakeCredential | DiscoverableMakeCredential => Some("mc"),
+            DigitalCredentialIssuance => Some("dci"),
+            DigitalCredentialPresentation => Some("dcp"),
+            Unknown => None,
         }
     }
 
-    fn from_cable_string(
-        val: &str,
-        supports_non_discoverable_make_credential: bool,
-    ) -> Option<Self> {
+    fn from_cable_string(val: &str) -> Self {
         use CableRequestType::*;
         match val {
-            "ga" => Some(GetAssertion),
-            "mc" => Some(if supports_non_discoverable_make_credential {
-                MakeCredential
-            } else {
-                DiscoverableMakeCredential
-            }),
-            _ => None,
+            "ga" => GetAssertion,
+            "mc" => MakeCredential,
+            "dci" => DigitalCredentialIssuance,
+            "dcp" => DigitalCredentialPresentation,
+            _ => Unknown,
         }
     }
 }
@@ -425,6 +423,17 @@ async fn connect_cable_authenticator_impl<'a, U: UiCallback + 'a>(
     ui_callback: &'a U,
     connect_uri: Option<Builder>,
 ) -> Result<CtapAuthenticator<'a, Tunnel, U>, WebauthnCError> {
+    #[allow(deprecated)]
+    if !matches!(
+        request_type,
+        CableRequestType::MakeCredential
+            | CableRequestType::GetAssertion
+            | CableRequestType::DiscoverableMakeCredential
+    ) {
+        error!("Unsupported cable request type: {request_type:?}");
+        return Err(WebauthnCError::NotSupported);
+    }
+
     // TODO: it may be better to return a caBLE-specific authenticator object,
     // rather than CtapAuthenticator, because the device will close the
     // Websocket connection as soon as we've sent a single command.
@@ -603,6 +612,14 @@ where
     transports.push("hybrid".to_string());
 
     let handshake = HandshakeV2::from_qr_url(url)?;
+    if !matches!(
+        handshake.request_type,
+        CableRequestType::GetAssertion | CableRequestType::MakeCredential
+    ) {
+        error!("Unknown or unsupported caBLE request type");
+        return Err(WebauthnCError::NotSupported);
+    }
+
     let discovery = handshake.to_discovery()?;
 
     let tunnel_uri = match options.tunnel_uri {
@@ -634,8 +651,7 @@ where
                 break;
             }
             CableFrameType::Ctap => match (handshake.request_type, msg.parse_request()?) {
-                (CableRequestType::MakeCredential, RequestType::MakeCredential(mc))
-                | (CableRequestType::DiscoverableMakeCredential, RequestType::MakeCredential(mc)) => {
+                (CableRequestType::MakeCredential, RequestType::MakeCredential(mc)) => {
                     perform_register_with_request(backend, mc, timeout_ms)
                 }
                 (CableRequestType::GetAssertion, RequestType::GetAssertion(ga)) => {
@@ -697,28 +713,39 @@ mod test {
     #[test]
     fn cable_request_type() {
         assert_eq!(
-            Some(CableRequestType::DiscoverableMakeCredential),
-            CableRequestType::from_cable_string("mc", false)
+            CableRequestType::MakeCredential,
+            CableRequestType::from_cable_string("mc"),
         );
         assert_eq!(
-            Some(CableRequestType::MakeCredential),
-            CableRequestType::from_cable_string("mc", true)
+            CableRequestType::GetAssertion,
+            CableRequestType::from_cable_string("ga"),
         );
         assert_eq!(
-            Some(CableRequestType::GetAssertion),
-            CableRequestType::from_cable_string("ga", false)
+            CableRequestType::Unknown,
+            CableRequestType::from_cable_string("nonsense"),
         );
         assert_eq!(
-            Some(CableRequestType::GetAssertion),
-            CableRequestType::from_cable_string("ga", true)
+            CableRequestType::DigitalCredentialIssuance,
+            CableRequestType::from_cable_string("dci"),
         );
-        assert_eq!(None, CableRequestType::from_cable_string("nonsense", false));
+        assert_eq!(
+            CableRequestType::DigitalCredentialPresentation,
+            CableRequestType::from_cable_string("dcp"),
+        );
 
+        assert_eq!(None, CableRequestType::Unknown.to_cable_string());
         assert_eq!(
-            "mc",
-            CableRequestType::DiscoverableMakeCredential.to_cable_string()
+            Some("mc"),
+            CableRequestType::MakeCredential.to_cable_string(),
         );
-        assert_eq!("mc", CableRequestType::MakeCredential.to_cable_string());
-        assert_eq!("ga", CableRequestType::GetAssertion.to_cable_string());
+        assert_eq!(Some("ga"), CableRequestType::GetAssertion.to_cable_string());
+        assert_eq!(
+            Some("dci"),
+            CableRequestType::DigitalCredentialIssuance.to_cable_string(),
+        );
+        assert_eq!(
+            Some("dcp"),
+            CableRequestType::DigitalCredentialPresentation.to_cable_string(),
+        );
     }
 }

--- a/webauthn-authenticator-rs/src/cable/noise.rs
+++ b/webauthn-authenticator-rs/src/cable/noise.rs
@@ -421,9 +421,9 @@ impl CableNoise {
     /// renders the internal state invalid for "retrying" or future
     /// transactions.
     pub fn process_response(mut self, response: &[u8]) -> Result<Crypter, WebauthnCError> {
-        if response.len() < 65 {
-            error!("Handshake response too short ({} bytes)", response.len());
-            return Err(WebauthnCError::MessageTooShort);
+        if response.len() != 65 + 16 {
+            error!("Handshake response wrong size ({} bytes)", response.len());
+            return Err(WebauthnCError::InvalidMessageLength);
         }
 
         // ProcessResponse
@@ -479,9 +479,9 @@ impl CableNoise {
         peer_identity: Option<&EcdhP256PublicKey>,
         message: &[u8],
     ) -> Result<(Crypter, Vec<u8>), WebauthnCError> {
-        if message.len() < 65 {
-            error!("Initiator message too short ({} bytes)", message.len());
-            return Err(WebauthnCError::MessageTooShort);
+        if message.len() != 65 + 16 {
+            error!("Initiator message wrong size ({} bytes)", message.len());
+            return Err(WebauthnCError::InvalidMessageLength);
         }
 
         // RespondToHandshake

--- a/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
+++ b/webauthn-authenticator-rs/src/ctap2/commands/mod.rs
@@ -191,7 +191,7 @@ fn value_to_map(v: Value, loc: &str) -> Option<BTreeMap<Value, Value>> {
     }
 }
 
-fn value_to_vec_u32(v: Value, loc: &str) -> Option<Vec<u32>> {
+pub(crate) fn value_to_vec_u32(v: Value, loc: &str) -> Option<Vec<u32>> {
     value_to_vec(v, loc).map(|v| {
         v.into_iter()
             .filter_map(|i| value_to_u32(&i, loc))

--- a/webauthn-authenticator-rs/src/types.rs
+++ b/webauthn-authenticator-rs/src/types.rs
@@ -4,17 +4,31 @@
 //! at build time, because they are part of some other API which doesn't change.
 
 /// caBLE request type.
+///
+/// As of v0.6, this struct is non-exhaustive to support non-CTAP protocols that use caBLE as a
+/// transport layer.
 #[derive(Debug, PartialEq, Eq, Clone, Default, Copy)]
+#[non_exhaustive]
 pub enum CableRequestType {
-    /// Logging in with an existing credential.
+    /// Unknown request type.
     #[default]
+    Unknown,
+
+    /// CTAP 2: Authenticate with an existing credential.
     GetAssertion,
 
-    /// Creating a new, non-discoverable credential.
+    /// CTAP 2: Create a new credential.
     MakeCredential,
 
-    /// Creating a new, discoverable credential.
+    /// Deprecated, use [`MakeCredential`][Self::MakeCredential].
+    #[deprecated(since = "0.6.2", note = "Use MakeCredential")]
     DiscoverableMakeCredential,
+
+    /// Digital Credentials API: credential presentation (not supported)
+    DigitalCredentialPresentation,
+
+    /// Digital Credentials API: credential issuance (not supported)
+    DigitalCredentialIssuance,
 }
 
 /// States that a caBLE connection can be in for

--- a/webauthn-authenticator-rs/src/ui/cli.rs
+++ b/webauthn-authenticator-rs/src/ui/cli.rs
@@ -43,14 +43,14 @@ impl UiCallback for Cli {
     }
 
     fn cable_qr_code(&self, request_type: CableRequestType, url: String) {
-        match request_type {
-            CableRequestType::DiscoverableMakeCredential | CableRequestType::MakeCredential => {
-                println!("Scan the QR code with your mobile device to create a new credential with caBLE:");
+        println!(
+            "Scan the QR code with your mobile device {}:",
+            match request_type {
+                CableRequestType::MakeCredential => "to enroll a new credential",
+                CableRequestType::GetAssertion => "to authenticate",
+                _ => "",
             }
-            CableRequestType::GetAssertion => {
-                println!("Scan the QR code with your mobile device to sign in with caBLE:");
-            }
-        }
+        );
         println!("This feature requires Android with Google Play, or iOS 16 or later.");
 
         #[cfg(feature = "qrcode")]


### PR DESCRIPTION
## Change summary

* Deprecate `CableRequestType::DiscoverableMakeCredential`, remove `supports_non_discoverable_make_credential` (was never added to CTAP 2.2).
* Add `CableRequestType` variants for DCAPI (not supported by us).
* Add `HandshakeV2::supported_transports` (CTAP 2.3).
* Verify that the public key in `HandshakeV2` is in compressed SEC1 format.
* Reject initial initiator and authenticator messages that are the wrong length, rather than just being too short.


## TODO

* Remove Noise old handshake support

Fixes #

## Checklist

- [x] This PR contains no AI generated code
- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
