### PR TITLE
Credential ID Length Limited to 4096 Bytes

### DIFF
--- a/webauthn-rs-core/src/constants.rs
+++ b/webauthn-rs-core/src/constants.rs
@@ -1,2 +1,5 @@
 // Can this ever change?
 pub const CHALLENGE_SIZE_BYTES: usize = 32;
+
+// WebAuthn L3 §6.5.1 (Attested Credential Data): credentialIdLength "Value MUST be <= 1023"
+pub const CREDENTIAL_ID_MAX_LENGTH: u16 = 1023;

--- a/webauthn-rs-core/src/constants.rs
+++ b/webauthn-rs-core/src/constants.rs
@@ -2,4 +2,6 @@
 pub const CHALLENGE_SIZE_BYTES: usize = 32;
 
 // WebAuthn L3 §6.5.1 (Attested Credential Data): credentialIdLength "Value MUST be <= 1023"
-pub const CREDENTIAL_ID_MAX_LENGTH: u16 = 1023;
+// However, for compatibility with future PQC key-wrapped-keys, we will use a softer limit
+// of 4096 bytes to fit up to ML-DSA-65
+pub const CREDENTIAL_ID_MAX_LENGTH: u16 = 4096;

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -1381,14 +1381,14 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
 
         let mut valid_acd = vec![0; 16]; // aaguid
-        valid_acd.extend_from_slice(&1023_u16.to_be_bytes());
-        valid_acd.extend_from_slice(&[0; 1023]);
+        valid_acd.extend_from_slice(&4096_u16.to_be_bytes());
+        valid_acd.extend_from_slice(&[0; 4096]);
         valid_acd.push(0xa0); // empty cbor map for public key
         assert!(super::acd_parser(&valid_acd).is_ok());
 
         let mut invalid_acd = vec![0; 16]; // aaguid
-        invalid_acd.extend_from_slice(&1024_u16.to_be_bytes());
-        invalid_acd.extend_from_slice(&[0; 1024]);
+        invalid_acd.extend_from_slice(&4097_u16.to_be_bytes());
+        invalid_acd.extend_from_slice(&[0; 4097]);
         invalid_acd.push(0xa0); // empty cbor map for public key
         assert!(super::acd_parser(&invalid_acd).is_err());
     }

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -1,6 +1,7 @@
 //! Internal structures for parsing webauthn registrations and challenges. This *may* change
 //! at anytime and should not be relied on in your library.
 
+use crate::constants::CREDENTIAL_ID_MAX_LENGTH;
 use crate::error::WebauthnError;
 use crate::proto::*;
 use nom::bytes::complete::{tag, take};
@@ -205,6 +206,17 @@ fn aaguid_parser(i: &[u8]) -> nom::IResult<&[u8], Aaguid> {
 fn acd_parser(i: &[u8]) -> nom::IResult<&[u8], AttestedCredentialData> {
     let (i, aaguid) = aaguid_parser(i)?;
     let (i, cred_id_len) = be_u16(i)?;
+
+    if cred_id_len > CREDENTIAL_ID_MAX_LENGTH {
+        warn!(
+            "cred_id_len ({:?}) exceeds the WebAuthn maximum of {:?} bytes.",
+            cred_id_len, CREDENTIAL_ID_MAX_LENGTH
+        );
+        return Err(nom::Err::Failure(nom::error::Error::new(
+            i,
+            nom::error::ErrorKind::TooLarge,
+        )));
+    }
 
     if usize::from(cred_id_len) > i.len() {
         warn!(
@@ -1362,6 +1374,23 @@ mod tests {
         ];
 
         assert!(AuthenticatorData::<Authentication>::try_from(raw.as_slice()).is_ok());
+    }
+
+    #[test]
+    fn acd_parser_credential_id_length() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let mut valid_acd = vec![0; 16]; // aaguid
+        valid_acd.extend_from_slice(&1023_u16.to_be_bytes());
+        valid_acd.extend_from_slice(&[0; 1023]);
+        valid_acd.push(0xa0); // empty cbor map for public key
+        assert!(super::acd_parser(&valid_acd).is_ok());
+
+        let mut invalid_acd = vec![0; 16]; // aaguid
+        invalid_acd.extend_from_slice(&1024_u16.to_be_bytes());
+        invalid_acd.extend_from_slice(&[0; 1024]);
+        invalid_acd.push(0xa0); // empty cbor map for public key
+        assert!(super::acd_parser(&invalid_acd).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Change summary
- Adds a maximum length check for the AttestedCredentialData parser (Credentials should not have credential IDs longer than 4096 bytes)
- Adds simple internals.rs test for 4096-byte and 4097-byte credential IDs which should pass and fail, respectively

Fixes #580 

## Checklist

- [x] This PR contains no AI generated code
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
